### PR TITLE
bhkMoppBvTreeShape fix

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -868,6 +868,11 @@
         <option value="19" name="World LOD Multitexture"></option>
     </enum>
 
+    <enum name="MOPPDataBuildType" storage="byte">
+        <option value="0" name="BUILT_WITH_CHUNK_SUBDIVISION">Setting for PS3 games. This tells the mopp compiler to organize the mopp code into smaller chunks so it can be processed on the PlayStation 3 spu.</option>
+        <option value="1" name="BUILT_WITHOUT_CHUNK_SUBDIVISION">Setting for PC games.</option>
+    </enum>
+
     <!--Compounds
         These are like C structures and are used as sub-parts of more complex
         classes when there are multiple pieces of data repeated in an array.-->
@@ -2135,8 +2140,10 @@
         <add name="Origin" type="Vector3">Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus 0.1.</add>
         <add name="Scale" type="float">The scaling factor to quantize the MOPP: the quantization factor is equal to 256*256 divided by this number. In Oblivion files, scale is taken equal to 256*256*254 / (size + 0.2) where size is the largest dimension of the bounding box of the packed shape.</add>
         <add name="Old MOPP Data" ver2="10.0.1.0" type="byte" nifskopetype="blob" arr1="MOPP Data Size - 1">The tree of bounding volume data (old style, contains more than just the mopp script).</add>
+        <add name="MOPP Data Build Type" type="MOPPDataBuildType" ver1="20.2.0.7" vercond="User Version >= 12">How MOPP Data are organized.
+        	For PC games set BUILT_WITHOUT_CHUNK_SUBDIVISION.
+        	For PS3 games set BUILT_WITH_CHUNK_SUBDIVISION.</add>
         <add name="MOPP Data" ver1="10.0.1.2" type="byte" nifskopetype="blob" arr1="MOPP Data Size">The tree of bounding volume data.</add>
-        <add name="Unknown Byte 1" type="byte" ver1="20.2.0.7" vercond="User Version >= 12">Unknown</add>
     </niobject>
 
 


### PR DESCRIPTION
Update/fix of bhkMoppBvTreeShape block according to skyfox's discovery (see http://niftools.sourceforge.net/forum/viewtopic.php?p=27954#p27954). Revealed use of "Unknown byte" and determined its right position in nif structure (before MOPP data block).
