### PR TITLE
FO4 Support

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -6374,7 +6374,7 @@
     <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
         Fallout 4 Tri Shape
         <add name="Bounding Sphere" type="SphereBV" />
-        <add name="Skin" type="Ref" />
+        <add name="Skin" type="Ref" template="NiObject" />
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" />
         <add name="VF1" type="byte" />
         <add name="VF2" type="byte" />
@@ -6499,7 +6499,7 @@
 
     <niobject name="BSSkin::Instance" inherit="NiObject">
         Fallout 4 Skin Instance
-        <add name="Target" type="Ptr" />
+        <add name="Target" type="Ptr" template="NiAVObject" />
         <add name="Bone Data" type="Ref" template="BSSkin::BoneData" />
         <add name="Num Bones" type="uint" />
         <add name="Bones" type="Ptr" arr1="Num Bones" />

--- a/nif.xml
+++ b/nif.xml
@@ -1279,8 +1279,7 @@
         <add name="Unknown Int 3" type="uint" default="0" ver1="30.0.0.2">Unknown. Possibly User Version 2?</add>
         <add name="Export Info" type="ExportInfo" ver1="10.0.1.2" ver2="10.0.1.2" />
         <add name="Export Info" type="ExportInfo" ver1="10.1.0.0" cond="(User Version &gt;= 10) || ((User Version == 1) &amp;&amp; (Version != 10.2.0.0))" />
-        <!-- Absolutely must use ver/userver2 as NifSkope will not process cond on this line causing all earlier NIFs to fail -->
-        <add name="Export Info 3" type="ShortString" ver="20.2.0.7" userver2="130" />
+        <add name="Export Info 3" type="ShortString" cond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))" />
         <add name="Num Block Types" type="ushort" ver1="10.0.1.0">Number of object types in this NIF file.</add>
         <add name="Block Types" type="SizedString" arr1="Num Block Types" ver1="10.0.1.0">List of all object types used in this NIF file.</add>
         <add name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" ver1="10.0.1.0">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -5049,9 +5049,19 @@
         <add name="Glossiness" type="float">The material&#039;s specular power, or glossiness (0-999).</add>
         <add name="Specular Color" type="Color3">Adds a colored highlight.</add>
         <add name="Specular Strength" type="float" default="1.0">Brightness of specular highlight. (0=not visible) (0-999)</add>
-        <add name="Lighting Effect 1" type="float">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
-        <add name="Lighting Effect 2" type="float">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
-        <add name="Unknown 9 Floats" type="float" arr1="9" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Lighting Effect 1" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
+        <add name="Lighting Effect 2" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
+		<add name="Subsurface Rolloff" type="float"  vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Unknown Float 1" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Backlight Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Grayscale to Palette Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Wetness Spec Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Wetness Spec Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Wetness Min Var" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Wetness Env Map Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Wetness Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+		<add name="Wetness Metalness" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Environment Map Scale" type="float" cond="Skyrim Shader Type == 1">Scales the intensity of the environment/cube map. (0-1)</add>
         <add name="Unknown Env Map Int" type="ushort" cond="Skyrim Shader Type == 1" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Skin Tint Color" type="Color3" cond="Skyrim Shader Type == 5">Tints the base texture. Overridden by game settings.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -6290,24 +6290,24 @@
     <compound name="BSVertexDataRigid">
         Rigid Vertex Data compound
         <add name="Vertex" type="HalfVector3" />
-        <add name="Unknown Dot" type="hfloat" />
+        <add name="Bitangent X" type="hfloat" />
         <add name="UV" type="HalfTexCoord" />
         <add name="Normal" type="ByteVector3" />
-        <add name="Unknown Byte 1" type="byte" />
+        <add name="Bitangent Y" type="byte" />
         <add name="Tangent" type="ByteVector3" />
-        <add name="Unknown Byte 2" type="byte" />
+        <add name="Bitangent Z" type="byte" />
         <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
     </compound>
     
     <compound name="BSVertexDataSkinned">
         Skinned Vertex Data compound
         <add name="Vertex" type="HalfVector3" />
-        <add name="Unknown Dot" type="hfloat" />
+        <add name="Bitangent X" type="hfloat" />
         <add name="UV" type="HalfTexCoord" />
         <add name="Normal" type="ByteVector3" />
-        <add name="Unknown Byte 1" type="byte" />
+        <add name="Bitangent Y" type="byte" />
         <add name="Tangent" type="ByteVector3" />
-        <add name="Unknown Byte 2" type="byte" />
+        <add name="Bitangent Z" type="byte" />
         <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
         <add name="Bone Weights" type="hfloat" arr1="4" />
         <add name="Bone Indices" type="byte" arr1="4" />
@@ -6316,14 +6316,14 @@
     <compound name="BSVertexData">
         Catch all Vertex Data compound, SLOW
         <add name="Vertex" type="HalfVector3" />
-        <add name="Unknown Dot" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG != 3))" />
+        <add name="Bitangent X" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG != 3))" />
         <add name="Unknown Short 1" type="ushort" cond="((ARG == 6) || (ARG == 3))" />
         <add name="Unknown Int 1" type="uint" cond="ARG == 3" />
         <add name="UV" type="HalfTexCoord" cond="ARG &gt; 4" />
         <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
-        <add name="Unknown Byte 1" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
+        <add name="Bitangent Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
         <add name="Tangent" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
-        <add name="Unknown Byte 2" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
+        <add name="Bitangent Z" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
         <add name="Vertex Colors" type="ByteColor4" cond="((ARG == 6) || (ARG == 7) || (ARG == 9) || (ARG == 10))" />
         <add name="Bone Weights" type="hfloat" cond="ARG &gt; 6" arr1="4" />
         <add name="Bone Indices" type="byte" cond="ARG &gt; 6" arr1="4" />

--- a/nif.xml
+++ b/nif.xml
@@ -6289,7 +6289,8 @@
     
     <compound name="BSVertexData">
         <add name="Vertex" type="HalfVector3" />
-        <add name="Unknown Dot" type="hfloat" />
+        <add name="Unknown Dot" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG != 3))" />
+        <add name="Unknown Short 1" type="ushort" cond="((ARG == 6) || (ARG == 3))" />
         <add name="Unknown Int 1" type="uint" cond="ARG == 3" />
         <add name="UV" type="HalfTexCoord" cond="ARG &gt; 4" />
         <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />

--- a/nif.xml
+++ b/nif.xml
@@ -6342,7 +6342,7 @@
 
     <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
         Fallout 4 Tri Shape
-        <add name="Unknown 4 Floats" type="float" arr1="4" />
+        <add name="Bounding Sphere" type="SphereBV" />
         <add name="Skin" type="Ref" />
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" />
         <add name="Vertex Flag 1" type="byte" />
@@ -6446,8 +6446,7 @@
 
     <compound name="BSSkinBoneTrans">
         Fallout 4 Bone Transform
-        <add name="Bounding Sphere" type="Vector3" />
-        <add name="Radius" type="float" />
+        <add name="Bounding Sphere" type="SphereBV" />
         <add name="Rotation" type="Matrix33" />
         <add name="Translation" type="Vector3" />
         <add name="Scale" type="float" />

--- a/nif.xml
+++ b/nif.xml
@@ -5035,10 +5035,84 @@
         <option value="31" name="SLSF2_HD_LOD_Objects"></option>
     </bitflags>
 
+    <bitflags name="Fallout4ShaderPropertyFlags1" storage="uint">
+        Fallout 4 Shader Property Flags 1
+        <option value="0" name="FSF1_Specular" />
+        <option value="1" name="FSF1_Skinned" />
+        <option value="2" name="FSF1_Temp_Refraction" />
+        <option value="3" name="FSF1_Vertex_Alpha" />
+        <option value="4" name="FSF1_GreyscaleToPalette_Color" />
+        <option value="5" name="FSF1_GreyscaleToPalette_Alpha" />
+        <option value="6" name="FSF1_Use_Falloff" />
+        <option value="7" name="FSF1_Environment_Mapping" />
+        <option value="8" name="FSF1_RGB_Falloff" />
+        <option value="9" name="FSF1_Cast_Shadows" />
+        <option value="10" name="FSF1_Face" />
+        <option value="11" name="FSF1_UI_Mask_Rects" />
+        <option value="12" name="FSF1_Model_Space_Normals" />
+        <option value="13" name="FSF1_Non_Projective_Shadows" />
+        <option value="14" name="FSF1_Landscape" />
+        <option value="15" name="FSF1_Refraction" />
+        <option value="16" name="FSF1_Fire_Refraction" />
+        <option value="17" name="FSF1_Eye_Environment_Mapping" />
+        <option value="18" name="FSF1_Hair" />
+        <option value="19" name="FSF1_Screendoor_Alpha_Fade" />
+        <option value="20" name="FSF1_Localmap_Hide_Secret" />
+        <option value="21" name="FSF1_Skin_Tint" />
+        <option value="22" name="FSF1_Own_Emit" />
+        <option value="23" name="FSF1_Projected_UV" />
+        <option value="24" name="FSF1_Multiple_Textures" />
+        <option value="25" name="FSF1_Tessellate" />
+        <option value="26" name="FSF1_Decal" />
+        <option value="27" name="FSF1_Dynamic_Decal" />
+        <option value="28" name="FSF1_Character_Lighting" />
+        <option value="29" name="FSF1_External_Emittance" />
+        <option value="30" name="FSF1_Soft_Effect" />
+        <option value="31" name="FSF1_ZBuffer_Test" />
+    </bitflags>
+    
+    <bitflags name="Fallout4ShaderPropertyFlags2" storage="uint">
+        Fallout 4 Shader Property Flags 2
+        <option value="0" name="FSF2_ZBuffer_Write" />
+        <option value="1" name="FSF2_LOD_Landscape" />
+        <option value="2" name="FSF2_LOD_Objects" />
+        <option value="3" name="FSF2_No_Fade" />
+        <option value="4" name="FSF2_Double_Sided" />
+        <option value="5" name="FSF2_Vertex_Colors" />
+        <option value="6" name="FSF2_Glow_Map" />
+        <option value="7" name="FSF2_Transform_Changed" />
+        <option value="8" name="FSF2_Dismemberment_Meatcuff" />
+        <option value="9" name="FSF2_Tint" />
+        <option value="10" name="FSF2_Grass_Vertex_Lighting" />
+        <option value="11" name="FSF2_Grass_Uniform_Scale" />
+        <option value="12" name="FSF2_Grass_Fit_Slope" />
+        <option value="13" name="FSF2_Grass_Billboard" />
+        <option value="14" name="FSF2_No_LOD_Land_Blend" />
+        <option value="15" name="FSF2_Dismemberment" />
+        <option value="16" name="FSF2_Wireframe" />
+        <option value="17" name="FSF2_Weapon_Blood" />
+        <option value="18" name="FSF2_Hide_On_Local_Map" />
+        <option value="19" name="FSF2_Premult_Alpha" />
+        <option value="20" name="FSF2_VATS_Target" />
+        <option value="21" name="FSF2_Anisotropic_Lighting" />
+        <option value="22" name="FSF2_Skew_Specular_Alpha" />
+        <option value="23" name="FSF2_Menu_Screen" />
+        <option value="24" name="FSF2_Multi_Layer_Parallax" />
+        <option value="25" name="FSF2_Alpha_Test" />
+        <option value="26" name="FSF2_Gradient_Remap" />
+        <option value="27" name="FSF2_VATS_Target_Draw_All" />
+        <option value="28" name="FSF2_Pipboy_Screen" />
+        <option value="29" name="FSF2_Tree_Anim" />
+        <option value="30" name="FSF2_Effect_Lighting" />
+        <option value="31" name="FSF2_Refraction_Writes_Depth" />
+    </bitflags>
+
     <niobject name="BSLightingShaderProperty"  abstract="0" inherit="NiProperty">
-        Skyrim PP shader for assigning material/shader/texture.
-        <add name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" vercond="User Version == 12" default="2185233153">Skyrim Shader Flags for setting render/shader options.</add>
-        <add name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" vercond="User Version == 12" default="32801">Skyrim Shader Flags for setting render/shader options.</add>
+        Bethesda shader property for Skyrim and later.
+        <add name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" vercond="(User Version 2 != 130)" default="2185233153">Skyrim Shader Flags for setting render/shader options.</add>
+        <add name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" vercond="(User Version 2 != 130)" default="32801">Skyrim Shader Flags for setting render/shader options.</add>
+        <add name="Shader Flags 1" type="Fallout4ShaderPropertyFlags1" vercond="(User Version 2 == 130)" default="2151678465">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</add>
+        <add name="Shader Flags 2" type="Fallout4ShaderPropertyFlags2" vercond="(User Version 2 == 130)" default="129">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</add>
         <add name="UV Offset" type="TexCoord">Offset UVs</add>
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures, see above.</add>
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</add>
@@ -5082,9 +5156,11 @@
     </niobject>
 
     <niobject name="BSEffectShaderProperty" abstract="0" inherit="NiProperty">
