### PR TITLE
Num UV Sets fix for Bethesda games

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -2819,9 +2819,8 @@
         <add name="Compress Flags" type="byte" ver1="10.1.0.0">Unknown.</add>
         <add name="Has Vertices" type="bool" default="1">Is the vertex array present? (Always non-zero.)</add>
         <add name="Vertices" type="Vector3" arr1="Num Vertices" cond="Has Vertices">The mesh vertices.</add>
-        <add name="Num UV Sets" type="byte" vercond="Version >= 10.0.1.0" calculated="1">Number of UV texture sets.
-
-        	Fallout3/Skyrim: can't be higher than 1.</add>
+        <add name="Num UV Sets" type="byte" vercond="((Version >= 10.0.1.0) &amp;&amp; (!((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version &lt;= 12))))" calculated="1">Number of UV texture sets.</add>
+        <add name="BS Num UV Sets" type="byte" vercond="((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version &lt;= 12))" calculated="1">Bethesda's version of Number of UV texture sets. Games always use value 1. Always set to 1.</add>
         <add name="Extra Vectors Flags" type="ExtraVectorsFlags" vercond="Version >= 10.0.1.0">Bit 4: Has Tangents/Bitangents</add>
         <add name="Unknown Int 2" type="uint" ver1="20.2.0.7" userver="12" cond="!NiPSysData">Unknown, seen in Skyrim.</add>
         <add name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</add>
@@ -2845,7 +2844,7 @@
 
             Note: for compatibility with NifTexture, set this value to either 0x00000000 or 0xFFFFFFFF.
         </add>
-        <add name="UV Sets" type="TexCoord" arr1="(Num UV Sets &amp; 63)" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</add>
+        <add name="UV Sets" type="TexCoord" arr1="(Num UV Sets &amp; 63) | (BS Num UV Sets &amp; 1)" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</add>
         <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE" vercond="User Version &lt; 12">Consistency Flags</add>
         <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE" vercond="User Version >= 12" cond="!NiPSysData">Consistency Flags</add>
         <add name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" ver1="20.0.0.4" vercond="User Version &lt; 12">Unknown.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.7.1.1">
+<niftoolsxml version="0.8.1.1">
     <!--These are the version numbers marked as supported by NifSkope.
         The num argument is the numeric representation created by storing
         each part of the version in a byte.  For example, 4.0.0.2 is


### PR DESCRIPTION
@niftools/nifxml-reviewer 

This PR is a result of a conversation between @ttl269 & @jonwd7 about setting ExtraVectorsFlags + Num UV. 

The problem with the nif.xml currently is that in the case of bad (unexpected) values entered into "Num UV Sets" Nifskope produces an error and the nif doesn't load/render. He originally entered value 4095 which caused error with new nif.xml.

Initial discussion was whether or not it is better to keep the value split a a pair of bytes "ExtraVectorsFlags" and "Num UV Sets or BS Num UV Sets" or revert it to original ushort "BS Num UV Sets", so the values like 4097 would be back again.

The commit proposes how to keep two separated values with "protection" against unexpected values.
Update to ensure 'Num UV Set's for Skyrim and Fallout nifs are immune from unexpected values.
