### PR TITLE
Particle system + 20.3.0.9 support

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -2869,9 +2869,12 @@
         <add name="Compress Flags" type="byte" ver1="10.1.0.0">Unknown.</add>
         <add name="Has Vertices" type="bool" default="1">Is the vertex array present? (Always non-zero.)</add>
         <add name="Vertices" type="Vector3" arr1="Num Vertices" cond="Has Vertices">The mesh vertices.</add>
-        <add name="Num UV Sets" type="byte" vercond="Version >= 10.0.1.0" calculated="1">Number of UV texture sets.
+        <add name="Num UV Sets" type="byte" vercond="(Version >= 10.0.1.0) &amp;&amp; (Endian Type == 1)" calculated="1">Number of UV texture sets.
         Fallout3/Skyrim: can't be higher than 1.</add>
-        <add name="Extra Vectors Flags" type="ExtraVectorsFlags" vercond="Version >= 10.0.1.0">Bit 4: Has Tangents/Bitangents</add>
+        <add name="Extra Vectors Flags" type="ExtraVectorsFlags" vercond="(Version >= 10.0.1.0) &amp;&amp; (Endian Type == 1)">Bit 4: Has Tangents/Bitangents</add>
+        <add name="Extra Vectors Flags" type="ExtraVectorsFlags" vercond="(Version >= 10.0.1.0) &amp;&amp; (Endian Type == 0)">Bit 4: Has Tangents/Bitangents</add>
+        <add name="Num UV Sets" type="byte" vercond="(Version >= 10.0.1.0) &amp;&amp; (Endian Type == 0)" calculated="1">Number of UV texture sets.
+        Fallout3/Skyrim: can't be higher than 1.</add>
         <add name="Unknown Int 2" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version == 12)" cond="!NiPSysData">Unknown, seen in Skyrim.</add>
         <add name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</add>
         <add name="Normals" type="Vector3" arr1="Num Vertices" cond="Has Normals">The lighting normals.</add>
@@ -6232,15 +6235,21 @@
     <compound name="Transition"><!-- taken from kfm.xml-->
         <add name="Animation" type="int">Refers to another animation</add>
         <add name="Type" type="int" />
-        <add name="Duration" type="float" cond="Type != 5" />
-        <add name="Num Intermediate Anims" type="int" cond="Type != 5" />
-        <add name="Intermediate Anims" type="IntermediateAnim" arr1="Num Intermediate Anims" cond="Type != 5" />
-        <add name="Num TextKeyPairs" type="int" cond="Type != 5" />
+        <add name="Duration" type="float" cond="(Type != 5) &amp;&amp; (Type != 4)" />
+        <add name="Num Intermediate Anims" type="int" cond="(Type != 5) &amp;&amp; (Type != 4)" />
+        <add name="Intermediate Anims" type="IntermediateAnim" arr1="Num Intermediate Anims" cond="Num Intermediate Anims" />
+        <add name="Num TextKeyPairs" type="int" cond="(Type != 5) &amp;&amp; (Type != 4)" />
+        <add name="TextKeyPairs" type="TextKeyPair" cond="Num TextKeyPairs" />
     </compound>
 
     <compound name="IntermediateAnim"><!-- taken from kfm.xml-->
         <add name="Unknown Int" type="int" />
         <add name="Event" type="SizedString" />
+    </compound>
+
+    <compound name="TextKeyPair">
+        <add name="Unknown Int" type="int" />
+        <add name="Unknown float" type="float" />
     </compound>
 
     <!-- Skyrim specific havok block -->
@@ -6343,6 +6352,193 @@
         <add name="Num Bones 2" type="uint">Unknown</add>
         <add name="Bones" type="Ref" arr1="Num Bones 2" template="NiNode">Unknown</add>
     </niobject>