-        Skyrim non-PP shader model, used primarily for transparency effects, often as decal.
-        <add name="Shader Flags 1" type="SkyrimShaderPropertyFlags1"></add>
-        <add name="Shader Flags 2" type="SkyrimShaderPropertyFlags2"></add>
+        Bethesda effect shader property for Skyrim and later.
+        <add name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" vercond="(User Version 2 != 130)" />
+        <add name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" vercond="(User Version 2 != 130)" />
+        <add name="Shader Flags 1" type="Fallout4ShaderPropertyFlags1" vercond="(User Version 2 == 130)" />
+        <add name="Shader Flags 2" type="Fallout4ShaderPropertyFlags2" vercond="(User Version 2 == 130)" />
         <add name="UV Offset" type="TexCoord">Offset UVs</add>
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures</add>
         <add name="Source Texture"  type="SizedString">points to an external texture.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -6547,8 +6547,8 @@
     </niobject>
 	
     <compound name="BSPackedGeomDataCombined">
+        <add name="Grayscale to Palette Scale" type="float" />
         <add name="Rotation" type="Matrix33" />
-        <add name="Unk Float 1" type="float" />
         <add name="Translation" type="Vector3" />
         <add name="Scale" type="float" />
         <add name="Bounding Sphere" type="SphereBV" />

--- a/nif.xml
+++ b/nif.xml
@@ -6362,32 +6362,32 @@
     </niobject>
     
     <compound name="BSSITSSubSegment">
-        <add name="Triangle Offset" type="uint" />
-        <add name="Triangle Count" type="uint" />
-        <add name="Segment Offset" type="uint" />
+        <add name="Start Index" type="uint" />
+        <add name="Num Primitives" type="uint" />
+        <add name="Parent Array Index" type="uint" />
         <add name="Unknown Int 1" type="uint" />
     </compound>
     
     <compound name="BSSITSSegment">
-        <add name="Triangle Offset" type="uint" />
-        <add name="Triangle Count" type="uint" />
-        <add name="Unknown Hash" type="uint" />
-        <add name="Num Segments" type="uint" />
-        <add name="Sub Segment" type="BSSITSSubSegment" arr1="Num Segments" />
+        <add name="Start Index" type="uint" />
+        <add name="Num Primitives" type="uint" />
+        <add name="Parent Array Index" type="uint" />
+        <add name="Num Sub Segments" type="uint" />
+        <add name="Sub Segment" type="BSSITSSubSegment" arr1="Num Sub Segments" />
     </compound>
 
-    <compound name="SubIndexRecordB">
-        <add name="Unknown Int 1" type="uint" />
+    <compound name="BSSITSSubSegmentData">
+        <add name="Segment/User" type="uint">If Unknown Int 2 is 0xffffffff, this value refers to the Segment at the listed index.</add>
         <add name="Unknown Int 2" type="uint" />
         <add name="Num Data" type="uint" />
         <add name="Extra Data" type="float" arr1="Num Data" />
     </compound>
 
-    <compound name="SubIndexPart2">
-        <add name="Num A2" type="uint" />
-        <add name="Num B2" type="uint" />
-        <add name="Sequence" type="uint" arr1="Num A2" />
-        <add name="Sub Index Record" type="SubIndexRecordB" arr1="Num B2" />
+    <compound name="BSSITSSubSegmentRecord">
+        <add name="Num Segments" type="uint" />
+        <add name="Total Segments" type="uint" />
+        <add name="Array Indices" type="uint" arr1="Num Segments" />
+        <add name="Sub Segments" type="BSSITSSubSegmentData" arr1="Total Segments" />
         <!-- TODO: Actual ShortString type (current "ShortString" is actually a byte) -->
         <add name="SSF Length" type="ushort" />
         <add name="SSF File" type="byte" arr1="SSF Length" />
@@ -6395,11 +6395,11 @@
 
     <niobject name="BSSubIndexTriShape" inherit="BSTriShape">
         Fallout 4 Sub-Index Tri Shape
-        <add name="Num Triangles 2" type="uint" cond="Data Size &gt; 0" />
-        <add name="Num A" type="uint" cond="Data Size &gt; 0" />
-        <add name="Num B" type="uint" cond="Data Size &gt; 0" />
-        <add name="Segment" type="BSSITSSegment" arr1="Num A" cond="Data Size &gt; 0" />
-        <add name="Sub Index Part 2" type="SubIndexPart2" cond="(Num A &lt; Num B) &amp;&amp; (Data Size &gt; 0)" />
+        <add name="Num Primitives" type="uint" cond="Data Size &gt; 0" />
+        <add name="Num Segments" type="uint" cond="Data Size &gt; 0" />
+        <add name="Total Segments" type="uint" cond="Data Size &gt; 0" />
+        <add name="Segment" type="BSSITSSegment" arr1="Num Segments" cond="Data Size &gt; 0" />
+        <add name="Sub Segment Data" type="BSSITSSubSegmentRecord" cond="(Num Segments &lt; Total Segments) &amp;&amp; (Data Size &gt; 0)" />
     </niobject>
     
     <!-- Fallout 4 Physics -->

--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.7.1.1">
+<niftoolsxml version="0.8.0.0">
     <!--These are the version numbers marked as supported by NifSkope.
         The num argument is the numeric representation created by storing
         each part of the version in a byte.  For example, 4.0.0.2 is

--- a/nif.xml
+++ b/nif.xml
@@ -29,7 +29,7 @@
     <version num="20.0.0.4">Civilization IV, Oblivion, Sid Meier's Railroads</version>
     <version num="20.0.0.5">Oblivion</version>
     <version num="20.1.0.3">Megami Tensei: Imagine</version>
-    <version num="20.2.0.7">Emerge, Empire Earth III, Fallout 3, Skyrim</version>
+    <version num="20.2.0.7">Emerge, Empire Earth III, Fallout 3, Skyrim, Fallout 4</version>
     <version num="20.2.0.8">Emerge, Empire Earth III, Atlantica</version>
     <!-- version 20.3.0.1 is found in Props/GDCLargeContainer.nif-->
     <version num="20.3.0.1">Emerge</version>
@@ -6355,8 +6355,8 @@
         <add name="Num B2" type="uint" />
         <add name="Sequence" type="uint" arr1="Num A2" />
         <add name="Sub Index Record" type="SubIndexRecordB" arr1="Num B2" />
+        <!-- TODO: Actual ShortString type (current "ShortString" is actually a byte) -->
         <add name="SSP Length" type="ushort" />
-        <!-- There is no actual char support in NifSkope! -->
         <add name="SSP File" type="byte" arr1="SSP Length" />
     </compound>
 
@@ -6365,9 +6365,7 @@
         <add name="Num Triangles 2" type="uint" cond="Data Size &gt; 0" />
         <add name="Num A" type="uint" cond="Data Size &gt; 0" />
         <add name="Num B" type="uint" cond="Data Size &gt; 0" />
-        <!-- Can't use multiplication in expressions! -->
         <add name="Sub Index Part 1" type="SubIndexPart1" arr1="Num A" cond="Data Size &gt; 0" />
-        <!-- end hack -->
         <add name="Sub Index Part 2" type="SubIndexPart2" cond="(Num A &lt; Num B) &amp;&amp; (Data Size &gt; 0)" />
     </niobject>
     

--- a/nif.xml
+++ b/nif.xml
@@ -6362,19 +6362,19 @@
         <add name="LOD2 Size" type="uint" />
     </niobject>
     
-    <compound name="SubIndexRecordA">
+    <compound name="BSSITSSubSegment">
+        <add name="Triangle Offset" type="uint" />
+        <add name="Triangle Count" type="uint" />
+        <add name="Segment Offset" type="uint" />
         <add name="Unknown Int 1" type="uint" />
-        <add name="Unknown Int 2" type="uint" />
-        <add name="Unknown Int 3" type="uint" />
-        <add name="Unknown Int 4" type="uint" />
     </compound>
     
-    <compound name="SubIndexPart1">
-        <add name="Unknown Int 1" type="uint" />
-        <add name="Unknown Int 2" type="uint" />
-        <add name="Unknown Int 3" type="uint" />
-        <add name="Num Records" type="uint" />
-        <add name="Sub Index Record" type="SubIndexRecordA" arr1="Num Records" />
+    <compound name="BSSITSSegment">
+        <add name="Triangle Offset" type="uint" />
+        <add name="Triangle Count" type="uint" />
+        <add name="Unknown Hash" type="uint" />
+        <add name="Num Segments" type="uint" />
+        <add name="Sub Segment" type="BSSITSSubSegment" arr1="Num Segments" />
     </compound>
 
     <compound name="SubIndexRecordB">
@@ -6399,7 +6399,7 @@
         <add name="Num Triangles 2" type="uint" cond="Data Size &gt; 0" />
         <add name="Num A" type="uint" cond="Data Size &gt; 0" />
         <add name="Num B" type="uint" cond="Data Size &gt; 0" />
-        <add name="Sub Index Part 1" type="SubIndexPart1" arr1="Num A" cond="Data Size &gt; 0" />
+        <add name="Segment" type="BSSITSSegment" arr1="Num A" cond="Data Size &gt; 0" />
         <add name="Sub Index Part 2" type="SubIndexPart2" cond="(Num A &lt; Num B) &amp;&amp; (Data Size &gt; 0)" />
     </niobject>
     

--- a/nif.xml
+++ b/nif.xml
@@ -106,7 +106,11 @@
     <basic name="float" count="0" niflibtype="float" nifskopetype="float">
         A standard 32-bit floating point number.
     </basic>
-
+    
+    <basic name="hfloat" count="0" niflibtype="hfloat" nifskopetype="hfloat">
+        A 16-bit floating point number.
+    </basic>
+    
     <basic name="HeaderString" count="0" niflibtype="HeaderString" nifskopetype="headerstring">
         A variable length string that ends with a newline character (0x0A).  The string starts as follows depending on the version:
 
@@ -1081,6 +1085,13 @@
         <add name="Num Vertices" type="ushort">Number of vertices in this group.</add>
         <add name="Vertex Indices" type="ushort" arr1="Num Vertices">The vertex indices.</add>
     </compound>
+    
+    <compound name="HalfVector3">
+        A vector in 3D space (x,y,z).
+        <add name="x" type="hfloat">First coordinate.</add>
+        <add name="y" type="hfloat">Second coordinate.</add>
+        <add name="z" type="hfloat">Third coordinate.</add>
+    </compound>
 
     <compound name="Vector3" niflibtype="Vector3" nifskopetype="vector3">
         A vector in 3D space (x,y,z).
@@ -1268,6 +1279,7 @@
         <add name="Unknown Int 3" type="uint" default="0" ver1="30.0.0.2">Unknown. Possibly User Version 2?</add>
         <add name="Export Info" type="ExportInfo" ver1="10.0.1.2" ver2="10.0.1.2" />
         <add name="Export Info" type="ExportInfo" ver1="10.1.0.0" cond="(User Version &gt;= 10) || ((User Version == 1) &amp;&amp; (Version != 10.2.0.0))" />
+        <add name="Export Info 3" type="ShortString" cond="(Version == 20.2.0.7) &amp;amp; (User Version 2 == 130)" />
         <add name="Num Block Types" type="ushort" ver1="10.0.1.0">Number of object types in this NIF file.</add>
         <add name="Block Types" type="SizedString" arr1="Num Block Types" ver1="10.0.1.0">List of all object types used in this NIF file.</add>
         <add name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" ver1="10.0.1.0">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</add>
@@ -1370,6 +1382,12 @@
         Texture coordinates (u,v). As in OpenGL; image origin is in the lower left corner.
         <add name="u" type="float">First coordinate.</add>
         <add name="v" type="float">Second coordinate.</add>
+    </compound>
+    
+    <compound name="HalfTexCoord">
+        Texture coordinates (u,v).
+        <add name="u" type="hfloat">First coordinate.</add>
+        <add name="v" type="hfloat">Second coordinate.</add>
     </compound>
 
     <compound name="TexDesc">
