### PR TITLE
Num UV Sets split

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -915,9 +915,9 @@
         <option value="1" name="Emissive Color">Emissive Color.</option>
     </enum>
 
-    <bitflags name="ExtraVectorsFlags" storage="byte">
-        <option value="4" name="Tangents_Bitangents">Has Tangents and Bitangents Vectors.</option>
-    </bitflags>
+    <enum name="ExtraVectorsFlags" storage="byte">
+        <option value="16" name="Tangents_Bitangents">Has Tangents and Bitangents Vectors.</option>
+    </enum>
 
     <!--Compounds
         These are like C structures and are used as sub-parts of more complex


### PR DESCRIPTION
@neomonkeus @skyfox69 @jonwd7 @Ghostwalker71 @throttlekitty @nexustheru @amorilia
Changed definition of `Num UV Sets` (for >= 10.0.1.0 only) and get rid of `BS Num UV Sets`.
`Num UV Sets` defined as byte containing number of UV texture sets. Added definition of `Extra Vectors Flags` stored in byte. Only known function of that flags by that time is 4th bit representing flag for Tangents/Bitangents arrays - this is defined in ~~_bitflags_~~ type `ExtraVectorsFlags`.
As there is no certainity that number of UV Sets can be stored in all 8 bits, I have left AND function on line 2731 where "arr1" is getting a number of UV Sets only from lower 6 bits (i.e. max number of UV Sets is 63). There is a note about that on line 2725 (although it is for old version 4.0.0.2).

As there is a bug in Nifskope not allowing to "untick" an item of _bitflags_ in case that there is defined only one option, I changed `ExtraVectorFlags` type from _bitflags_ to _enum_.
