### PR TITLE
Num UV Sets fix

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -981,11 +981,6 @@
         <option value="1" name="Emissive Color">Emissive Color.</option>
     </enum>
 
-    <enum name="ExtraVectorsFlags" storage="byte">
-        <option value="0" name="None">No Tangents and Bitangents Vectors.</option>
-        <option value="16" name="Tangents_Bitangents">Has Tangents and Bitangents Vectors.</option>
-    </enum>
-
     <enum name="hkConstraintType" storage="uint">
         The type of constraint.
         <option value="0" name="BallAndSocket">A ball and socket constraint.</option>

--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.8.3.0">
+<niftoolsxml version="0.8.4.0">
     <!--These are the version numbers marked as supported by NifSkope.
         The num argument is the numeric representation created by storing
         each part of the version in a byte.  For example, 4.0.0.2 is

--- a/nif.xml
+++ b/nif.xml
@@ -2851,6 +2851,44 @@
         Describes a mesh, built from triangles.
     </niobject>
 
+    <bitflags name="VectorFlags" storage="ushort">
+        <option value="0" name="UV_1" />
+        <option value="1" name="UV_2" />
+        <option value="2" name="UV_4" />
+        <option value="3" name="UV_8" />
+        <option value="4" name="UV_16" />
+        <option value="5" name="UV_32" />
+        <option value="6" name="Unk64" />
+        <option value="7" name="Unk128" />
+        <option value="8" name="Unk256" />
+        <option value="9" name="Unk512" />
+        <option value="10" name="Unk1024" />
+        <option value="11" name="Unk2048" />
+        <option value="12" name="Has_Tangents" />
+        <option value="13" name="Unk8192" />
+        <option value="14" name="Unk16384" />
+        <option value="15" name="Unk32768" />
+    </bitflags>
+    
+    <bitflags name="BSVectorFlags" storage="ushort">
+        <option value="0" name="Has_UV" />
+        <option value="1" name="Unk2" />
+        <option value="2" name="Unk4" />
+        <option value="3" name="Unk8" />
+        <option value="4" name="Unk16" />
+        <option value="5" name="Unk32" />
+        <option value="6" name="Unk64" />
+        <option value="7" name="Unk128" />
+        <option value="8" name="Unk256" />
+        <option value="9" name="Unk512" />
+        <option value="10" name="Unk1024" />
+        <option value="11" name="Unk2048" />
+        <option value="12" name="Has_Tangents" />
+        <option value="13" name="Unk8192" />
+        <option value="14" name="Unk16384" />
+        <option value="15" name="Unk32768" />
+    </bitflags>
+
     <niobject name="NiGeometryData" abstract="1" inherit="NiObject">
         Mesh data: vertices, vertex normals, etc.
         <add name="Unknown Int" type="int" ver1="10.2.0.0">Unknown identifier. Always 0.</add>
@@ -2862,15 +2900,13 @@
         <add name="Compress Flags" type="byte" ver1="10.1.0.0">Unknown.</add>
         <add name="Has Vertices" type="bool" default="1">Is the vertex array present? (Always non-zero.)</add>
         <add name="Vertices" type="Vector3" arr1="Num Vertices" cond="Has Vertices">The mesh vertices.</add>
-        <add name="Num UV Sets" type="byte" vercond="Version >= 10.0.1.0" calculated="1">Number of UV texture sets.
-
-        	Fallout3/Skyrim: can't be higher than 1.</add>
-        <add name="Extra Vectors Flags" type="ExtraVectorsFlags" vercond="Version >= 10.0.1.0">Bit 4: Has Tangents/Bitangents</add>
+        <add name="Vector Flags" type="VectorFlags" vercond="((Version &gt;= 10.0.1.0) &amp;&amp; (Version != 20.2.0.7))" />
+        <add name="BS Vector Flags" type="BSVectorFlags" vercond="(Version == 20.2.0.7)" />
         <add name="Unknown Int 2" type="uint" ver1="20.2.0.7" userver="12" cond="!NiPSysData">Unknown, seen in Skyrim.</add>
         <add name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</add>
         <add name="Normals" type="Vector3" arr1="Num Vertices" cond="Has Normals">The lighting normals.</add>
-        <add name="Tangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) &amp;&amp; (Extra Vectors Flags &amp; 16)" ver1="10.1.0.0">Tangent vectors.</add>
-        <add name="Bitangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) &amp;&amp; (Extra Vectors Flags &amp; 16)" ver1="10.1.0.0">Bitangent vectors.</add>
+        <add name="Tangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) &amp;&amp; ((Vector Flags | BS Vector Flags) &amp; 4096)" ver1="10.1.0.0">Tangent vectors.</add>
+        <add name="Bitangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) &amp;&amp; ((Vector Flags | BS Vector Flags) &amp; 4096)" ver1="10.1.0.0">Bitangent vectors.</add>
         <add name="Center" type="Vector3">Center of the bounding box (smallest box that contains all vertices) of the mesh.</add>
         <add name="Radius" type="float">Radius of the mesh: maximal Euclidean distance between the center and all vertices.</add>
         <add name="Unknown 13 shorts" type="short" arr1="13" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Unknown, always 0?</add>
@@ -2888,7 +2924,7 @@
 
             Note: for compatibility with NifTexture, set this value to either 0x00000000 or 0xFFFFFFFF.
         </add>
-        <add name="UV Sets" type="TexCoord" arr1="(Num UV Sets &amp; 63)" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</add>
+        <add name="UV Sets" type="TexCoord" arr1="((Num UV Sets &amp; 63) | (Vector Flags &amp; 63) | (BS Vector Flags &amp; 1))" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</add>
         <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE" vercond="User Version &lt; 12">Consistency Flags</add>
         <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE" vercond="User Version >= 12" cond="!NiPSysData">Consistency Flags</add>
         <add name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" ver1="20.0.0.4" vercond="User Version &lt; 12">Unknown.</add>


### PR DESCRIPTION
This is a redo of #51 since I did not seem to have permission to rebase the PR.   These changes work for all games and fix all FO3 UV Sets regressions.

The only downside is for UV Sets > 1 in non-Bethesda games the UV Sets count now becomes a combination of flags.  UV_1 + UV_2 = 3 UV Sets,  and UV_1 + UV_4 = 5 UV Sets and so on.

This was the only way to treat the field as a single ushort which is necessary for endianness changes when reading the field 16 bytes at once because the value is read/written 16 bytes at once and uses bitmasking to retrieve the UV count.

Closes #51 