@@ -2380,7 +2398,7 @@
 
     <niobject name="NiExtraData" abstract="1" inherit="NiObject">
         A generic extra data object.
-        <add name="Name" type="string" ver1="10.0.1.0">Name of this object.</add>
+        <add name="Name" type="string" ver1="10.0.1.0" cond="!BSExtraData">Name of this object.</add>
         <add name="Next Extra Data" type="Ref" template="NiExtraData" ver2="4.2.2.0">Block number of the next extra data object.</add>
     </niobject>
 
@@ -2526,11 +2544,11 @@
 
     <niobject name="NiDynamicEffect" abstract="1" inherit="NiAVObject">
         A dynamic effect such as a light or environment map.
-        <add name="Switch State" type="bool" ver1="10.1.0.106">Turns effect on and off?  Switches list to list of unaffected nodes?</add>
-        <add name="Num Affected Node List Pointers" type="uint" ver2="4.0.0.2">The number of affected nodes referenced.</add>
-        <add name="Num Affected Nodes" type="uint" ver1="10.1.0.0">The number of affected nodes referenced.</add>
+        <add name="Switch State" type="bool" ver1="10.1.0.106" vercond="User Version 2 &lt; 130">Turns effect on and off?  Switches list to list of unaffected nodes?</add>
+        <add name="Num Affected Node List Pointers" type="uint" ver2="4.0.0.2" >The number of affected nodes referenced.</add>
         <add name="Affected Node List Pointers" type="uint" arr1="Num Affected Node List Pointers" ver2="4.0.0.2">This is probably the list of affected nodes. For some reason i do not know the max exporter seems to write pointers instead of links. But it doesn&#039;t matter because at least in version 4.0.0.2 the list is automagically updated by the engine during the load stage.</add>
-        <add name="Affected Nodes" type="Ref" template="NiAVObject" arr1="Num Affected Nodes" ver1="10.1.0.0">The list of affected nodes?</add>
+        <add name="Num Affected Nodes" type="uint" ver1="10.1.0.0" vercond="User Version 2 &lt; 130">The number of affected nodes referenced.</add>
+        <add name="Affected Nodes" type="Ref" template="NiAVObject" arr1="Num Affected Nodes" ver1="10.1.0.0" vercond="User Version 2 &lt; 130">The list of affected nodes?</add>
     </niobject>
 
     <niobject name="NiLight" abstract="1" inherit="NiDynamicEffect">
@@ -2789,8 +2807,10 @@
 
     <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
         Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
-        <add name="Data" type="Ref" template="NiGeometryData">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="3.3.0.13">Skin instance index.</add>
+        <add name="Data" type="Ref" template="NiGeometryData" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Data" type="uint" template="NiGeometryData" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="3.3.0.13" cond="!NiParticleSystem">Skin instance index.</add>
+        <add name="Skin Instance" type="uint" template="NiSkinInstance" ver1="3.3.0.13" cond="NiParticleSystem">Skin instance index.</add>
         <add name="Num Materials" type="uint" ver1="20.2.0.7">Num Materials</add>
         <add name="Material Name" type="string" arr1="Num Materials" ver1="20.2.0.7">Unknown string.  Shader?</add>
         <add name="Material Extra Data" type="int" arr1="Num Materials" ver1="20.2.0.7">Unknown integer; often -1. (Is this a link, array index?)</add>
@@ -2800,7 +2820,8 @@
         <add name="Unknown Integer" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Unknown value, usually -1. (Not a link)</add>
         <add name="Unknown Byte" type="byte" default="255" userver="1">Cyanide extension (only in version 10.2.0.0?).</add>
         <add name="Unknown Integer 2" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown.</add>
-        <add name="Dirty Flag" type="bool" ver1="20.2.0.7">Dirty Flag?</add>
+        <add name="Dirty Flag" type="bool" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt; 130)">Dirty Flag?</add>
+        <add name="Unknown Integer 3" type="int" vercond="(User Version >= 12) &amp;&amp; (User Version 2 >= 130)">Dirty Flag?</add>
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" ver1="20.2.0.7" userver="12">Two property links, used by Bethesda.</add>
     </niobject>
 
@@ -3347,8 +3368,8 @@
         Generic node object for grouping.
         <add name="Num Children" type="uint">The number of child objects.</add>
         <add name="Children" type="Ref" template="NiAVObject" arr1="Num Children">List of child node object indices.</add>
-        <add name="Num Effects" type="uint">The number of references to effect objects that follow.</add>
-        <add name="Effects" type="Ref" template="NiDynamicEffect" arr1="Num Effects">List of node effects. ADynamicEffect?</add>
+        <add name="Num Effects" type="uint" vercond="User Version 2 &lt; 130">The number of references to effect objects that follow.</add>
+        <add name="Effects" type="Ref" template="NiDynamicEffect" arr1="Num Effects" vercond="User Version 2 &lt; 130">List of node effects. ADynamicEffect?</add>
     </niobject>
 
     <niobject name="NiBone" abstract="0" inherit="NiNode">
@@ -3490,6 +3511,9 @@
 		<add name="Unknown Short 2" type="ushort" vercond="User Version >= 12">Unknown</add>
 		<add name="Unknown Short 3" type="ushort" vercond="User Version >= 12">Unknown</add>
 		<add name="Unknown Int 1" type="uint" vercond="User Version >= 12">Unknown</add>
+        <add name="Unknown Int 2" type="int" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)">Unknown</add>
+        <add name="Unknown Int 3" type="int" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)">Unknown</add>
+        <add name="Data" type="Ref" template="NiPSysData" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)">Unknown</add>
 		<add name="World Space" type="bool" ver1="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</add>
         <add name="Num Modifiers" type="uint" ver1="10.1.0.0">The number of modifier references.</add>
         <add name="Modifiers" type="Ref" template="NiPSysModifier" arr1="Num Modifiers" ver1="10.1.0.0">The list of particle modifiers.</add>
@@ -3754,7 +3778,8 @@
     <niobject name="NiPSysMeshEmitter" abstract="0" inherit="NiPSysEmitter">
         Particle emitter that uses points on a specified mesh to emit from.
         <add name="Num Emitter Meshes" type="uint">The number of references to emitter meshes that follow.</add>
-        <add name="Emitter Meshes" type="Ref" template="NiTriBasedGeom" arr1="Num Emitter Meshes">Links to meshes used for emitting.</add>
+        <!-- Note: Reduced strictness of validation -->
+        <add name="Emitter Meshes" type="Ref" template="NiAVObject" arr1="Num Emitter Meshes">Links to meshes used for emitting.</add>
         <add name="Initial Velocity Type" type="VelocityType">The way the particles get their initial direction and speed.</add>
         <add name="Emission Type" type="EmitFrom">The parts of the mesh that the particles emit from.</add>
         <add name="Emission Axis" type="Vector3">The emission axis.</add>
@@ -4861,7 +4886,8 @@
         <add name="Byte 1" type="byte">Unknown</add>
         <add name="Byte 2" type="byte">Unknown</add>
         <add name="Byte 3" type="byte">Unknown</add>
-        <add name="Interpolator 10?" type="Ref" template="NiInterpolator">Unknown, unsure if this is actually another interpolator link.</add>
+        <!-- Note: Reduced strictness of validation -->
+        <add name="Interpolator 10?" type="Ref" template="NiObject">Unknown, unsure if this is actually another interpolator link.</add>
 	</niobject>
 
    <niobject name="BSShaderTextureSet" abstract="0" inherit="NiObject">
@@ -5009,6 +5035,7 @@
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</add>
         <add name="Emissive Color" type="Color3">Glow color and alpha</add>
         <add name="Emissive Multiple" type="float">Multiplied emissive colors</add>
+        <add name="Wet Material" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Texture Clamp Mode" type="TexClampMode">How to handle texture borders.</add>
         <add name="Alpha" type="float" default="1.0">The material&#039;s opacity (1=non-transparent).</add>
         <add name="Refraction Strength" type="float">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
@@ -5017,8 +5044,11 @@
         <add name="Specular Strength" type="float" default="1.0">Brightness of specular highlight. (0=not visible) (0-999)</add>
         <add name="Lighting Effect 1" type="float">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
         <add name="Lighting Effect 2" type="float">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
+        <add name="Unknown 9 Floats" type="float" arr1="9" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Environment Map Scale" type="float" cond="Skyrim Shader Type == 1">Scales the intensity of the environment/cube map. (0-1)</add>
+        <add name="Unknown Env Map Int" type="ushort" cond="Skyrim Shader Type == 1" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Skin Tint Color" type="Color3" cond="Skyrim Shader Type == 5">Tints the base texture. Overridden by game settings.</add>
+        <add name="Unknown Skin Tint Int" type="uint" cond="Skyrim Shader Type == 5" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Hair Tint Color" type="Color3" cond="Skyrim Shader Type == 6">Tints the base texture. Overridden by game settings.</add>
         <add name="Max Passes" type="float" cond="Skyrim Shader Type == 7">Max Passes</add>
         <add name="Scale" type="float" cond="Skyrim Shader Type == 7">Scale</add>
@@ -5040,15 +5070,20 @@
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures</add>
         <add name="Source Texture"  type="SizedString">points to an external texture.</add>
         <add name="Texture Clamp Mode" type="uint">How to handle texture borders.</add>
-        <!-- Seems to behave the same as in LightingShader, but needs flags instead? -->
-        <add name="Falloff Start Angle" type="float" default="1.0">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
-        <add name="Falloff Stop Angle" type="float" default="1.0">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
-        <add name="Falloff Start Opacity" type="float">Alpha falloff multiplier at start angle</add>
-        <add name="Falloff Stop Opacity" type="float">Alpha falloff multiplier at end angle</add>
-        <add name="Emissive Color" type="Color4">Emissive color</add>
-        <add name="Emissive Multiple" type="float">Multiplier for Emissive Color (RGB part)</add>
-        <add name="Soft Falloff Depth" type="float"></add>
-        <add name="Greyscale Texture"  type="SizedString">Points to an external texture, used as palette for SLSF1_Greyscale_To_PaletteColor/SLSF1_Greyscale_To_PaletteAlpha.</add>
+        <add name="Falloff Start Angle" type="float" default="1.0" vercond="User Version 2 &lt; 130">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
+        <add name="Falloff Stop Angle" type="float" default="1.0" vercond="User Version 2 &lt; 130">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
+        <add name="Falloff Start Opacity" type="float" vercond="User Version 2 &lt; 130">Alpha falloff multiplier at start angle</add>
+        <add name="Falloff Stop Opacity" type="float" vercond="User Version 2 &lt; 130">Alpha falloff multiplier at end angle</add>
+        <add name="Emissive Color" type="Color4" vercond="User Version 2 &lt; 130">Emissive color</add>
+        <add name="Emissive Multiple" type="float" vercond="User Version 2 &lt; 130">Multiplier for Emissive Color (RGB part)</add>
+        <add name="Soft Falloff Depth" type="float" vercond="User Version 2 &lt; 130"></add>
+        <add name="Greyscale Texture"  type="SizedString" vercond="User Version 2 &lt; 130">Points to an external texture, used as palette for SLSF1_Greyscale_To_PaletteColor/SLSF1_Greyscale_To_PaletteAlpha.</add>
+        <add name="Unknown 10 Floats" type="float" arr1="10" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Emissive Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Normal Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Specular Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Unknown Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Unknown Float 1" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
     </niobject>
     
     <bitflags name="SkyrimWaterShaderFlags" storage="byte">
@@ -6243,4 +6278,184 @@
     </niobject>
     
     
