### PR TITLE
NiSkinPartition unknowns removed

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -1362,25 +1362,25 @@
 
         <!-- related to the file posted in tracker item #3117836:
             http://sourceforge.net/tracker/?func=detail&aid=3117836&group_id=149157&atid=776343 -->
-        <add name="Unknown 83 C3" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1" ></add>
+<!--        <add name="Unknown 83 C3" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1" ></add>
         <add name="Unknown 00 00 1" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>
         <add name="Num Vertices 2" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>
         <add name="Unknown 00 00 2" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>
         <add name="Unknown 00 00 3" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>
         <add name="Unknown 00 00 4" type="ushort" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>
-        <add name="Unknown Arr 1" type="SkinPartitionUnknownItem1" arr1="Num Vertices 2" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>
+        <add name="Unknown Arr 1" type="SkinPartitionUnknownItem1" arr1="Num Vertices 2" ver1="10.2.0.0" ver2="10.2.0.0" vercond="User Version == 1"></add>-->
     </compound>
 
     <!-- related to the file posted in tracker item #3117836:
         http://sourceforge.net/tracker/?func=detail&aid=3117836&group_id=149157&atid=776343 -->
-    <compound name="SkinPartitionUnknownItem1">
+<!--    <compound name="SkinPartitionUnknownItem1">
         <add name="Unknown Flags" type="uint"></add>
         <add name="f1" type="float"></add>
         <add name="f2" type="float"></add>
         <add name="f3" type="float"></add>
         <add name="f4" type="float"></add>
         <add name="f5" type="float"></add>
-    </compound>
+    </compound>-->
 
     <compound name="QTransform">
         <add name="Translation" type="Vector3">Translation.</add>


### PR DESCRIPTION
@neomonkeus @skyfox69 @jonwd7 @Ghostwalker71 @throttlekitty @nexustheru @amorilia
I have found a strange additions at the end of NiSkinPartition block definition. There is notice:

```
<!-- related to the file posted in tracker item #3117836:
            http://sourceforge.net/tracker/?func=detail&aid=3117836&group_id=149157&atid=776343 -->
```

followed by 7 lines of added unknowns conditioned only for nifs Version = 10.2.0.0 and UserVersion = 1. There is also added a compound `SkinPartitionUnknownItem1`.
Yesterday I have got sample nifs from Blood Bowl game which are precisely of that Version and UserVersion and these unknowns causes error on nif load - **these unknowns should not be there**. Without these lines, nifs from Blood Bowl game are loading ok.
- Does anybody know anything about that mentioned _tracker item #3117836_ on sourceforge? That link don't works for me - it requires login into SourceForge account.
- Is it possible to get nif file(s) on which these unknowns was added to nif.xml?

For now I have uncommented them out as it is possible that these unknowns are valid for some nif versions - maybe there are only bad version/user version numbers in conditions.