-    
-    
+
+<!-- Support for Divinity 2 .cat files, version 20.3.0.9, user version 196608 -->
+    <niobject name="MdlMan::CModelTemplateDataEntry" abstract="0">
+        Unknown.
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Unknown byte 1" type="byte">Unknown</add>
+        <add name="Model Filename" type="string">Unknown.</add>
+        <add name="Extra data?" type="Ref">Unknown</add>
+        <add name="Num Entries" type="uint">Unknown</add>
+        <add name="Entry" type="Ref" arr1="Num Entries">Unknown</add>
+    </niobject>
+
+    <niobject name="MdlMan::CSkeletonDataEntry" abstract="0">
+        Unknown.
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Unknown byte 1" type="byte">Unknown</add>
+        <add name="Skeleton Filename" type="string">Unknown.</add>
+        <add name="Skeleton Node" type="Ref">Unknown</add>
+    </niobject>
+
+    <niobject name="MdlMan::CAMDataEntry" abstract="0">
+        Unknown.
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Has Kfm Data" type="bool">Has Kfm data?</add>
+        <add name="Kfm Name" type="string">Unknown.</add>
+        <add name="Kfm Data size" type="uint">Size of Kfm Data in bytes.</add>
+        <add name="Kfm Data" type="KfmData" cond="Has Kfm Data">Complete Kfm data?</add>
+    </niobject>
+
+    <niobject name="MdlMan::CMeshDataEntry" abstract="0">
+        Unknown.
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Unknown byte 1" type="byte">Unknown</add>
+        <add name="Mesh Filename" type="string">Unknown.</add>
+        <add name="Unknown byte 2" type="byte">Unknown</add>
+        <add name="Mesh Node" type="Ref">Unknown</add>
+    </niobject>
+
+    <niobject name="MdlMan::CAnimationDataEntry" abstract="0">
+        Unknown.
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Unknown byte 1" type="byte">Unknown</add>
+        <add name="Animation Filename" type="string">Unknown.</add>
+        <add name="Num Sequences" type="uint">Unknown</add>
+        <add name="Sequence" type="Ref" arr1="Num Sequences">Unknown</add>
+    </niobject>
+<!-- Support for Divinity 2 .cat files, version 20.3.0.9, user version 196608 -END- -->
+
+<!-- Support for Divinity 2 MdlManBinary.nif file, version 20.3.0.9, user version 196608 -->
+    <compound name="CModel">
+        <add name="Unknown int" type="uint">Unknown</add>
+        <add name="Num Meshes" type="uint">Unknown</add>
+        <add name="Meshes" type="Ref" arr1="Num Meshes" template="CMesh">Unknown</add>
+    </compound>
+
+    <compound name="ModelPrototype">
+        <add name="Name" type="SizedString">Unknown</add>
+        <add name="Prototype" type="Ref" template="CModelPrototype">Unknown</add>
+    </compound>
+
+    <compound name="ModelTemplate">
+        <add name="Name" type="SizedString">Unknown</add>
+        <add name="Template" type="Ref" template="CModelTemplate">Unknown</add>
+    </compound>
+
+    <compound name="CStringMapperItem1">
+        <add name="Name" type="SizedString">Unknown</add>
+        <add name="Unknown int" type="uint">Unknown</add>
+    </compound>
+
+    <compound name="CStringMapperSubItem1">
+        <add name="Name" type="SizedString">Unknown</add>
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Unknown int 2" type="uint">Unknown</add>
+    </compound>
+
+    <compound name="CStringMapperItem3">
+        <add name="Unknown int 1" type="uint">Unknown</add>
+        <add name="Num SubItems" type="uint">Unknown</add>
+        <add name="SubItem" type="CStringMapperSubItem1" arr1="Num SubItems">Unknown</add>
+    </compound>
+
+    <niobject name="CModelManager" abstract="0">
+        <add name="String Mapper?" type="Ref">Unknown</add>
+        <add name="Num Models" type="uint">Unknown</add>
+        <add name="Model" type="CModel" arr1="Num Models">Unknown</add>
+        <add name="Num Prototypes" type="uint">Unknown</add>
+        <add name="Model Prototype" type="ModelPrototype" arr1="Num Prototypes">Unknown</add>
+        <add name="Num Templates" type="uint">Unknown</add>
+        <add name="Model Template" type="ModelTemplate" arr1="Num Templates">Unknown</add>
+    </niobject>
+
+    <niobject name="CStringMapper" abstract="0">
+        <add name="Num Items 1" type="uint">Unknown</add>
+        <add name="Item 1" type="CStringMapperItem1" arr1="Num Items 1">Unknown</add>
+        <add name="Num Items 2" type="uint">Unknown</add>
+        <add name="Item 2" type="CStringMapperItem1" arr1="Num Items 2">Unknown</add>
+        <add name="Num Items 3" type="uint">Unknown</add>
+        <add name="Item 3" type="CStringMapperItem3" arr1="Num Items 3">Unknown</add>
+    </niobject>
+
+    <compound name="CMeshItem">
+        <add name="Unknown int 1" type="int">Unknown</add>
+        <add name="Unknown link" type="Ref">Unknown</add>
+    </compound>
+
+    <niobject name="CMesh" abstract="0">
+        <add name="Filename" type="string">Unknown</add>
+        <add name="Name" type="string">Unknown</add>
+        <add name="Unknown byte 1" type="byte">Unknown</add>
+        <add name="Unknown int 1" type="int">Unknown</add>
+        <add name="Num Items" type="uint">Unknown</add>
+        <add name="Item" type="CMeshItem" arr1="Num Items">Unknown</add>
+    </niobject>
+
+    <niobject name="CMeshEntry" abstract="0">
+        <add name="Unknown int 1" type="int">Unknown</add>
+        <add name="Unknown int 2" type="int">Unknown</add>
+        <add name="Unknown int 3" type="int">Unknown</add>
+        <add name="Unknown byte 1" type="byte">Unknown</add>
+        <add name="Unknown int 4" type="int">Unknown</add>
+        <add name="Unknown link" type="Ref">Unknown</add>
+    </niobject>
+
+    <compound name="CPropertyGroupItem">
+        <add name="Unknown int 1" type="int">Unknown</add>
+        <add name="Unknown int 2" type="int">Unknown</add>
+        <add name="Unknown int 3" type="int">Unknown</add>
+    </compound>
+
+    <niobject name="CPropertyGroup" abstract="0">
+        <add name="Num Items" type="uint">Unknown</add>
+        <add name="Items" type="CPropertyGroupItem" arr1="Num Items">Unknown</add>
+    </niobject>
+
+    <compound name="CModelPrototypeItem">
+        <add name="Unknown int" type="int">Unknown</add>
+        <add name="Unknown link" type="Ref">Unknown</add>
+    </compound>
+
+    <niobject name="CModelPrototype" abstract="0">
+        <add name="Name" type="string">Unknown</add>
+        <add name="Filename" type="string">Unknown</add>
+        <add name="Unknown int 3" type="int">Unknown</add>
+        <add name="Unknown link" type="Ref">Unknown</add>
+        <add name="Num Unknown Vectors3" type="uint">Unknown</add>
+        <add name="Unknown Vectors3" type="Vector3" arr1="Num Unknown Vectors3">Unknown</add>
+        <add name="Num Unknown ints" type="uint">Unknown</add>
+        <add name="Unknown ints" type="int" arr1="Num Unknown ints">Unknown</add>
+        <add name="Num Items" type="uint">Unknown</add>
+        <add name="Items" type="CModelPrototypeItem" arr1="Num Items">Unknown</add>
+        <add name="Num CKFMDescriptors" type="uint">Unknown</add>
+        <add name="CKFMDescriptors" type="Ref" arr1="Num CKFMDescriptors">Unknown</add>
+        <add name="Num Parts" type="uint">Unknown</add>
+        <add name="Parts" type="CModelPrototypeItem" arr1="Num Parts">Unknown</add>
+    </niobject>
+
+    <niobject name="CKFMDescriptor" abstract="0">
+        <add name="Name" type="string">Unknown</add>
+        <add name="Unknown link" type="Ref">Unknown</add>
+    </niobject>
+
+    <niobject name="CSlot" abstract="0">
+        <add name="Name" type="string">Unknown</add>
+        <add name="Unknown link" type="Ref">Unknown</add>
+        <add name="Unknown int" type="int">Unknown</add>
+        <add name="Num 1" type="uint">Unknown</add>
+        <add name="Unknown ints 1" type="int" arr1="Num 1">Unknown</add>
+        <add name="Num 2" type="uint">Unknown</add>
+        <add name="Unknown links" type="Ref" arr1="Num 2">Unknown</add>
+    </niobject>
+
+    <compound name="CModelTemplateItem">
+        <add name="Num 1" type="uint">Unknown</add>
+        <add name="Unknown bytes 1" type="byte" arr1="Num 1">Unknown</add>
+        <add name="Num 2" type="uint">Unknown</add>
+        <add name="Unknown bytes 2" type="byte" arr1="Num 2">Unknown</add>
+    </compound>
+
+    <niobject name="CModelTemplate" abstract="0">
+        <add name="Name" type="string">Unknown</add>
+        <add name="Unknown int 2" type="int">Unknown</add>
+        <add name="Unknown link 1" type="Ref">Unknown</add>
+        <add name="Unknown link 2" type="Ref">Unknown</add>
+        <add name="Num Items" type="uint">Unknown</add>
+        <add name="Items" type="CModelTemplateItem" arr1="Num Items">Unknown</add>
+    </niobject>
+<!-- Support for Divinity 2 MdlManBinary.nif file, version 20.3.0.9, user version 196608 -END- -->
+
 </niftoolsxml>


### PR DESCRIPTION
@neomonkeus @skyfox69 @jonwd7 @Ghostwalker71 @throttlekitty @nexustheru @amorilia
1. Better support for Skyrim particle system - some "Unknowns" replaced in `NiPSysData` and `BSStripPSysData` blocks.
2. Better support for 20.3.0.9 games Divinity 2 and Black Prophecy. Added structure of `CSStreamableAssetData` block found in .item files (actually nif files) of Divinity 2 game.