+    <!-- Fallout 4 Geometry -->
+    
+    <compound name="BSVertexData">
+        <add name="Vertex" type="HalfVector3" />
+        <add name="dotNormal?" type="hfloat" />
+        <add name="UV" type="HalfTexCoord"  cond="ARG != 4" />
+        <add name="Unknown 8 Bytes" type="byte" arr1="8" cond="ARG &gt; 3" />
+        <add name="Vertex Colors" type="ByteColor4" cond="ARG == 6" />
+        <add name="Unknown 2 Ints" type="uint" cond="ARG == 7" arr1="2" />
+        <add name="Unknown 4 Halfs" type="hfloat" cond="ARG &gt;= 8" arr1="4" />
+        <add name="Unknown 4 Bytes" type="byte" cond="ARG &gt;= 8" arr1="4" />
+        <add name="Unknown Int 1" type="uint" cond="ARG == 9" />
+        <add name="Unknown 2 Ints 2" type="uint" cond="ARG == 10" arr1="2" />
+    </compound>
+
+    <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
+        Fallout 4 Tri Shape
+        <add name="Unknown 4 Floats" type="float" arr1="4" />
+        <add name="Skin" type="Ref" />
+        <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" />
+        <add name="Vertex Flag 1" type="byte" />
+        <add name="Vertex Flag 2" type="byte" />
+        <add name="Vertex Flag 3" type="byte" />
+        <add name="Vertex Flag 4" type="byte" />
+        <add name="Vertex Flag 5" type="byte" />
+        <add name="Vertex Flag 6" type="byte" />
+        <add name="Vertex Flag 7" type="byte" />
+        <add name="Vertex Flag 8" type="byte" />
+        <add name="Num Triangles" type="uint" />
+        <add name="Num Vertices" type="ushort" />
+        <add name="Data Size" type="uint" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Flag 1" />
+        <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
+    </niobject>
+
+    <niobject name="BSMeshLODTriShape" inherit="BSTriShape">
+        Fallout 4 LOD Tri Shape
+        <add name="LOD0 Size" type="uint" />
+        <add name="LOD1 Size" type="uint" />
+        <add name="LOD2 Size" type="uint" />
+    </niobject>
+    
+    <compound name="SubIndexRecordA">
+        <add name="Unknown Int 1" type="uint" />
+        <add name="Unknown Int 2" type="uint" />
+        <add name="Unknown Int 3" type="uint" />
+        <add name="Unknown Int 4" type="uint" />
+    </compound>
+    
+    <compound name="SubIndexPart1">
+        <add name="Unknown Int 1" type="uint" />
+        <add name="Unknown Int 2" type="uint" />
+        <add name="Unknown Int 3" type="uint" />
+        <add name="Num Records" type="uint" />
+        <add name="Sub Index Record" type="SubIndexRecordA" arr1="Num Records" />
+    </compound>
+
+    <compound name="SubIndexRecordB">
+        <add name="Unknown Int 1" type="uint" />
+        <add name="Unknown Half 1" type="hfloat" />
+        <add name="Unknown Half 2" type="hfloat" />
+        <add name="Num Data" type="uint" />
+        <add name="Extra Data" type="float" arr1="Num Data" />
+    </compound>
+
+    <compound name="SubIndexPart2">
+        <add name="Num A2" type="uint" />
+        <add name="Num B2" type="uint" />
+        <add name="Sequence" type="uint" arr1="Num A2" />
+        <add name="Sub Index Record" type="SubIndexRecordB" arr1="Num B2" />
+        <add name="SSP Length" type="ushort" />
+        <!-- There is no actual char support in NifSkope! -->
+        <add name="SSP File" type="byte" arr1="SSP Length" />
+    </compound>
+
+    <niobject name="BSSubIndexTriShape" inherit="BSTriShape">
+        Fallout 4 Sub-Index Tri Shape
+        <add name="Num Triangles 2" type="uint" cond="Data Size &gt; 0" />
+        <add name="Num A" type="uint" cond="Data Size &gt; 0" />
+        <add name="Num B" type="uint" cond="Data Size &gt; 0" />
+        <!-- Can't use multiplication in expressions! -->
+        <add name="Sub Index Part 1" type="SubIndexPart1" arr1="Num A" cond="Data Size &gt; 0" />
+        <!-- end hack -->
+        <add name="Sub Index Part 2" type="SubIndexPart2" cond="(Num A &lt; Num B) &amp;&amp; (Data Size &gt; 0)" />
+    </niobject>
+    
+    <!-- Fallout 4 Physics -->
+
+    <niobject name="bhkNPCollisionObject" inherit="bhkCollisionObject">
+        Fallout 4 Collision Object
+        <add name="Unknown Int 2" type="uint">Unknown.</add>
+    </niobject>
+
+    <niobject name="BSExtraData" inherit="NiExtraData">
+        Fallout 4 Extra Data
+    </niobject>
+    
+    <niobject name="bhkPhysicsSystem" inherit="BSExtraData">
+        Fallout 4 Collision System
+        <add name="Num Bytes" type="uint" />
+        <add name="Data" type="byte" nifskopetype="blob" arr1="Num Bytes" />
+    </niobject>
+
+    <niobject name="bhkRagdollSystem" inherit="BSExtraData">
+        Fallout 4 Ragdoll System
+        <add name="Num Bytes" type="uint" />
+        <add name="Data" type="byte" nifskopetype="blob" arr1="Num Bytes" />
+    </niobject>
+
+    <niobject name="BSClothExtraData" inherit="BSExtraData">
+        Fallout 4 Cloth data
+        <add name="Num Bytes" type="uint" />
+        <add name="Data" type="byte" nifskopetype="blob" arr1="Num Bytes" />
+    </niobject>
+    
+    <!-- Fallout 4 Skeleton -->
+
+    <compound name="BSSkinBoneTrans">
+        Fallout 4 Bone Transform
+        <add name="Bounding Sphere" type="Vector3" />
+        <add name="Radius" type="float" />
+        <add name="Rotation" type="Matrix33" />
+        <add name="Translation" type="Vector3" />
+        <add name="Scale" type="float" />
+    </compound>
+
+    <niobject name="BSSkin::Instance" inherit="NiObject">
+        Fallout 4 Skin Instance
+        <add name="Unknown Int 1" type="uint" />
+        <add name="Bone Data" type="Ref" template="BSSkin::BoneData" />
+        <add name="Num Bones" type="uint" />
+        <add name="Bones" type="Ref" arr1="Num Bones" />
+        <add name="Unknown Int 2" type="uint" />
+    </niobject>
+
+    <niobject name="BSSkin::BoneData" inherit="NiObject">
+        Fallout 4 Bone Data
+        <add name="Num Bones" type="uint" />
+        <add name="Bones" type="BSSkinBoneTrans" arr1="Num Bones" />
+    </niobject>
+
+    <niobject name="BSPositionData" inherit="NiExtraData">
+        Fallout 4 Positional Data
+        <add name="Num Data" type="uint" />
+        <add name="Data" type="hfloat" arr1="Num Data" />
+    </niobject>
+
+    <compound name="BSConnectPoint">
+        <add name="Root" type="SizedString" />
+        <add name="Variable Name" type="SizedString" />
+        <add name="Unknown Float 1" type="float" />
+        <add name="Unknown 6 Shorts" type="ushort" arr1="6" />
+        <add name="Unknown 4 Floats" type="float" arr1="4" />
+    </compound>
+
+    <niobject name="BSConnectPoint::Parents" inherit="NiExtraData">
+        Fallout 4 Item Slot Parent
+        <add name="Num Connect Points" type="uint" />
+        <add name="Connect Points" type="BSConnectPoint" arr1="Num Connect Points" />
+    </niobject>
+
+    <niobject name="BSConnectPoint::Children" inherit="NiExtraData">
+        Fallout 4 Item Slot Child
+        <add name="Unknown Byte" type="byte" />
+        <add name="Num Targets" type="int" />
+        <add name="Target" type="SizedString" arr1="Num Targets" />
+    </niobject>
+    
+    <niobject name="BSEyeCenterExtraData" inherit="NiExtraData">
+        Fallout 4 Eye Center Data
+        <add name="Num Data" type="int" />
+        <add name="Data" type="float" arr1="Num Data" />
+    </niobject>
+    
+    <!-- Fallout 4 Animation -->
+    
+    <niobject name="NiLightRadiusController" inherit="NiFloatInterpController">
+    
+    </niobject>
+
 </niftoolsxml>

--- a/nif.xml
+++ b/nif.xml
@@ -6546,13 +6546,13 @@
         <add name="Data" type="float" arr1="Num Data" />
     </niobject>
 	
-	<compound name="BSPackedGeomData">
+    <compound name="BSPackedGeomData">
         <add name="Unk1" type="uint" arr1="8" />
         <add name="Num Unk2" type="uint" />
         <add name="Unk2" type="uint" arr1="Num Unk2" arr2="18" />
         <add name="Unk Int 1" type="uint" />
         <add name="Unk Int 2" type="uint" />
-	</compound>
+    </compound>
     
     <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
         Fallout 4 Packed Combined Geometry Data

--- a/nif.xml
+++ b/nif.xml
@@ -2814,10 +2814,12 @@
 
     <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
         Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
-        <add name="Data" type="Ref" template="NiGeometryData" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Data" type="uint" template="NiGeometryData" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="3.3.0.13" cond="!NiParticleSystem">Skin instance index.</add>
-        <add name="Skin Instance" type="uint" template="NiSkinInstance" ver1="3.3.0.13" cond="NiParticleSystem">Skin instance index.</add>
+        <add name="Data" type="Ref" template="NiGeometryData" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))">Data index (NiTriShapeData/NiTriStripData).</add>
+		<add name="Data" type="Ref" template="NiGeometryData" ver="20.2.0.7" userver2="130" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+		<add name="Data" type="uint" ver="20.2.0.7" userver2="130" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+		<add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version &gt;= 3.3.0.13) &amp;&amp; !((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))">Skin instance index.</add>
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver="20.2.0.7" userver2="130" cond="!NiParticleSystem">Skin instance index.</add>
+        <add name="Skin Instance" type="uint" ver="20.2.0.7" userver2="130" cond="NiParticleSystem">Skin instance index.</add>
         <add name="Num Materials" type="uint" ver1="20.2.0.7">Num Materials</add>
         <add name="Material Name" type="string" arr1="Num Materials" ver1="20.2.0.7">Unknown string.  Shader?</add>
         <add name="Material Extra Data" type="int" arr1="Num Materials" ver1="20.2.0.7">Unknown integer; often -1. (Is this a link, array index?)</add>
@@ -5042,7 +5044,7 @@
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</add>
         <add name="Emissive Color" type="Color3">Glow color and alpha</add>
         <add name="Emissive Multiple" type="float">Multiplied emissive colors</add>
-        <add name="Wet Material" type="StringIndex" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wet Material" type="string" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Texture Clamp Mode" type="TexClampMode">How to handle texture borders.</add>
         <add name="Alpha" type="float" default="1.0">The material&#039;s opacity (1=non-transparent).</add>
         <add name="Refraction Strength" type="float">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>

--- a/nif.xml
+++ b/nif.xml
@@ -1391,7 +1391,7 @@
         <add name="v" type="float">Second coordinate.</add>
     </compound>
     
-    <compound name="HalfTexCoord">
+    <compound name="HalfTexCoord" nifskopetype="halfvector2">
         Texture coordinates (u,v).
         <add name="u" type="hfloat">First coordinate.</add>
         <add name="v" type="hfloat">Second coordinate.</add>
@@ -6358,8 +6358,8 @@
         <add name="Sequence" type="uint" arr1="Num A2" />
         <add name="Sub Index Record" type="SubIndexRecordB" arr1="Num B2" />
         <!-- TODO: Actual ShortString type (current "ShortString" is actually a byte) -->
-        <add name="SSP Length" type="ushort" />
-        <add name="SSP File" type="byte" arr1="SSP Length" />
+        <add name="SSF Length" type="ushort" />
+        <add name="SSF File" type="byte" arr1="SSF Length" />
     </compound>
 
     <niobject name="BSSubIndexTriShape" inherit="BSTriShape">

--- a/nif.xml
+++ b/nif.xml
@@ -6545,9 +6545,32 @@
         <add name="Num Data" type="int" />
         <add name="Data" type="float" arr1="Num Data" />
     </niobject>
+	
+	<compound name="BSPackedGeomData">
+        <add name="Unk1" type="uint" arr1="8" />
+        <add name="Num Unk2" type="uint" />
+        <add name="Unk2" type="uint" arr1="Num Unk2" arr2="18" />
+        <add name="Unk Int 1" type="uint" />
+        <add name="Unk Int 2" type="uint" />
+	</compound>
     
     <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
         Fallout 4 Packed Combined Geometry Data
+        <add name="VF1" type="byte" />
+        <add name="VF2" type="byte" />
+        <add name="VF3" type="byte" />
+        <add name="VF4" type="byte" />
+        <add name="VF5" type="byte" />
+        <add name="VF6" type="byte" />
+        <add name="VF7" type="byte" />
+        <add name="VF8" type="byte" />
+        <add name="Num Vertices" type="uint" />
+        <add name="Num Triangles" type="uint" />
+        <add name="Unknown Int 1" type="uint" />
+        <add name="Unknown Int 2" type="uint" />
+        <add name="Num Data" type="uint" />
+        <add name="Unk 1" type="byte" arr1="Num Data" arr2="8" />
+        <add name="Data" type="BSPackedGeomData" arr1="Num Data" />
     </niobject>
     
     <!-- Fallout 4 Animation -->

--- a/nif.xml
+++ b/nif.xml
@@ -6292,13 +6292,13 @@
         <add name="Unknown Dot" type="hfloat" />
         <add name="Unknown Int 1" type="uint" cond="ARG == 3" />
         <add name="UV" type="HalfTexCoord" cond="ARG &gt; 4" />
-        <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Unknown Byte 1" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Tangent" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Unknown Byte 2" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Vertex Colors" type="ByteColor4" cond="((ARG == 7) || (ARG == 9) || (ARG == 10))" />
-        <add name="Bone Weights" type="hfloat" cond="ARG &gt;= 6" arr1="4" />
-        <add name="Bone Indices" type="byte" cond="ARG &gt;= 6" arr1="4" />
+        <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
+        <add name="Unknown Byte 1" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
+        <add name="Tangent" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
+        <add name="Unknown Byte 2" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
+        <add name="Vertex Colors" type="ByteColor4" cond="((ARG == 6) || (ARG == 7) || (ARG == 9) || (ARG == 10))" />
+        <add name="Bone Weights" type="hfloat" cond="ARG &gt; 6" arr1="4" />
+        <add name="Bone Indices" type="byte" cond="ARG &gt; 6" arr1="4" />
         <add name="Unknown Int 2" type="uint" cond="ARG == 10" />
     </compound>
 

--- a/nif.xml
+++ b/nif.xml
@@ -6319,15 +6319,15 @@
         <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
         <add name="Bone Weights" type="hfloat" arr1="4" />
         <add name="Bone Indices" type="byte" arr1="4" />
+        <add name="Unknown Int 2" type="uint" cond="(ARG &amp; 16) != 0" />
     </compound>
     
     <compound name="BSVertexData">
         Catch all Vertex Data compound, SLOW
         <add name="Vertex" type="HalfVector3" />
-        <add name="Bitangent X" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG != 3))" />
-        <add name="Unknown Short 1" type="ushort" cond="((ARG == 6) || (ARG == 3))" />
-        <add name="Unknown Int 1" type="uint" cond="ARG == 3" />
-        <add name="UV" type="HalfTexCoord" cond="ARG &gt; 4" />
+        <add name="Bitangent X" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG &gt; 4))" />
+        <add name="Unknown Short 1" type="ushort" cond="((ARG == 6) || (ARG &lt; 5))" />
+        <add name="UV" type="HalfTexCoord" cond="(ARG &gt; 2) &amp;&amp; (ARG != 4)" />
         <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
         <add name="Bitangent Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
         <add name="Tangent" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
@@ -6337,29 +6337,76 @@
         <add name="Bone Indices" type="byte" cond="ARG &gt; 6" arr1="4" />
         <add name="Unknown Int 2" type="uint" cond="ARG == 10" />
     </compound>
+    
+    <compound name="BSVertexDataFloat">
+        Rigid Vertex Data compound
+        <add name="Vertex" type="Vector3" />
+        <add name="Bitangent X" type="float" />
+        <add name="UV" type="HalfTexCoord" />
+        <add name="Normal" type="ByteVector3" />
+        <add name="Bitangent Y" type="byte" />
+        <add name="Tangent" type="ByteVector3" />
+        <add name="Bitangent Z" type="byte" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
+        <add name="Bone Weights" type="hfloat" cond="(ARG &amp; 4) != 0" arr1="4" />
+        <add name="Bone Indices" type="byte" cond="(ARG &amp; 4) != 0" arr1="4" />
+    </compound>
+    
+    <compound name="BSVertexDataNoTangents">
+        TODO: Temporary
+        <add name="Vertex" type="HalfVector3" />
+        <add name="Unknown Short 1" type="ushort" />
+        <add name="Normal" type="ByteVector3" />
+        <add name="Unknown Byte 1" type="byte" />
+        <add name="Vertex Colors" type="ByteColor4" cond="ARG == 4" />
+    </compound>
+    
+    <compound name="BSVertexDataNoNormals">
+        TODO: Temporary
+        <add name="Vertex" type="HalfVector3" />
+        <add name="Unknown Short 1" type="ushort" />
+        <add name="UV" type="HalfTexCoord" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
+        <add name="Bone Weights" type="hfloat" cond="(ARG &amp; 4) != 0" arr1="4" />
+        <add name="Bone Indices" type="byte" cond="(ARG &amp; 4) != 0" arr1="4" />
+    </compound>
 
     <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
         Fallout 4 Tri Shape
         <add name="Bounding Sphere" type="SphereBV" />
         <add name="Skin" type="Ref" />
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" />
-        <add name="Vertex Flag 1" type="byte" />
-        <add name="Vertex Flag 2" type="byte" />
-        <add name="Vertex Flag 3" type="byte" />
-        <add name="Vertex Flag 4" type="byte" />
-        <add name="Vertex Flag 5" type="byte" />
-        <add name="Vertex Flag 6" type="byte" />
-        <add name="Vertex Flag 7" type="byte" />
-        <add name="Vertex Flag 8" type="byte" />
+        <add name="VF1" type="byte" />
+        <add name="VF2" type="byte" />
+        <add name="VF3" type="byte" />
+        <add name="VF4" type="byte" />
+        <add name="VF5" type="byte" />
+        <add name="VF6" type="byte" />
+        <add name="VF7" type="byte" />
+        <add name="VF8" type="byte" />
         <add name="Num Triangles" type="uint" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-        <add name="Vertex Data" type="BSVertexDataRigid" arr1="Num Vertices" arg="Vertex Flag 7" 
-            cond="(Data Size &gt; 0) &amp;&amp; ((Vertex Flag 7 &amp; 1) != 0) &amp;&amp; ((Vertex Flag 7 &amp; 4) == 0)" />
-        <add name="Vertex Data" type="BSVertexDataSkinned" arr1="Num Vertices" arg="Vertex Flag 7" 
-            cond="(Data Size &gt; 0) &amp;&amp; ((Vertex Flag 7 &amp; 1) != 0) &amp;&amp; ((Vertex Flag 7 &amp; 4) != 0) &amp;&amp; (Vertex Flag 5 == 0)" />
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Flag 1"
-            cond="(Data Size &gt; 0) &amp;&amp; (((Vertex Flag 7 &amp; 1) == 0) || Vertex Flag 5 &gt; 0)" />
+		<!-- Below are several compounds to bypass the inability to check multiple flags via multiple ARG passing -->
+		<!-- NifSkope performance is also **extremely** poor with ARG passing and so optimized compounds for the majority of cases were created -->
+		<!-- Rigid (Optimized) -->
+        <add name="Vertex Data" type="BSVertexDataRigid" arr1="Num Vertices" arg="VF7" 
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; ((VF7 &amp; 1) != 0) &amp;&amp; ((VF7 &amp; 4) == 0) &amp;&amp; (VF6 == 176)" />
+		<!-- Skinned (Optimized) -->
+        <add name="Vertex Data" type="BSVertexDataSkinned" arr1="Num Vertices" arg="VF7" 
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; ((VF7 &amp; 1) != 0) &amp;&amp; ((VF7 &amp; 4) != 0) &amp;&amp; (VF6 == 176)" />
+		<!-- Catch All (SLOW) -->
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF1"
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; ((VF7 &amp; 1) == 0) &amp;&amp; ((VF6 == 176) || (VF6 == 16))" />
+		<!-- Float Replacement (SCOL folder) -->
+        <add name="Vertex Data" type="BSVertexDataFloat" arr1="Num Vertices" arg="VF7"
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) != 0) &amp;&amp; (VF6 == 176)" />
+		<!-- Edge Case #1 (VF6 == 48) -->
+        <add name="Vertex Data" type="BSVertexDataNoNormals" arr1="Num Vertices" arg="VF7"
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; (VF6 == 48)" />
+		<!-- Edge Case #2 (VF6 == 144) -->
+        <add name="Vertex Data" type="BSVertexDataNoTangents" arr1="Num Vertices" arg="VF1"
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; (VF6 == 144)" />
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
     </niobject>
 
@@ -6497,6 +6544,10 @@
         Fallout 4 Eye Center Data
         <add name="Num Data" type="int" />
         <add name="Data" type="float" arr1="Num Data" />
+    </niobject>
+    
+    <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
+        Fallout 4 Packed Combined Geometry Data
     </niobject>
     
     <!-- Fallout 4 Animation -->

--- a/nif.xml
+++ b/nif.xml
@@ -6309,7 +6309,7 @@
         <add name="Num Triangles" type="uint" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Flag 1" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Flag 1" cond="Data Size &gt; 0" />
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -2396,7 +2396,7 @@
         <add name="Data Layers" type="HavokColFilter" arr1="Num Data Layers">Havok Layers for each strip data.</add>
     </niobject>
 
-    <niobject name="NiExtraData" abstract="1" inherit="NiObject">
+    <niobject name="NiExtraData" abstract="0" inherit="NiObject">
         A generic extra data object.
         <add name="Name" type="string" ver1="10.0.1.0" cond="!BSExtraData">Name of this object.</add>
         <add name="Next Extra Data" type="Ref" template="NiExtraData" ver2="4.2.2.0">Block number of the next extra data object.</add>
@@ -6406,11 +6406,12 @@
 
     <niobject name="BSSkin::Instance" inherit="NiObject">
         Fallout 4 Skin Instance
-        <add name="Unknown Int 1" type="uint" />
+        <add name="Target" type="Ptr" />
         <add name="Bone Data" type="Ref" template="BSSkin::BoneData" />
         <add name="Num Bones" type="uint" />
-        <add name="Bones" type="Ref" arr1="Num Bones" />
-        <add name="Unknown Int 2" type="uint" />
+        <add name="Bones" type="Ptr" arr1="Num Bones" />
+        <add name="Num Unknown" type="uint" />
+        <add name="Unknown" type="Vector3" arr1="Num Unknown" />
     </niobject>
 
     <niobject name="BSSkin::BoneData" inherit="NiObject">

--- a/nif.xml
+++ b/nif.xml
@@ -1086,6 +1086,13 @@
         <add name="Vertex Indices" type="ushort" arr1="Num Vertices">The vertex indices.</add>
     </compound>
     
+    <compound name="ByteVector3" nifskopetype="bytevector3">
+        A vector in 3D space (x,y,z).
+        <add name="x" type="byte">First coordinate.</add>
+        <add name="y" type="byte">Second coordinate.</add>
+        <add name="z" type="byte">Third coordinate.</add>
+    </compound>
+    
     <compound name="HalfVector3" nifskopetype="halfvector3">
         A vector in 3D space (x,y,z).
         <add name="x" type="hfloat">First coordinate.</add>
@@ -6285,13 +6292,9 @@
         <add name="Unknown Dot" type="hfloat" />
         <add name="Unknown Int 1" type="uint" cond="ARG == 3" />
         <add name="UV" type="HalfTexCoord" cond="ARG &gt; 4" />
-        <add name="Normal X" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Normal Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Normal Z" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
         <add name="Unknown Byte 1" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Tangent X" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Tangent Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
-        <add name="Tangent Z" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Tangent" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
         <add name="Unknown Byte 2" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
         <add name="Vertex Colors" type="ByteColor4" cond="((ARG == 7) || (ARG == 9) || (ARG == 10))" />
         <add name="Bone Weights" type="hfloat" cond="ARG &gt;= 6" arr1="4" />

--- a/nif.xml
+++ b/nif.xml
@@ -6478,9 +6478,9 @@
     <compound name="BSConnectPoint">
         <add name="Root" type="SizedString" />
         <add name="Variable Name" type="SizedString" />
-        <add name="Unknown Float 1" type="float" />
-        <add name="Unknown 6 Shorts" type="ushort" arr1="6" />
-        <add name="Unknown 4 Floats" type="float" arr1="4" />
+        <add name="Rotation" type="Quaternion" />
+        <add name="Translation" type="Vector3" />
+        <add name="Scale" type="float" />
     </compound>
 
     <niobject name="BSConnectPoint::Parents" inherit="NiExtraData">

--- a/nif.xml
+++ b/nif.xml
@@ -1086,7 +1086,7 @@
         <add name="Vertex Indices" type="ushort" arr1="Num Vertices">The vertex indices.</add>
     </compound>
     
-    <compound name="HalfVector3">
+    <compound name="HalfVector3" nifskopetype="halfvector3">
         A vector in 3D space (x,y,z).
         <add name="x" type="hfloat">First coordinate.</add>
         <add name="y" type="hfloat">Second coordinate.</add>
@@ -5035,7 +5035,7 @@
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</add>
         <add name="Emissive Color" type="Color3">Glow color and alpha</add>
         <add name="Emissive Multiple" type="float">Multiplied emissive colors</add>
-        <add name="Wet Material" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wet Material" type="StringIndex" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Texture Clamp Mode" type="TexClampMode">How to handle texture borders.</add>
         <add name="Alpha" type="float" default="1.0">The material&#039;s opacity (1=non-transparent).</add>
         <add name="Refraction Strength" type="float">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
@@ -6282,22 +6282,21 @@
     
     <compound name="BSVertexData">
         <add name="Vertex" type="HalfVector3" />
-        <add name="dotNormal?" type="hfloat" />
-        <add name="UV" type="HalfTexCoord"  cond="ARG != 4" />
-        <add name="Normal X" type="byte" cond="ARG &gt; 3" />
-        <add name="Normal Y" type="byte" cond="ARG &gt; 3" />
-        <add name="Normal Z" type="byte" cond="ARG &gt; 3" />
-        <add name="Unknown Byte 1" type="byte" cond="ARG &gt; 3" />
-        <add name="Tangent X" type="byte" cond="ARG &gt; 3" />
-        <add name="Tangent Y" type="byte" cond="ARG &gt; 3" />
-        <add name="Tangent Z" type="byte" cond="ARG &gt; 3" />
-        <add name="Unknown Byte 2" type="byte" cond="ARG &gt; 3" />
-        <add name="Vertex Colors" type="ByteColor4" cond="ARG == 6" />
-        <add name="Unknown 2 Ints" type="uint" cond="ARG == 7" arr1="2" />
-        <add name="Unknown 4 Halfs" type="hfloat" cond="ARG &gt;= 8" arr1="4" />
-        <add name="Unknown 4 Bytes" type="byte" cond="ARG &gt;= 8" arr1="4" />
-        <add name="Unknown Int 1" type="uint" cond="ARG == 9" />
-        <add name="Unknown 2 Ints 2" type="uint" cond="ARG == 10" arr1="2" />
+        <add name="Unknown Dot" type="hfloat" />
+        <add name="Unknown Int 1" type="uint" cond="ARG == 3" />
+        <add name="UV" type="HalfTexCoord" cond="ARG &gt; 4" />
+        <add name="Normal X" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Normal Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Normal Z" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Unknown Byte 1" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Tangent X" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Tangent Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Tangent Z" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Unknown Byte 2" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 6) &amp;&amp; (ARG != 7))" />
+        <add name="Vertex Colors" type="ByteColor4" cond="((ARG == 7) || (ARG == 9) || (ARG == 10))" />
+        <add name="Bone Weights" type="hfloat" cond="ARG &gt;= 6" arr1="4" />
+        <add name="Bone Indices" type="byte" cond="ARG &gt;= 6" arr1="4" />
+        <add name="Unknown Int 2" type="uint" cond="ARG == 10" />
     </compound>
 
     <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
@@ -6344,8 +6343,7 @@
 
     <compound name="SubIndexRecordB">
         <add name="Unknown Int 1" type="uint" />
-        <add name="Unknown Half 1" type="hfloat" />
-        <add name="Unknown Half 2" type="hfloat" />
+        <add name="Unknown Int 2" type="uint" />
         <add name="Num Data" type="uint" />
         <add name="Extra Data" type="float" arr1="Num Data" />
     </compound>

--- a/nif.xml
+++ b/nif.xml
@@ -1053,7 +1053,7 @@
         <add name="a" type="float">Alpha.</add>
     </compound>
 
-    <compound name="ByteColor4"><!-- niflibtype="Color4" nifskopetype="color4" -->
+    <compound name="ByteColor4" nifskopetype="bytecolor4"><!-- niflibtype="Color4" nifskopetype="color4" -->
         A color with alpha (red, green, blue, alpha).
         <add name="r" type="byte">Red color component.</add>
         <add name="g" type="byte">Green color component.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -5087,20 +5087,18 @@
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures</add>
         <add name="Source Texture"  type="SizedString">points to an external texture.</add>
         <add name="Texture Clamp Mode" type="uint">How to handle texture borders.</add>
-        <add name="Falloff Start Angle" type="float" default="1.0" vercond="User Version 2 &lt; 130">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
-        <add name="Falloff Stop Angle" type="float" default="1.0" vercond="User Version 2 &lt; 130">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
-        <add name="Falloff Start Opacity" type="float" vercond="User Version 2 &lt; 130">Alpha falloff multiplier at start angle</add>
-        <add name="Falloff Stop Opacity" type="float" vercond="User Version 2 &lt; 130">Alpha falloff multiplier at end angle</add>
-        <add name="Emissive Color" type="Color4" vercond="User Version 2 &lt; 130">Emissive color</add>
-        <add name="Emissive Multiple" type="float" vercond="User Version 2 &lt; 130">Multiplier for Emissive Color (RGB part)</add>
-        <add name="Soft Falloff Depth" type="float" vercond="User Version 2 &lt; 130"></add>
-        <add name="Greyscale Texture"  type="SizedString" vercond="User Version 2 &lt; 130">Points to an external texture, used as palette for SLSF1_Greyscale_To_PaletteColor/SLSF1_Greyscale_To_PaletteAlpha.</add>
-        <add name="Unknown 10 Floats" type="float" arr1="10" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Emissive Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Falloff Start Angle" type="float" default="1.0">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
+        <add name="Falloff Stop Angle" type="float" default="1.0">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
+        <add name="Falloff Start Opacity" type="float">Alpha falloff multiplier at start angle</add>
+        <add name="Falloff Stop Opacity" type="float">Alpha falloff multiplier at end angle</add>
+        <add name="Emissive Color" type="Color4">Emissive color</add>
+        <add name="Emissive Multiple" type="float">Multiplier for Emissive Color (RGB part)</add>
+        <add name="Soft Falloff Depth" type="float"></add>
+        <add name="Greyscale Texture"  type="SizedString">Points to an external texture, used as palette for SLSF1_Greyscale_To_PaletteColor/SLSF1_Greyscale_To_PaletteAlpha.</add>
+        <add name="Env Map Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Normal Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Specular Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Unknown Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Unknown Float 1" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Env Mask Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Environment Map Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
     </niobject>
     
     <bitflags name="SkyrimWaterShaderFlags" storage="byte">

--- a/nif.xml
+++ b/nif.xml
@@ -2815,9 +2815,9 @@
     <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
         Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
         <add name="Data" type="Ref" template="NiGeometryData" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))">Data index (NiTriShapeData/NiTriStripData).</add>
-		<add name="Data" type="Ref" template="NiGeometryData" ver="20.2.0.7" userver2="130" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
-		<add name="Data" type="uint" ver="20.2.0.7" userver2="130" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
-		<add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version &gt;= 3.3.0.13) &amp;&amp; !((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))">Skin instance index.</add>
+        <add name="Data" type="Ref" template="NiGeometryData" ver="20.2.0.7" userver2="130" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Data" type="uint" ver="20.2.0.7" userver2="130" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version &gt;= 3.3.0.13) &amp;&amp; !((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))">Skin instance index.</add>
         <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver="20.2.0.7" userver2="130" cond="!NiParticleSystem">Skin instance index.</add>
         <add name="Skin Instance" type="uint" ver="20.2.0.7" userver2="130" cond="NiParticleSystem">Skin instance index.</add>
         <add name="Num Materials" type="uint" ver1="20.2.0.7">Num Materials</add>
@@ -2830,7 +2830,7 @@
         <add name="Unknown Byte" type="byte" default="255" userver="1">Cyanide extension (only in version 10.2.0.0?).</add>
         <add name="Unknown Integer 2" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown.</add>
         <add name="Dirty Flag" type="bool" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt; 130)">Dirty Flag?</add>
-        <add name="Unknown Integer 3" type="int" vercond="(User Version >= 12) &amp;&amp; (User Version 2 >= 130)">Dirty Flag?</add>
+        <add name="Unknown Integer 3" type="int" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)">Dirty Flag?</add>
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" ver1="20.2.0.7" userver="12">Two property links, used by Bethesda.</add>
     </niobject>
 
@@ -5053,17 +5053,17 @@
         <add name="Specular Strength" type="float" default="1.0">Brightness of specular highlight. (0=not visible) (0-999)</add>
         <add name="Lighting Effect 1" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
         <add name="Lighting Effect 2" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
-		<add name="Subsurface Rolloff" type="float"  vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Subsurface Rolloff" type="float"  vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Unknown Float 1" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Backlight Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Grayscale to Palette Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Wetness Spec Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Wetness Spec Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Wetness Min Var" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Wetness Env Map Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Wetness Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-		<add name="Wetness Metalness" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Backlight Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Grayscale to Palette Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wetness Spec Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wetness Spec Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wetness Min Var" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wetness Env Map Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wetness Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wetness Metalness" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Environment Map Scale" type="float" cond="Skyrim Shader Type == 1">Scales the intensity of the environment/cube map. (0-1)</add>
         <add name="Unknown Env Map Int" type="ushort" cond="Skyrim Shader Type == 1" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Skin Tint Color" type="Color3" cond="Skyrim Shader Type == 5">Tints the base texture. Overridden by game settings.</add>
@@ -5089,6 +5089,7 @@
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures</add>
         <add name="Source Texture"  type="SizedString">points to an external texture.</add>
         <add name="Texture Clamp Mode" type="uint">How to handle texture borders.</add>
+        <!-- Seems to behave the same as in LightingShader, but needs flags instead? -->
         <add name="Falloff Start Angle" type="float" default="1.0">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
         <add name="Falloff Stop Angle" type="float" default="1.0">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
         <add name="Falloff Start Opacity" type="float">Alpha falloff multiplier at start angle</add>
@@ -6512,10 +6513,10 @@
         <add name="Unk Int 2" type="uint" />
     </compound>
 	
-	<compound name="BSPackedGeomObject">
-		<add name="Unknown Int 1" type="uint" />
-		<add name="Object Hash?" type="uint" />
-	</compound>
+    <compound name="BSPackedGeomObject">
+        <add name="Unknown Int 1" type="uint" />
+        <add name="Object Hash?" type="uint" />
+    </compound>
     
     <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
         Fallout 4 Packed Combined Geometry Data

--- a/nif.xml
+++ b/nif.xml
@@ -6316,34 +6316,7 @@
         <option value="15" name="VF_Unknown_8" />      <!-- & 32768 -->
     </bitflags>
     
-    <compound name="BSVertexDataRigid">
-        Rigid Vertex Data compound
-        <add name="Vertex" type="HalfVector3" />
-        <add name="Bitangent X" type="hfloat" />
-        <add name="UV" type="HalfTexCoord" />
-        <add name="Normal" type="ByteVector3" />
-        <add name="Bitangent Y" type="byte" />
-        <add name="Tangent" type="ByteVector3" />
-        <add name="Bitangent Z" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
-    </compound>
-    
-    <compound name="BSVertexDataSkinned">
-        Skinned Vertex Data compound
-        <add name="Vertex" type="HalfVector3" />
-        <add name="Bitangent X" type="hfloat" />
-        <add name="UV" type="HalfTexCoord" />
-        <add name="Normal" type="ByteVector3" />
-        <add name="Bitangent Y" type="byte" />
-        <add name="Tangent" type="ByteVector3" />
-        <add name="Bitangent Z" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
-        <add name="Bone Weights" type="hfloat" arr1="4" />
-        <add name="Bone Indices" type="byte" arr1="4" />
-    </compound>
-    
     <compound name="BSVertexData">
-        Catch all Vertex Data compound, SLOW
         <add name="Vertex" type="HalfVector3" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
         <add name="Bitangent X" type="hfloat" cond="((ARG &amp; 256) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
         <add name="Unknown Short" type="ushort" cond="((ARG &amp; 256) == 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
@@ -6359,20 +6332,6 @@
         <add name="Bone Weights" type="hfloat" arr1="4" cond="(ARG &amp; 1024) != 0" />
         <add name="Bone Indices" type="byte" arr1="4" cond="(ARG &amp; 1024) != 0" />
         <add name="Unknown Int 2" type="uint" cond="(ARG &amp; 4096) != 0" />
-    </compound>
-    
-    <compound name="BSVertexDataFloat">
-        Rigid Vertex Data compound
-        <add name="Vertex" type="Vector3" />
-        <add name="Bitangent X" type="float" />
-        <add name="UV" type="HalfTexCoord" />
-        <add name="Normal" type="ByteVector3" />
-        <add name="Bitangent Y" type="byte" />
-        <add name="Tangent" type="ByteVector3" />
-        <add name="Bitangent Z" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
-        <add name="Bone Weights" type="hfloat" cond="(ARG &amp; 1024) != 0" arr1="4" />
-        <add name="Bone Indices" type="byte" cond="(ARG &amp; 1024) != 0" arr1="4" />
     </compound>
 
     <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
@@ -6390,20 +6349,7 @@
         <add name="Num Triangles" type="uint" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-        <!-- NifSkope performance is **extremely** poor with ARG passing and so optimized compounds for the majority of cases were created -->
-        <!-- Rigid (Optimized) -->
-        <add name="Vertex Data" type="BSVertexDataRigid" arr1="Num Vertices" arg="VF" 
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF == 432) || (VF == 944))" />
-        <!-- Skinned (Optimized) -->
-        <add name="Vertex Data" type="BSVertexDataSkinned" arr1="Num Vertices" arg="VF" 
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF == 1456) || (VF == 1968))" />
-        <!-- Catch All (SLOW) -->
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF"
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF &amp; 16384) == 0) &amp;&amp; ((VF != 432) &amp;&amp; (VF != 944) &amp;&amp; (VF != 1456) &amp;&amp; (VF != 1968))" />
-        <!-- Float Replacement (SCOL folder) -->
-        <add name="Vertex Data" type="BSVertexDataFloat" arr1="Num Vertices" arg="VF"
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF &amp; 16384) != 0)" />
-
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF" cond="Data Size &gt; 0" />
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -6285,7 +6285,14 @@
         <add name="Vertex" type="HalfVector3" />
         <add name="dotNormal?" type="hfloat" />
         <add name="UV" type="HalfTexCoord"  cond="ARG != 4" />
-        <add name="Unknown 8 Bytes" type="byte" arr1="8" cond="ARG &gt; 3" />
+        <add name="Normal X" type="byte" cond="ARG &gt; 3" />
+        <add name="Normal Y" type="byte" cond="ARG &gt; 3" />
+        <add name="Normal Z" type="byte" cond="ARG &gt; 3" />
+        <add name="Unknown Byte 1" type="byte" cond="ARG &gt; 3" />
+        <add name="Tangent X" type="byte" cond="ARG &gt; 3" />
+        <add name="Tangent Y" type="byte" cond="ARG &gt; 3" />
+        <add name="Tangent Z" type="byte" cond="ARG &gt; 3" />
+        <add name="Unknown Byte 2" type="byte" cond="ARG &gt; 3" />
         <add name="Vertex Colors" type="ByteColor4" cond="ARG == 6" />
         <add name="Unknown 2 Ints" type="uint" cond="ARG == 7" arr1="2" />
         <add name="Unknown 4 Halfs" type="hfloat" cond="ARG &gt;= 8" arr1="4" />

--- a/nif.xml
+++ b/nif.xml
@@ -6546,13 +6546,33 @@
         <add name="Data" type="float" arr1="Num Data" />
     </niobject>
 	
+    <compound name="BSPackedGeomDataCombined">
+        <add name="Rotation" type="Matrix33" />
+        <add name="Unk Float 1" type="float" />
+        <add name="Translation" type="Vector3" />
+        <add name="Scale" type="float" />
+        <add name="Bounding Sphere" type="SphereBV" />
+    </compound>
+    
+    <compound name="BSPackedGeomDataLOD">
+        <add name="Triangle Count" type="uint" />
+        <add name="Triangle Offset" type="uint" />
+    </compound>
+    
     <compound name="BSPackedGeomData">
-        <add name="Unk1" type="uint" arr1="8" />
-        <add name="Num Unk2" type="uint" />
-        <add name="Unk2" type="uint" arr1="Num Unk2" arr2="18" />
+        <add name="Num Verts" type="uint" />
+        <add name="LOD Levels" type="uint" />
+        <add name="LOD" type="BSPackedGeomDataLOD" arr1="LOD Levels" />
+        <add name="Num Combined" type="uint" />
+        <add name="Combined" type="BSPackedGeomDataCombined" arr1="Num Combined" />
         <add name="Unk Int 1" type="uint" />
         <add name="Unk Int 2" type="uint" />
     </compound>
+	
+	<compound name="BSPackedGeomObject">
+		<add name="Unknown Int 1" type="uint" />
+		<add name="Object Hash?" type="uint" />
+	</compound>
     
     <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
         Fallout 4 Packed Combined Geometry Data
@@ -6566,11 +6586,11 @@
         <add name="VF8" type="byte" />
         <add name="Num Vertices" type="uint" />
         <add name="Num Triangles" type="uint" />
-        <add name="Unknown Int 1" type="uint" />
-        <add name="Unknown Int 2" type="uint" />
+        <add name="Unknown Flags 1" type="uint" />
+        <add name="Unknown Flags 2" type="uint" />
         <add name="Num Data" type="uint" />
-        <add name="Unk 1" type="byte" arr1="Num Data" arr2="8" />
-        <add name="Data" type="BSPackedGeomData" arr1="Num Data" />
+        <add name="Object" type="BSPackedGeomObject" arr1="Num Data" />
+        <add name="Object Data" type="BSPackedGeomData" arr1="Num Data" />
     </niobject>
     
     <!-- Fallout 4 Animation -->

--- a/nif.xml
+++ b/nif.xml
@@ -6297,6 +6297,25 @@
     
     <!-- Fallout 4 Geometry -->
     
+    <bitflags name="VertexFlags" storage="ushort">
+        <option value="0" name="VF_Unknown_1" />       <!-- & 1 -->
+        <option value="1" name="VF_Unknown_2" />       <!-- & 2 -->
+        <option value="2" name="VF_Unknown_3" />       <!-- & 4 -->
+        <option value="3" name="VF_Unknown_4" />       <!-- & 8 -->
+        <option value="4" name="VF_Vertex" />          <!-- & 16 -->
+        <option value="5" name="VF_UVs" />             <!-- & 32 -->
+        <option value="6" name="VF_Unknown_5" />       <!-- & 64 -->
+        <option value="7" name="VF_Normals" />         <!-- & 128 -->
+        <option value="8" name="VF_Tangents" />        <!-- & 256 -->
+        <option value="9" name="VF_Vertex_Colors" />   <!-- & 512 -->
+        <option value="10" name="VF_Skinned" />        <!-- & 1024 -->
+        <option value="11" name="VF_Unknown_6" />      <!-- & 2048 -->
+        <option value="12" name="VF_Male_Eyes" />      <!-- & 4096 -->
+        <option value="13" name="VF_Unknown_7" />      <!-- & 8192 -->
+        <option value="14" name="VF_Full_Precision" /> <!-- & 16384 -->
+        <option value="15" name="VF_Unknown_8" />      <!-- & 32768 -->
+    </bitflags>
+    
     <compound name="BSVertexDataRigid">
         Rigid Vertex Data compound
         <add name="Vertex" type="HalfVector3" />
@@ -6306,7 +6325,7 @@
         <add name="Bitangent Y" type="byte" />
         <add name="Tangent" type="ByteVector3" />
         <add name="Bitangent Z" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
     </compound>
     
     <compound name="BSVertexDataSkinned">
@@ -6318,26 +6337,28 @@
         <add name="Bitangent Y" type="byte" />
         <add name="Tangent" type="ByteVector3" />
         <add name="Bitangent Z" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
         <add name="Bone Weights" type="hfloat" arr1="4" />
         <add name="Bone Indices" type="byte" arr1="4" />
-        <add name="Unknown Int 2" type="uint" cond="(ARG &amp; 16) != 0" />
     </compound>
     
     <compound name="BSVertexData">
         Catch all Vertex Data compound, SLOW
-        <add name="Vertex" type="HalfVector3" />
-        <add name="Bitangent X" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG &gt; 4))" />
-        <add name="Unknown Short 1" type="ushort" cond="((ARG == 6) || (ARG &lt; 5))" />
-        <add name="UV" type="HalfTexCoord" cond="(ARG &gt; 2) &amp;&amp; (ARG != 4)" />
-        <add name="Normal" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
-        <add name="Bitangent Y" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
-        <add name="Tangent" type="ByteVector3" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
-        <add name="Bitangent Z" type="byte" cond="((ARG &gt; 3) &amp;&amp; (ARG != 7))" />
-        <add name="Vertex Colors" type="ByteColor4" cond="((ARG == 6) || (ARG == 7) || (ARG == 9) || (ARG == 10))" />
-        <add name="Bone Weights" type="hfloat" cond="ARG &gt; 6" arr1="4" />
-        <add name="Bone Indices" type="byte" cond="ARG &gt; 6" arr1="4" />
-        <add name="Unknown Int 2" type="uint" cond="ARG == 10" />
+        <add name="Vertex" type="HalfVector3" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
+        <add name="Bitangent X" type="hfloat" cond="((ARG &amp; 256) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
+        <add name="Unknown Short" type="ushort" cond="((ARG &amp; 256) == 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
+        <add name="Vertex" type="Vector3" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 16384) != 0)" />
+        <add name="Bitangent X" type="float" cond="((ARG &amp; 256) != 0) &amp;&amp; ((ARG &amp; 16384) != 0)" />
+        <add name="Unknown Int" type="uint" cond="((ARG &amp; 256) == 0) &amp;&amp; ((ARG &amp; 16384) != 0)" />
+        <add name="UV" type="HalfTexCoord" cond="(ARG &amp; 32) != 0" />
+        <add name="Normal" type="ByteVector3" cond="(ARG &amp; 128) != 0" />
+        <add name="Bitangent Y" type="byte" cond="(ARG &amp; 128) != 0" />
+        <add name="Tangent" type="ByteVector3" cond="((ARG &amp; 128) != 0) &amp;&amp; ((ARG &amp; 256) != 0)" />
+        <add name="Bitangent Z" type="byte" cond="((ARG &amp; 128) != 0) &amp;&amp; ((ARG &amp; 256) != 0)" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
+        <add name="Bone Weights" type="hfloat" arr1="4" cond="(ARG &amp; 1024) != 0" />
+        <add name="Bone Indices" type="byte" arr1="4" cond="(ARG &amp; 1024) != 0" />
+        <add name="Unknown Int 2" type="uint" cond="(ARG &amp; 4096) != 0" />
     </compound>
     
     <compound name="BSVertexDataFloat">
@@ -6349,28 +6370,9 @@
         <add name="Bitangent Y" type="byte" />
         <add name="Tangent" type="ByteVector3" />
         <add name="Bitangent Z" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
-        <add name="Bone Weights" type="hfloat" cond="(ARG &amp; 4) != 0" arr1="4" />
-        <add name="Bone Indices" type="byte" cond="(ARG &amp; 4) != 0" arr1="4" />
-    </compound>
-    
-    <compound name="BSVertexDataNoTangents">
-        TODO: Temporary
-        <add name="Vertex" type="HalfVector3" />
-        <add name="Unknown Short 1" type="ushort" />
-        <add name="Normal" type="ByteVector3" />
-        <add name="Unknown Byte 1" type="byte" />
-        <add name="Vertex Colors" type="ByteColor4" cond="ARG == 4" />
-    </compound>
-    
-    <compound name="BSVertexDataNoNormals">
-        TODO: Temporary
-        <add name="Vertex" type="HalfVector3" />
-        <add name="Unknown Short 1" type="ushort" />
-        <add name="UV" type="HalfTexCoord" />
-        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
-        <add name="Bone Weights" type="hfloat" cond="(ARG &amp; 4) != 0" arr1="4" />
-        <add name="Bone Indices" type="byte" cond="(ARG &amp; 4) != 0" arr1="4" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 512) != 0" />
+        <add name="Bone Weights" type="hfloat" cond="(ARG &amp; 1024) != 0" arr1="4" />
+        <add name="Bone Indices" type="byte" cond="(ARG &amp; 1024) != 0" arr1="4" />
     </compound>
 
     <niobject name="BSTriShape" abstract="0" inherit="NiAVObject">
@@ -6378,37 +6380,30 @@
         <add name="Bounding Sphere" type="SphereBV" />
         <add name="Skin" type="Ref" template="NiObject" />
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" />
-        <add name="VF1" type="byte" />
-        <add name="VF2" type="byte" />
+        <add name="Vertex Size" type="byte" />
+        <add name="Float Size" type="byte" />
         <add name="VF3" type="byte" />
         <add name="VF4" type="byte" />
         <add name="VF5" type="byte" />
-        <add name="VF6" type="byte" />
-        <add name="VF7" type="byte" />
+        <add name="VF" type="VertexFlags" />
         <add name="VF8" type="byte" />
         <add name="Num Triangles" type="uint" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-		<!-- Below are several compounds to bypass the inability to check multiple flags via multiple ARG passing -->
-		<!-- NifSkope performance is also **extremely** poor with ARG passing and so optimized compounds for the majority of cases were created -->
-		<!-- Rigid (Optimized) -->
-        <add name="Vertex Data" type="BSVertexDataRigid" arr1="Num Vertices" arg="VF7" 
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; ((VF7 &amp; 1) != 0) &amp;&amp; ((VF7 &amp; 4) == 0) &amp;&amp; (VF6 == 176)" />
-		<!-- Skinned (Optimized) -->
-        <add name="Vertex Data" type="BSVertexDataSkinned" arr1="Num Vertices" arg="VF7" 
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; ((VF7 &amp; 1) != 0) &amp;&amp; ((VF7 &amp; 4) != 0) &amp;&amp; (VF6 == 176)" />
-		<!-- Catch All (SLOW) -->
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF1"
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; ((VF7 &amp; 1) == 0) &amp;&amp; ((VF6 == 176) || (VF6 == 16))" />
-		<!-- Float Replacement (SCOL folder) -->
-        <add name="Vertex Data" type="BSVertexDataFloat" arr1="Num Vertices" arg="VF7"
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) != 0) &amp;&amp; (VF6 == 176)" />
-		<!-- Edge Case #1 (VF6 == 48) -->
-        <add name="Vertex Data" type="BSVertexDataNoNormals" arr1="Num Vertices" arg="VF7"
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; (VF6 == 48)" />
-		<!-- Edge Case #2 (VF6 == 144) -->
-        <add name="Vertex Data" type="BSVertexDataNoTangents" arr1="Num Vertices" arg="VF1"
-            cond="(Data Size &gt; 0) &amp;&amp; ((VF7 &amp; 64) == 0) &amp;&amp; (VF6 == 144)" />
+        <!-- NifSkope performance is **extremely** poor with ARG passing and so optimized compounds for the majority of cases were created -->
+        <!-- Rigid (Optimized) -->
+        <add name="Vertex Data" type="BSVertexDataRigid" arr1="Num Vertices" arg="VF" 
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF == 432) || (VF == 944))" />
+        <!-- Skinned (Optimized) -->
+        <add name="Vertex Data" type="BSVertexDataSkinned" arr1="Num Vertices" arg="VF" 
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF == 1456) || (VF == 1968))" />
+        <!-- Catch All (SLOW) -->
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF"
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF &amp; 16384) == 0) &amp;&amp; ((VF != 432) &amp;&amp; (VF != 944) &amp;&amp; (VF != 1456) &amp;&amp; (VF != 1968))" />
+        <!-- Float Replacement (SCOL folder) -->
+        <add name="Vertex Data" type="BSVertexDataFloat" arr1="Num Vertices" arg="VF"
+            cond="(Data Size &gt; 0) &amp;&amp; ((VF &amp; 16384) != 0)" />
+
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -1279,7 +1279,8 @@
         <add name="Unknown Int 3" type="uint" default="0" ver1="30.0.0.2">Unknown. Possibly User Version 2?</add>
         <add name="Export Info" type="ExportInfo" ver1="10.0.1.2" ver2="10.0.1.2" />
         <add name="Export Info" type="ExportInfo" ver1="10.1.0.0" cond="(User Version &gt;= 10) || ((User Version == 1) &amp;&amp; (Version != 10.2.0.0))" />
-        <add name="Export Info 3" type="ShortString" cond="(Version == 20.2.0.7) &amp;amp; (User Version 2 == 130)" />
+        <!-- Absolutely must use ver/userver2 as NifSkope will not process cond on this line causing all earlier NIFs to fail -->
+        <add name="Export Info 3" type="ShortString" ver="20.2.0.7" userver2="130" />
         <add name="Num Block Types" type="ushort" ver1="10.0.1.0">Number of object types in this NIF file.</add>
         <add name="Block Types" type="SizedString" arr1="Num Block Types" ver1="10.0.1.0">List of all object types used in this NIF file.</add>
         <add name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" ver1="10.0.1.0">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -6287,7 +6287,34 @@
     
     <!-- Fallout 4 Geometry -->
     
+    <compound name="BSVertexDataRigid">
+        Rigid Vertex Data compound
+        <add name="Vertex" type="HalfVector3" />
+        <add name="Unknown Dot" type="hfloat" />
+        <add name="UV" type="HalfTexCoord" />
+        <add name="Normal" type="ByteVector3" />
+        <add name="Unknown Byte 1" type="byte" />
+        <add name="Tangent" type="ByteVector3" />
+        <add name="Unknown Byte 2" type="byte" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
+    </compound>
+    
+    <compound name="BSVertexDataSkinned">
+        Skinned Vertex Data compound
+        <add name="Vertex" type="HalfVector3" />
+        <add name="Unknown Dot" type="hfloat" />
+        <add name="UV" type="HalfTexCoord" />
+        <add name="Normal" type="ByteVector3" />
+        <add name="Unknown Byte 1" type="byte" />
+        <add name="Tangent" type="ByteVector3" />
+        <add name="Unknown Byte 2" type="byte" />
+        <add name="Vertex Colors" type="ByteColor4" cond="(ARG &amp; 2) != 0" />
+        <add name="Bone Weights" type="hfloat" arr1="4" />
+        <add name="Bone Indices" type="byte" arr1="4" />
+    </compound>
+    
     <compound name="BSVertexData">
+        Catch all Vertex Data compound, SLOW
         <add name="Vertex" type="HalfVector3" />
         <add name="Unknown Dot" type="hfloat" cond="((ARG != 6) &amp;&amp; (ARG != 3))" />
         <add name="Unknown Short 1" type="ushort" cond="((ARG == 6) || (ARG == 3))" />
@@ -6319,7 +6346,12 @@
         <add name="Num Triangles" type="uint" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Flag 1" cond="Data Size &gt; 0" />
+        <add name="Vertex Data" type="BSVertexDataRigid" arr1="Num Vertices" arg="Vertex Flag 7" 
+            cond="(Data Size &gt; 0) &amp;&amp; ((Vertex Flag 7 &amp; 1) != 0) &amp;&amp; ((Vertex Flag 7 &amp; 4) == 0)" />
+        <add name="Vertex Data" type="BSVertexDataSkinned" arr1="Num Vertices" arg="Vertex Flag 7" 
+            cond="(Data Size &gt; 0) &amp;&amp; ((Vertex Flag 7 &amp; 1) != 0) &amp;&amp; ((Vertex Flag 7 &amp; 4) != 0) &amp;&amp; (Vertex Flag 5 == 0)" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Flag 1"
+            cond="(Data Size &gt; 0) &amp;&amp; (((Vertex Flag 7 &amp; 1) == 0) || Vertex Flag 5 &gt; 0)" />
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -6404,31 +6404,40 @@
     
     <!-- Fallout 4 Physics -->
 
-    <niobject name="bhkNPCollisionObject" inherit="bhkCollisionObject">
+    <niobject name="bhkSystem" abstract="1" inherit="NiObject">
+        Fallout 4 Physics System
+    </niobject>
+    
+    <niobject name="bhkNPCollisionObject" inherit="NiCollisionObject">
         Fallout 4 Collision Object
-        <add name="Unknown Int 2" type="uint">Unknown.</add>
+        <add name="Flags" type="ushort">
+            Due to inaccurate reporting in the CK the Reset and Sync On Update positions are a guess.
+            Bits: 0=Reset, 2=Notify, 3=SetLocal, 7=SyncOnUpdate, 10=AnimTargeted
+        </add>
+        <add name="Data" type="Ref" template="bhkSystem" />
+        <add name="Body ID" type="uint" />
+    </niobject>
+    
+    <niobject name="bhkPhysicsSystem" inherit="bhkSystem">
+        Fallout 4 Collision System
+        <add name="Size" type="uint" />
+        <add name="Data" type="byte" nifskopetype="blob" arr1="Size" />
+    </niobject>
+
+    <niobject name="bhkRagdollSystem" inherit="bhkSystem">
+        Fallout 4 Ragdoll System
+        <add name="Size" type="uint" />
+        <add name="Data" type="byte" nifskopetype="blob" arr1="Size" />
     </niobject>
 
     <niobject name="BSExtraData" inherit="NiExtraData">
         Fallout 4 Extra Data
     </niobject>
-    
-    <niobject name="bhkPhysicsSystem" inherit="BSExtraData">
-        Fallout 4 Collision System
-        <add name="Num Bytes" type="uint" />
-        <add name="Data" type="byte" nifskopetype="blob" arr1="Num Bytes" />
-    </niobject>
-
-    <niobject name="bhkRagdollSystem" inherit="BSExtraData">
-        Fallout 4 Ragdoll System
-        <add name="Num Bytes" type="uint" />
-        <add name="Data" type="byte" nifskopetype="blob" arr1="Num Bytes" />
-    </niobject>
 
     <niobject name="BSClothExtraData" inherit="BSExtraData">
         Fallout 4 Cloth data
-        <add name="Num Bytes" type="uint" />
-        <add name="Data" type="byte" nifskopetype="blob" arr1="Num Bytes" />
+        <add name="Size" type="uint" />
+        <add name="Data" type="byte" nifskopetype="blob" arr1="Size" />
     </niobject>
     
     <!-- Fallout 4 Skeleton -->
@@ -6443,7 +6452,7 @@
 
     <niobject name="BSSkin::Instance" inherit="NiObject">
         Fallout 4 Skin Instance
-        <add name="Target" type="Ptr" template="NiAVObject" />
+        <add name="Root Parent" type="Ptr" template="NiAVObject" />
         <add name="Bone Data" type="Ref" template="BSSkin::BoneData" />
         <add name="Num Bones" type="uint" />
         <add name="Bones" type="Ptr" arr1="Num Bones" />
@@ -6464,8 +6473,8 @@
     </niobject>
 
     <compound name="BSConnectPoint">
-        <add name="Root" type="SizedString" />
-        <add name="Variable Name" type="SizedString" />
+        <add name="Parent" type="SizedString" />
+        <add name="Name" type="SizedString" />
         <add name="Rotation" type="Quaternion" />
         <add name="Translation" type="Vector3" />
         <add name="Scale" type="float" />
@@ -6479,9 +6488,9 @@
 
     <niobject name="BSConnectPoint::Children" inherit="NiExtraData">
         Fallout 4 Item Slot Child
-        <add name="Unknown Byte" type="byte" />
-        <add name="Num Targets" type="int" />
-        <add name="Target" type="SizedString" arr1="Num Targets" />
+        <add name="Skinned" type="bool" />
+        <add name="Num Points" type="int" />
+        <add name="Name" type="SizedString" arr1="Num Points" />
     </niobject>
     
     <niobject name="BSEyeCenterExtraData" inherit="NiExtraData">


### PR DESCRIPTION
New basic and compound types such as hfloat, ByteVector3, HalfVector3, new trishapes, new NiExtraData/BSExtraData.  Changes to existing blocks were minimal.  Most changed were BSLightingShaderProperty and BSEffectShaderProperty.

Currently parses 100% of FO4 NIFs. 

### New NiObjects

NiAVObject:

    BSTriShape
    BSMeshLODTriShape
    BSSubIndexTriShape

bhkCollisionObject:

    bhkNPCollisionObject

NiFloatInterpController:

    NiLightRadiusController

NiExtraData:

    BSPositionData
    BSConnectPoint::Parents
    BSConnectPoint::Children
    BSEyeCenterExtraData
    BSPackedCombinedSharedGeomDataExtra
    BSExtraData

BSExtraData was made in order to exclude it and its ancestors during a condition check for NiExtraData Name <add>

BSExtraData:

    bhkPhysicsSystem
    bhkRagdollSystem
    BSClothExtraData



