### PR TITLE
nifxml 0.9

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -2003,13 +2003,17 @@
     </compound>
 
     <compound name="PrismaticDescriptor">
-        <!-- Oblivion -->
-        <add name="Pivot A" type="Vector4" ver2="20.0.0.5">Pivot A.</add>
-        <add name="Rotation Matrix A" type="Vector4" arr1="4" ver2="20.0.0.5">4x4 rotation matrix, rotates the child entity.</add>
-        <add name="Pivot B" type="Vector4" ver2="20.0.0.5">Pivot B.</add>
-        <add name="Sliding B" type="Vector4" ver2="20.0.0.5">Describes the axis the object is able to travel along. Unit vector.</add>
-        <add name="Plane B" type="Vector4" ver2="20.0.0.5">Plane normal. Describes the plane the object is able to move on.</add>
-
+        <!-- In reality Havok loads these as Transform A and Transform B using hkTransform -->
+        <!-- Oblivion (Order is a guess) -->
+        <add name="Pivot A" type="Vector4" ver2="20.0.0.5">Pivot.</add>
+        <add name="Rotation A" type="Vector4" ver2="20.0.0.5">Rotation axis.</add>
+        <add name="Plane A" type="Vector4" ver2="20.0.0.5">Plane normal. Describes the plane the object is able to move on.</add>
+        <add name="Sliding A" type="Vector4" ver2="20.0.0.5">Describes the axis the object is able to travel along. Unit vector.</add>
+        <add name="Pivot B" type="Vector4" ver2="20.0.0.5">Pivot in B coordinates.</add>
+        <add name="Rotation B" type="Vector4" ver2="20.0.0.5">Rotation axis.</add>
+        <add name="Plane B" type="Vector4" ver2="20.0.0.5">Plane normal. Describes the plane the object is able to move on in B coordinates.</add>
+        <add name="Sliding B" type="Vector4" ver2="20.0.0.5">Describes the axis the object is able to travel along in B coordinates. Unit vector.</add>
+        
         <!-- Fallout 3 -->
         <add name="Sliding A" type="Vector4" ver1="20.2.0.7">Describes the axis the object is able to travel along. Unit vector.</add>
         <add name="Rotation A" type="Vector4" ver1="20.2.0.7">Rotation axis.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -6398,6 +6398,7 @@
     </niobject>
 
     <compound name="LODInfo">
+        <add name="Num Bones" type="uint" />
         <add name="Num Active Skins" type="uint" />
         <add name="Skin Indices" type="uint" arr1="Num Active Skins" />
     </compound>

--- a/nif.xml
+++ b/nif.xml
@@ -1214,6 +1214,22 @@
         <add name="m33" type="float" default="1.0">Member 3,3 (bottom left)</add>
     </compound>
 
+    <compound name="Matrix34" niflibtype="Matrix34">
+        A 4x4 transformation matrix.
+        <add name="m11" type="float" default="1.0">The (1,1) element.</add>
+        <add name="m21" type="float" default="0.0">The (2,1) element.</add>
+        <add name="m31" type="float" default="0.0">The (3,1) element.</add>
+        <add name="m12" type="float" default="0.0">The (1,2) element.</add>
+        <add name="m22" type="float" default="1.0">The (2,2) element.</add>
+        <add name="m32" type="float" default="0.0">The (3,2) element.</add>
+        <add name="m13" type="float" default="0.0">The (1,3) element.</add>
+        <add name="m23" type="float" default="0.0">The (2,3) element.</add>
+        <add name="m33" type="float" default="1.0">The (3,3) element.</add>
+        <add name="m14" type="float" default="0.0">The (1,4) element.</add>
+        <add name="m24" type="float" default="0.0">The (2,4) element.</add>
+        <add name="m34" type="float" default="0.0">The (3,4) element.</add>
+    </compound>
+
     <compound name="Matrix44" niflibtype="Matrix44">
         A 4x4 transformation matrix.
         <add name="m11" type="float" default="1.0">The (1,1) element.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -3067,14 +3067,19 @@
         A simple LOD controller for bones.
     </niobject>
     
-    <compound name="GeomMaterialData">
+    <compound name="MaterialData">
         <add name="Has Shader" type="bool" ver1="10.0.1.0" ver2="20.1.0.3">Shader.</add>
         <add name="Shader Name" type="string" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">The shader name.</add>
-        <add name="Unknown Integer" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Unknown value, usually -1. (Not a link)</add>
-        <add name="Num Materials" type="uint" ver1="20.2.0.7">Num Materials</add>
-        <add name="Material Name" type="string" arr1="Num Materials" ver1="20.2.0.7">Unknown string.  Shader?</add>
-        <add name="Material Extra Data" type="int" arr1="Num Materials" ver1="20.2.0.7">Unknown integer; often -1. (Is this a link, array index?)</add>
-        <add name="Active Material" type="int" ver1="20.2.0.7" default="0">Active Material; often -1. (Is this a link, array index?)</add>
+        <add name="Shader Extra Data" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Extra data associated with the shader. A value of -1 means the shader is the default implementation.</add>
+        <add name="Num Materials" type="uint" ver1="20.2.0.5" />
+        <add name="Material Name" type="string" arr1="Num Materials" ver1="20.2.0.5">The name of the material.</add>
+        <add name="Material Extra Data" type="int" arr1="Num Materials" ver1="20.2.0.5">Extra data associated with the material. A value of -1 means the material is the default implementation.</add>
+        <add name="Active Material" type="int" default="-1" ver1="20.2.0.5">The index of the currently active material.</add>
+        <!-- Custom Versions -->
+        <add name="Unknown Byte" type="byte" default="255" ver1="10.2.0.0" ver2="10.2.0.0" userver="1">Cyanide extension (only in version 10.2.0.0?).</add>
+        <add name="Unknown Integer 2" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown.</add>
+        <!-- / Custom -->
+        <add name="Material Needs Update" type="bool" ver1="20.2.0.7">Whether the materials for this object always needs to be updated before rendering with them.</add>
     </compound>
 
     <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
@@ -3091,14 +3096,8 @@
         <add name="Data" type="Ref" template="NiGeometryData" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
         <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="3.3.0.13" vercond="(User Version 2 &lt; 100)" />
         <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
-        <add name="Material Data" type="GeomMaterialData" ver1="10.0.1.0" vercond="(User Version 2 &lt; 100)" />
-        <add name="Material Data" type="GeomMaterialData" ver1="10.0.1.0" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
-        <!-- Custom Versions -->
-        <add name="Unknown Byte" type="byte" default="255" userver="1">Cyanide extension (only in version 10.2.0.0?).</add>
-        <add name="Unknown Integer 2" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown.</add>
-        <!-- / Custom -->
-        <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &lt; 100)" />
-        <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
+        <add name="Material Data" type="MaterialData" ver1="10.0.1.0" vercond="(User Version 2 &lt; 100)" />
+        <add name="Material Data" type="MaterialData" ver1="10.0.1.0" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
         <!-- Bethesda -->
         <add name="Shader Property" type="Ref" template="BSShaderProperty" ver1="20.2.0.7" userver="12" />
         <add name="Alpha Property" type="Ref" template="NiAlphaProperty" ver1="20.2.0.7" userver="12" />
@@ -6213,7 +6212,7 @@
         </add>
     </compound>
 
-    <compound name="MeshData">
+    <compound name="DataStreamRef">
         <add name="Stream" type="Ref" template="NiDataStream">
             Reference to a data stream object which holds the data used by
             this reference.
@@ -6230,31 +6229,23 @@
             <!-- see Zorsis Zombie_Boy.nif -->
             A lookup table that maps submeshes to regions.
         </add>
-        <add name="Num Components" type="int" default="1" />
+        <add name="Num Components" type="uint" default="1" />
         <add name="Component Semantics" type="SemanticData" arr1="Num Components">Describes the semantic of each component.</add>
     </compound>
 
-    <compound name="MaterialData" ver1="20.5.0.0">
-        Data stored per-material by NiRenderObject
-        <add name="Material Name" type="string">The name of the material.</add>
-        <add name="Material Extra Data" type="uint">Extra data associated with the material?</add>
-    </compound>
-
-    <niobject name="NiRenderObject" inherit="NiAVObject">
+    <niobject name="NiRenderObject" abstract="1" inherit="NiAVObject">
         An object that can be rendered.
-        <add name="Num Materials" type="uint" />
-        <add name="Material Data" type="MaterialData" arr1="Num Materials">Per-material data.</add>
-        <add name="Active Material" type="int" default="-1">The index of the currently active material.</add>
-        <add name="Material Needs Update Default" type="bool">Whether the materials for this render object always needs to be updated before rendering with them.</add>
+        <add name="Material Data" type="MaterialData">Per-material data.</add>
     </niobject>
 
     <enum name="MeshPrimitiveType" storage="uint">
         Describes the type of primitives stored in a mesh object.
         <option value="0" name="MESH_PRIMITIVE_TRIANGLES">Triangle primitive type.</option>
         <option value="1" name="MESH_PRIMITIVE_TRISTRIPS">Triangle strip primitive type.</option>
-        <option value="2" name="MESH_PRIMITIVE_LINESTRIPS">Line strip primitive type.</option>
-        <option value="3" name="MESH_PRIMITIVE_QUADS">Quadrilateral primitive type.</option>
-        <option value="4" name="MESH_PRIMITIVE_POINTS">Point primitive type.</option>
+        <option value="2" name="MESH_PRIMITIVE_LINES">Lines primitive type.</option>
+        <option value="3" name="MESH_PRIMITIVE_LINESTRIPS">Line strip primitive type.</option>
+        <option value="4" name="MESH_PRIMITIVE_QUADS">Quadrilateral primitive type.</option>
+        <option value="5" name="MESH_PRIMITIVE_POINTS">Point primitive type.</option>
     </enum>
 
     <enum name="SyncPoint" storage="ushort">
@@ -6307,8 +6298,8 @@
         <add name="Num Submeshes" type="ushort">The number of submeshes contained in this mesh.</add>
         <add name="Instancing Enabled" type="bool">Sets whether hardware instancing is being used.</add>
         <add name="Bound" type="NiBound">The combined bounding volume of all submeshes.</add>
-        <add name="Num Datas" type="uint" />
-        <add name="Datas" type="MeshData" arr1="Num Datas" />
+        <add name="Num Datastreams" type="uint" />
+        <add name="Datastreams" type="DataStreamRef" arr1="Num Datastreams" />
         <add name="Num Modifiers" type="uint" />
         <add name="Modifiers" type="Ref" template="NiMeshModifier" arr1="Num Modifiers" />
 
@@ -6332,6 +6323,7 @@
     </niobject>
 
     <niobject name="NiMorphWeightsController" inherit="NiInterpController">
+        Manipulates a mesh with the semantic MORPHWEIGHTS using an NiMorphMeshModifier.
         <add name="Count" type="uint" />
         <add name="Num Interpolators" type="uint" />
         <add name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" />

--- a/nif.xml
+++ b/nif.xml
@@ -1900,31 +1900,23 @@
 
     <compound name="RagdollDescriptor">
         This constraint defines a cone in which an object can rotate. The shape of the cone can be controlled in two (orthogonal) directions.
-        <!-- Oblivion -->
-        <add name="Pivot A" type="Vector4" ver2="20.0.0.5">The point where the constraint is attached to its parent rigidbody.</add>
-        <add name="Plane A" type="Vector4" ver2="20.0.0.5">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
-        <add name="Twist A" type="Vector4" ver2="20.0.0.5">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane A.</add>
-        <add name="Pivot B" type="Vector4" ver2="20.0.0.5">The point where the constraint is attached to the other rigidbody.</add>
-        <add name="Plane B" type="Vector4" ver2="20.0.0.5">Defines the orthogonal plane in which the shape can be controlled (the direction orthogonal on this one and Twist B).</add>
-        <add name="Twist B" type="Vector4" ver2="20.0.0.5">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane B.</add>
+        <!-- Oblivion and Fallout 3, Havok 550 -->
+        <add name="Pivot A" type="Vector4" vercond="User Version 2 &lt;= 16">The point where the constraint is attached to its parent rigidbody.</add>
+        <add name="Plane A" type="Vector4" vercond="User Version 2 &lt;= 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
+        <add name="Twist A" type="Vector4" vercond="User Version 2 &lt;= 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane A.</add>
+        <add name="Pivot B" type="Vector4" vercond="User Version 2 &lt;= 16">The point where the constraint is attached to the other rigidbody.</add>
+        <add name="Plane B" type="Vector4" vercond="User Version 2 &lt;= 16">Defines the orthogonal plane in which the shape can be controlled (the direction orthogonal on this one and Twist B).</add>
+        <add name="Twist B" type="Vector4" vercond="User Version 2 &lt;= 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane B.</add>
 
-        <!-- Fallout 3 -->
-        <add name="Twist A" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane A.</add>
-        <add name="Plane A" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
-        <add name="Motor A" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
-        <add name="Pivot A" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Point around which the object will rotate. Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
-        <add name="Twist B" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane B.</add>
-        <add name="Plane B" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
-        <add name="Motor B" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
-        <add name="Pivot B" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
-
-        <!-- Fallout 3, file meshes\ragdollconstraint\stiff.rdt with User Version 2 = 16 -->
-        <add name="Pivot A?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Point around which the object will rotate. Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
-        <add name="Plane A?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
-        <add name="Twist A?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane A.</add>
-        <add name="Pivot B?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
-        <add name="Plane B?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
-        <add name="Twist B?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane B.</add>
+        <!-- Fallout 3 and later, Havok 660 and 2010 -->
+        <add name="Twist A" type="Vector4" vercond="User Version 2 &gt; 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane A.</add>
+        <add name="Plane A" type="Vector4" vercond="User Version 2 &gt; 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
+        <add name="Motor A" type="Vector4" vercond="User Version 2 &gt; 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
+        <add name="Pivot A" type="Vector4" vercond="User Version 2 &gt; 16">Point around which the object will rotate. Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
+        <add name="Twist B" type="Vector4" vercond="User Version 2 &gt; 16">Central directed axis of the cone in which the object can rotate. Orthogonal on Plane B.</add>
+        <add name="Plane B" type="Vector4" vercond="User Version 2 &gt; 16">Defines the orthogonal plane in which the body can move, the orthogonal directions in which the shape can be controlled (the direction orthogonal on this one and Twist A).</add>
+        <add name="Motor B" type="Vector4" vercond="User Version 2 &gt; 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
+        <add name="Pivot B" type="Vector4" vercond="User Version 2 &gt; 16">Defines the orthogonal directions in which the shape can be controlled (namely in this direction, and in the direction orthogonal on this one and Twist A).</add>
 
         <add name="Cone Max Angle" type="float">Maximum angle the object can rotate around the vector orthogonal on Plane A and Twist A relative to the Twist A vector. Note that Cone Min Angle is not stored, but is simply minus this angle.</add>
         <add name="Plane Min Angle" type="float">Minimum angle the object can rotate around Plane A, relative to Twist A.</add>
@@ -1939,33 +1931,24 @@
     <compound name="LimitedHingeDescriptor">
     	This constraint allows rotation about a specified axis, limited by specified boundaries.
     
-        <!-- Oblivion -->
-        <add name="Pivot A" type="Vector4" ver2="20.0.0.5">Pivot point around which the object will rotate.</add>
-        <add name="Axle A" type="Vector4" ver2="20.0.0.5">Axis of rotation.</add>
-        <add name="Perp2 Axle In A1" type="Vector4" ver2="20.0.0.5">Vector in the rotation plane which defines the zero angle.</add>
-        <add name="Perp2 Axle In A2" type="Vector4" ver2="20.0.0.5">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axle A and Perp2 Axle In A1.</add>
-        <add name="Pivot B" type="Vector4" ver2="20.0.0.5">Pivot A in second entity coordinate system.</add>
-        <add name="Axle B" type="Vector4" ver2="20.0.0.5">Axle A in second entity coordinate system.</add>
-        <add name="Perp2 Axle In B2" type="Vector4" ver2="20.0.0.5">Perp2 Axle In A2 in second entity coordinate system.</add>
+        <!-- Oblivion and Fallout 3, Havok 550 -->
+        <add name="Pivot A" type="Vector4" vercond="User Version 2 &lt;= 16">Pivot point around which the object will rotate.</add>
+        <add name="Axle A" type="Vector4" vercond="User Version 2 &lt;= 16">Axis of rotation.</add>
+        <add name="Perp2 Axle In A1" type="Vector4" vercond="User Version 2 &lt;= 16">Vector in the rotation plane which defines the zero angle.</add>
+        <add name="Perp2 Axle In A2" type="Vector4" vercond="User Version 2 &lt;= 16">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axle A and Perp2 Axle In A1.</add>
+        <add name="Pivot B" type="Vector4" vercond="User Version 2 &lt;= 16">Pivot A in second entity coordinate system.</add>
+        <add name="Axle B" type="Vector4" vercond="User Version 2 &lt;= 16">Axle A in second entity coordinate system.</add>
+        <add name="Perp2 Axle In B2" type="Vector4" vercond="User Version 2 &lt;= 16">Perp2 Axle In A2 in second entity coordinate system.</add>
 
-        <!-- Fallout 3 -->
-        <add name="Axle A" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Axis of rotation.</add>
-        <add name="Perp2 Axle In A1" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Vector in the rotation plane which defines the zero angle.</add>
-        <add name="Perp2 Axle In A2" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axle A and Perp2 Axle In A1.</add>
-        <add name="Pivot A" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Pivot point around which the object will rotate.</add>
-        <add name="Axle B" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Axle A in second entity coordinate system.</add>
-        <add name="Perp2 Axle In B1" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Perp2 Axle In A1 in second entity coordinate system.</add>
-        <add name="Perp2 Axle In B2" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Perp2 Axle In A2 in second entity coordinate system.</add>
-        <add name="Pivot B" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 &gt; 16">Pivot A in second entity coordinate system.</add>
-
-        <!-- Fallout 3, file meshes\ragdollconstraint\stiff.rdt with User Version 2 = 16 -->
-        <add name="Pivot A?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Pivot point around which the object will rotate.</add>
-        <add name="Axle A?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Axis of rotation.</add>
-        <add name="Perp2 Axle In A2?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axle A and Perp2 Axle In A1.</add>
-        <add name="Perp2 Axle In A1?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Vector in the rotation plane which defines the zero angle.</add>
-        <add name="Pivot B?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Pivot A in second entity coordinate system.</add>
-        <add name="Axle B?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Axle A in second entity coordinate system.</add>
-        <add name="Perp2 Axle In B1?" type="Vector4" ver1="20.2.0.7" vercond="User Version 2 == 16">Perp2 Axle In A1 in second entity coordinate system.</add>
+        <!-- Fallout 3 and later, Havok 660 and 2010 -->
+        <add name="Axle A" type="Vector4" vercond="User Version 2 &gt; 16">Axis of rotation.</add>
+        <add name="Perp2 Axle In A1" type="Vector4" vercond="User Version 2 &gt; 16">Vector in the rotation plane which defines the zero angle.</add>
+        <add name="Perp2 Axle In A2" type="Vector4" vercond="User Version 2 &gt; 16">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axle A and Perp2 Axle In A1.</add>
+        <add name="Pivot A" type="Vector4" vercond="User Version 2 &gt; 16">Pivot point around which the object will rotate.</add>
+        <add name="Axle B" type="Vector4" vercond="User Version 2 &gt; 16">Axle A in second entity coordinate system.</add>
+        <add name="Perp2 Axle In B1" type="Vector4" vercond="User Version 2 &gt; 16">Perp2 Axle In A1 in second entity coordinate system.</add>
+        <add name="Perp2 Axle In B2" type="Vector4" vercond="User Version 2 &gt; 16">Perp2 Axle In A2 in second entity coordinate system.</add>
+        <add name="Pivot B" type="Vector4" vercond="User Version 2 &gt; 16">Pivot A in second entity coordinate system.</add>
 
         <add name="Min Angle" type="float">Minimum rotation angle.</add>
         <add name="Max Angle" type="float">Maximum rotation angle.</add>
@@ -2025,7 +2008,6 @@
         <add name="Pivot B" type="Vector4" ver1="20.2.0.7">Pivot in B coordinates.</add>
 
         <add name="Min Distance" type="float">Describe the min distance the object is able to travel.</add>
-
         <add name="Max Distance" type="float">Describe the max distance the object is able to travel.</add>
         <add name="Friction" type="float" >Friction.</add>
 
@@ -2176,15 +2158,16 @@
 
     <compound name="MalleableDescriptor">
         <add name="Type" type="hkConstraintType">Type of constraint.</add>
-        <add name="Num Entities" type="uint">Usually 2. Number of bodies affected by this constraint.</add>
-        <add name="Entities" type="Ptr" template="bhkEntity" arr1="Num Entities">Usually NONE. The entities affected by this constraint.</add>
+        <add name="Num Entities" type="uint" default="2">Always 2 (Hardcoded). Number of bodies affected by this constraint.</add>
+        <add name="Entity A" type="Ptr" template="bhkEntity">Usually NONE. The entity affected by this constraint.</add>
+        <add name="Entity B" type="Ptr" template="bhkEntity">Usually NONE. The entity affected by this constraint.</add>
         <add name="Priority" type="uint" default="1">Usually 1. Higher values indicate higher priority of this constraint?</add>
         <add name="Ball and Socket" type="BallAndSocketDescriptor" cond="Type == 0" />
         <add name="Hinge" type="HingeDescriptor" cond="Type == 1" />
         <add name="Limited Hinge" type="LimitedHingeDescriptor" cond="Type == 2" />
         <add name="Prismatic" type="PrismaticDescriptor" cond="Type == 6" />
         <add name="Ragdoll" type="RagdollDescriptor" cond="Type == 7" />
-        <add name="StiffSpring" type="StiffSpringDescriptor" cond="Type == 8" />
+        <add name="Stiff Spring" type="StiffSpringDescriptor" cond="Type == 8" />
         <add name="Tau" type="float" ver2="20.0.0.5" /><!-- not in Fallout 3 or Skyrim -->
         <add name="Damping" type="float" ver2="20.0.0.5" /><!-- In TES CS described as Damping -->
         <add name="Strength" type="float" ver1="20.2.0.7" /><!-- In GECK and Creation Kit described as Strength -->
@@ -2192,15 +2175,16 @@
 
     <compound name="ConstraintData">
         <add name="Type" type="hkConstraintType">Type of constraint.</add>
-        <add name="Num Entities" type="uint">Usually 2. Number of bodies affected by this constraint.</add>
-        <add name="Entities" type="Ptr" template="bhkEntity" arr1="Num Entities">Usually NONE. The entities affected by this constraint.</add>
+        <add name="Num Entities 2" type="uint" default="2">Always 2 (Hardcoded). Number of bodies affected by this constraint.</add>
+        <add name="Entity A" type="Ptr" template="bhkEntity">Usually NONE. The entity affected by this constraint.</add>
+        <add name="Entity B" type="Ptr" template="bhkEntity">Usually NONE. The entity affected by this constraint.</add>
         <add name="Priority" type="uint" default="1">Usually 1. Higher values indicate higher priority of this constraint?</add>
         <add name="Ball and Socket" type="BallAndSocketDescriptor" cond="Type == 0" />
         <add name="Hinge" type="HingeDescriptor" cond="Type == 1" />
         <add name="Limited Hinge" type="LimitedHingeDescriptor" cond="Type == 2" />
         <add name="Prismatic" type="PrismaticDescriptor" cond="Type == 6" />
         <add name="Ragdoll" type="RagdollDescriptor" cond="Type == 7" />
-        <add name="StiffSpring" type="StiffSpringDescriptor" cond="Type == 8" />
+        <add name="Stiff Spring" type="StiffSpringDescriptor" cond="Type == 8" />
         <add name="Malleable" type="MalleableDescriptor" cond="Type == 13" />
     </compound>
 
@@ -2398,7 +2382,7 @@
 
     <niobject name="bhkStiffSpringConstraint" abstract="0" inherit="bhkConstraint">
         A spring constraint.
-        <add name="StiffSpring" type="StiffSpringDescriptor">Stiff Spring constraint.</add>
+        <add name="Stiff Spring" type="StiffSpringDescriptor">Stiff Spring constraint.</add>
     </niobject>
 
     <niobject name="bhkRagdollConstraint" abstract="0" inherit="bhkConstraint">

--- a/nif.xml
+++ b/nif.xml
@@ -2265,8 +2265,8 @@
         <add name="Unknown Bytes 2" type="byte" arr1="4" vercond="(User Version 2 &gt; 34)">Unknown. Skyrim only.</add>
         <add name="Num Constraints" type="uint"> The number of constraints this object is bound to.</add>
         <add name="Constraints" type="Ref" template="bhkSerializable" arr1="Num Constraints">Unknown.</add>
-        <add name="Body Flags" suffix="Old" type="uint" vercond="(User Version 2 &lt; 76)">1 = respond to wind</add>
-        <add name="Body Flags" suffix="New" type="ushort" vercond="(User Version 2 &gt;= 76)">1 = respond to wind</add>
+        <add name="Body Flags" type="uint" vercond="(User Version 2 &lt; 76)">1 = respond to wind</add>
+        <add name="Body Flags" type="ushort" vercond="(User Version 2 &gt;= 76)">1 = respond to wind</add>
     </niobject>
 
     <niobject name="bhkRigidBodyT" abstract="0" inherit="bhkRigidBody">
@@ -2667,8 +2667,8 @@
 
     <niobject name="NiAVObject" abstract="1" inherit="NiObjectNET">
         Base audiovisual object.
+        <add name="Flags" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects.</add>
         <add name="Flags" type="Flags" ver1="3.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26))">Basic flags for AV objects; commonly 0x000C or 0x000A.</add>
-        <add name="Flags" suffix="BS" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects.</add>
         <!-- TODO use MTransform -->
         <add name="Translation" type="Vector3">The translation vector.</add>
         <add name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</add>
@@ -2951,10 +2951,10 @@
     <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
         Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
         <add name="Data" type="Ref" template="NiGeometryData" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100))">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Data" suffix="BS" type="Ref" template="NiGeometryData" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Data" type="Ref" template="NiGeometryData" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
         <add name="Data" suffix="BSPS" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
         <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version &gt;= 3.3.0.13) &amp;&amp; !((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100))">Skin instance index.</add>
-        <add name="Skin Instance" suffix="BS" type="Ref" template="NiSkinInstance" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="!NiParticleSystem">Skin instance index.</add>
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="!NiParticleSystem">Skin instance index.</add>
         <add name="Skin Instance" suffix="BSPS" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="NiParticleSystem">Skin instance index.</add>
         <add name="Num Materials" type="uint" ver1="20.2.0.7">Num Materials</add>
         <add name="Material Name" type="string" arr1="Num Materials" ver1="20.2.0.7">Unknown string.  Shader?</add>

--- a/nif.xml
+++ b/nif.xml
@@ -1322,36 +1322,37 @@
         <add name="Variable 2 Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.0.0.5">Offset in the string palette where some variable string starts (so far only &#039;EmitterActive&#039; and &#039;BirthRate&#039; have been observed in official files, used for particle system controllers). Usually, -1.</add>
     </compound>
 
-    <compound name="ExportInfo" ver1="10.0.1.2">
+    <compound name="ExportInfo">
     	Information about how the file was exported
-        <add name="Unknown" type="uint" ver2="10.0.1.2" default="3">Probably the number of strings that follow.</add>
-        <add name="Creator" type="ShortString">Could be the name of the creator of the NIF file?</add>
-        <add name="Export Info 1" type="ShortString">Unknown. Can be something like &#039;TriStrip Process Script&#039;.</add>
-        <add name="Export Info 2" type="ShortString">Unknown. Possibly the selected option of the export script. Can be something like &#039;Default Export Script&#039;.</add>
+        <add name="Author" type="ShortString" />
+        <add name="Process Script" type="ShortString" />
+        <add name="Export Script" type="ShortString" />
     </compound>
 
     <!-- Don't use vercond in Header, it breaks niflib -->
     <compound name="Header">
         The NIF file header.
         <add name="Header String" type="HeaderString">&#039;NetImmerse File Format x.x.x.x&#039; (versions &lt;= 10.0.1.2) or &#039;Gamebryo File Format x.x.x.x&#039; (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</add>
-        <add name="Copyright" type="LineString" arr1="3" ver2="3.1" />
-        <add name="Version" type="FileVersion" default="0x04000002" ver1="3.3.0.13">The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002, 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...</add>
-        <add name="Endian Type" type="EndianType" default="ENDIAN_LITTLE" ver1="20.0.0.4">Determines the endianness of the data in the file.</add>
-        <add name="User Version" type="ulittle32" ver1="10.1.0.0">An extra version number, for companies that decide to modify the file format.</add>
-        <add name="Num Blocks" type="ulittle32" ver1="3.3.0.13">Number of file objects.</add>
-        <add name="User Version 2" type="ulittle32" default="0" cond="(User Version &gt;= 10) || ((User Version == 1) &amp;&amp; (Version != 10.2.0.0))" ver1="10.1.0.0">This also appears to be the extra user version number and must be set in some circumstances. Probably used by Bethesda to denote the Havok version.</add>
-        <add name="Unknown Int 3" type="uint" default="0" ver1="30.0.0.2">Unknown. Possibly User Version 2?</add>
-        <add name="Export Info" type="ExportInfo" ver1="10.0.1.2" ver2="10.0.1.2" />
-        <add name="Export Info" type="ExportInfo" ver1="10.1.0.0" cond="(User Version &gt;= 10) || ((User Version == 1) &amp;&amp; (Version != 10.2.0.0))" />
-        <add name="Export Info 3" type="ShortString" cond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130))" />
-        <add name="Num Block Types" type="ushort" ver1="10.0.1.0">Number of object types in this NIF file.</add>
-        <add name="Block Types" type="SizedString" arr1="Num Block Types" ver1="10.0.1.0">List of all object types used in this NIF file.</add>
-        <add name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" ver1="10.0.1.0">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</add>
-        <add name="Block Size" type="uint" arr1="Num Blocks" ver1="20.2.0.7">Array of block sizes?</add>
-        <add name="Num Strings" type="uint" ver1="20.1.0.3">Number of strings.</add>
-        <add name="Max String Length" type="uint" ver1="20.1.0.3">Maximum string length.</add>
-        <add name="Strings" type="SizedString" arr1="Num Strings" ver1="20.1.0.3">Strings.</add>
-        <add name="Unknown Int 2" type="uint" default="0" ver1="10.0.1.0">Unknown.</add>
+        <add name="Copyright" type="LineString" arr1="3" ver2="3.1.0.0" />
+        <add name="Version" type="FileVersion" default="0x04000002" ver1="3.1.0.1">The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002, 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...</add>
+        <add name="Endian Type" type="EndianType" default="ENDIAN_LITTLE" ver1="20.0.0.3">Determines the endianness of the data in the file.</add>
+        <add name="User Version" type="ulittle32" ver1="10.0.1.8">An extra version number, for companies that decide to modify the file format.</add>
+        <add name="Num Blocks" type="ulittle32" ver1="3.1.0.1">Number of file objects.</add>
+        <!-- BSStreamHeader -->
+        <add name="User Version 2" type="ulittle32" default="0" cond="(Version == 20.2.0.7) || (Version == 20.0.0.5) || ((Version == 20.0.0.4) &amp;&amp; (User Version == 11)) || ((Version &gt;= 10.0.1.2) &amp;&amp; (Version &lt; 20.0.0.4) &amp;&amp; (User Version &gt;= 3))" />
+        <add name="Export Info" type="ExportInfo" cond="(Version == 20.2.0.7) || (Version == 20.0.0.5) || ((Version == 20.0.0.4) &amp;&amp; (User Version == 11)) || ((Version &gt;= 10.0.1.2) &amp;&amp; (Version &lt; 20.0.0.4) &amp;&amp; (User Version &gt;= 3))" />
+        <add name="Max Filepath" type="ShortString" cond="(User Version 2 == 130)" />
+        <!-- / BSStreamHeader -->
+        <add name="Metadata" type="ByteArray" ver1="30.0.0.0" />
+        <add name="Num Block Types" type="ushort" ver1="5.0.0.1">Number of object types in this NIF file.</add>
+        <add name="Block Types" type="SizedString" arr1="Num Block Types" ver1="5.0.0.1">List of all object types used in this NIF file.</add>
+        <add name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" ver1="5.0.0.1">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</add>
+        <add name="Block Size" type="uint" arr1="Num Blocks" ver1="20.2.0.5">Array of block sizes?</add>
+        <add name="Num Strings" type="uint" ver1="20.1.0.1">Number of strings.</add>
+        <add name="Max String Length" type="uint" ver1="20.1.0.1">Maximum string length.</add>
+        <add name="Strings" type="SizedString" arr1="Num Strings" ver1="20.1.0.1">Strings.</add>
+        <add name="Num Groups" type="uint" default="0" ver1="5.0.0.6" />
+        <add name="Groups" type="uint" arr1="Num Groups" ver1="5.0.0.6" />
     </compound>
 
     <compound name="StringPalette">

--- a/nif.xml
+++ b/nif.xml
@@ -1720,14 +1720,6 @@
         <add name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</add>
     </compound>
 
-    <compound name="BoundingBox">
-        Bounding box.
-        <add name="Unknown Int" type="uint" default="1">Usually 1.</add>
-        <add name="Translation" type="Vector3">Translation vector.</add>
-        <add name="Rotation" type="Matrix33">Rotation matrix.</add>
-        <add name="Radius" type="Vector3">Radius, per direction.</add>
-    </compound>
-
 	<bitflags name="FurnitureEntryPoints" storage="ushort">
 		Bethesda Animation. Furniture entry points. It specifies the direction(s) from where the actor is able to enter (and leave) the position.
 		<option value="0" name="Front">front entry point</option>
@@ -2764,8 +2756,8 @@
         <add name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="(User Version 2 &lt;= 34)">All rendering properties attached to this object.</add>
         <add name="Unknown 1" type="uint" arr1="4" ver2="2.3">Always 2,0,2,0.</add>
         <add name="Unknown 2" type="byte" ver2="2.3">0 or 1.</add>
-        <add name="Has Bounding Box" type="bool" ver1="3.0" ver2="4.2.2.0" />
-        <add name="Bounding Box" type="BoundingBox" cond="Has Bounding Box" ver1="3.0" ver2="4.2.2.0" />
+        <add name="Has Bounding Volume" type="bool" ver1="3.0" ver2="4.2.2.0" />
+        <add name="Bounding Volume" type="BoundingVolume" cond="Has Bounding Volume" ver1="3.0" ver2="4.2.2.0" />
         <add name="Collision Object" type="Ref" template="NiCollisionObject" ver1="10.0.1.0" />
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -2710,20 +2710,20 @@
         <add name="Bounding Volume" type="BoundingVolume" cond="Use ABV == 1" />
     </niobject>
 
-    <bitflags name="bhkCOFlags" storage="ushort">
+    <bitflags name="bhkCOFlags" storage="ushort" prefix="BHKCO">
         bhkNiCollisionObject flags. The flags 0x2, 0x100, and 0x200 are not seen in any NIF nor get/set by the engine.
-        <option value="0" name="BHKCO_ACTIVE" />
-        <!--<option value="1" name="BHKCO_UNK1" />-->
-        <option value="2" name="BHKCO_NOTIFY" />
-        <option value="3" name="BHKCO_SET_LOCAL" />
-        <option value="4" name="BHKCO_DBG_DISPLAY" />
-        <option value="5" name="BHKCO_USE_VEL" />
-        <option value="6" name="BHKCO_RESET" />
-        <option value="7" name="BHKCO_SYNC_ON_UPDATE" />
-        <!--<option value="8" name="BHKCO_UNK2" />-->
-        <!--<option value="9" name="BHKCO_UNK3" />-->
-        <option value="10" name="BHKCO_ANIM_TARGETED" />
-        <option value="11" name="BHKCO_DISMEMBERED_LIMB" />
+        <option value="0" name="ACTIVE" />
+        <!--<option value="1" name="UNK1" />-->
+        <option value="2" name="NOTIFY" />
+        <option value="3" name="SET_LOCAL" />
+        <option value="4" name="DBG_DISPLAY" />
+        <option value="5" name="USE_VEL" />
+        <option value="6" name="RESET" />
+        <option value="7" name="SYNC_ON_UPDATE" />
+        <!--<option value="8" name="UNK2" />-->
+        <!--<option value="9" name="UNK3" />-->
+        <option value="10" name="ANIM_TARGETED" />
+        <option value="11" name="DISMEMBERED_LIMB" />
     </bitflags>
 
     <niobject name="bhkNiCollisionObject" abstract="1" inherit="NiCollisionObject">
@@ -5254,76 +5254,76 @@
         <option value="33" name="SHADER_NOLIGHTING">No Lighting Shader</option>
     </enum>
     
-    <bitflags name="BSShaderFlags" storage="uint">
+    <bitflags name="BSShaderFlags" storage="uint" prefix="F3SF1">
         Shader Property Flags
-        <option value="0" name="SF_Specular">Enables Specularity</option>
-        <option value="1" name="SF_Skinned">Required For Skinned Meshes</option>
-        <option value="2" name="SF_LowDetail">Lowddetail (seems to use standard diff/norm/spec shader)</option>
-        <option value="3" name="SF_Vertex_Alpha">Vertex Alpha</option>
-        <option value="4" name="SF_Unknown_1">Unknown</option>
-        <option value="5" name="SF_Single_Pass">Single Pass</option>
-        <option value="6" name="SF_Empty">Unknown</option>
-        <option value="7" name="SF_Environment_Mapping">Environment mapping (uses Envmap Scale)</option>
-        <option value="8" name="SF_Alpha_Texture">Alpha Texture Requires NiAlphaProperty to Enable</option>
-        <option value="9" name="SF_Unknown_2">Unknown</option>
-        <option value="10" name="SF_FaceGen">FaceGen</option>
-        <option value="11" name="SF_Parallax_Shader_Index_15">Parallax</option>
-        <option value="12" name="SF_Unknown_3">Unknown/Crash</option>
-        <option value="13" name="SF_Non_Projective_Shadows">Non-Projective Shadows</option>
-        <option value="14" name="SF_Unknown_4">Unknown/Crash</option>
-        <option value="15" name="SF_Refraction">Refraction (switches on refraction power)</option>
-        <option value="16" name="SF_Fire_Refraction">Fire Refraction (switches on refraction power/period)</option>
-        <option value="17" name="SF_Eye_Environment_Mapping">Eye Environment Mapping (does not use envmap light fade or envmap scale)</option>
-        <option value="18" name="SF_Hair">Hair</option>
-        <option value="19" name="SF_Dynamic_Alpha">Dynamic Alpha</option>
-        <option value="20" name="SF_Localmap_Hide_Secret">Localmap Hide Secret</option>
-        <option value="21" name="SF_Window_Environment_Mapping">Window Environment Mapping</option>
-        <option value="22" name="SF_Tree_Billboard">Tree Billboard</option>
-        <option value="23" name="SF_Shadow_Frustum">Shadow Frustum</option>
-        <option value="24" name="SF_Multiple_Textures">Multiple Textures (base diff/norm become null)</option>
-        <option value="25" name="SF_Remappable_Textures">usually seen w/texture animation</option>
-        <option value="26" name="SF_Decal_Single_Pass">Decal</option>
-        <option value="27" name="SF_Dynamic_Decal_Single_Pass">Dynamic Decal</option>
-        <option value="28" name="SF_Parallax_Occulsion">Parallax Occlusion</option>
-        <option value="29" name="SF_External_Emittance">External Emittance</option>
-        <option value="30" name="SF_Shadow_Map">Shadow Map</option>
-        <option value="31" name="SF_ZBuffer_Test">ZBuffer Test (1=on)</option>
+        <option value="0" name="Specular">Enables Specularity</option>
+        <option value="1" name="Skinned">Required For Skinned Meshes</option>
+        <option value="2" name="LowDetail">Lowddetail (seems to use standard diff/norm/spec shader)</option>
+        <option value="3" name="Vertex_Alpha">Vertex Alpha</option>
+        <option value="4" name="Unknown_1">Unknown</option>
+        <option value="5" name="Single_Pass">Single Pass</option>
+        <option value="6" name="Empty">Unknown</option>
+        <option value="7" name="Environment_Mapping">Environment mapping (uses Envmap Scale)</option>
+        <option value="8" name="Alpha_Texture">Alpha Texture Requires NiAlphaProperty to Enable</option>
+        <option value="9" name="Unknown_2">Unknown</option>
+        <option value="10" name="FaceGen">FaceGen</option>
+        <option value="11" name="Parallax_Shader_Index_15">Parallax</option>
+        <option value="12" name="Unknown_3">Unknown/Crash</option>
+        <option value="13" name="Non_Projective_Shadows">Non-Projective Shadows</option>
+        <option value="14" name="Unknown_4">Unknown/Crash</option>
+        <option value="15" name="Refraction">Refraction (switches on refraction power)</option>
+        <option value="16" name="Fire_Refraction">Fire Refraction (switches on refraction power/period)</option>
+        <option value="17" name="Eye_Environment_Mapping">Eye Environment Mapping (does not use envmap light fade or envmap scale)</option>
+        <option value="18" name="Hair">Hair</option>
+        <option value="19" name="Dynamic_Alpha">Dynamic Alpha</option>
+        <option value="20" name="Localmap_Hide_Secret">Localmap Hide Secret</option>
+        <option value="21" name="Window_Environment_Mapping">Window Environment Mapping</option>
+        <option value="22" name="Tree_Billboard">Tree Billboard</option>
+        <option value="23" name="Shadow_Frustum">Shadow Frustum</option>
+        <option value="24" name="Multiple_Textures">Multiple Textures (base diff/norm become null)</option>
+        <option value="25" name="Remappable_Textures">usually seen w/texture animation</option>
+        <option value="26" name="Decal_Single_Pass">Decal</option>
+        <option value="27" name="Dynamic_Decal_Single_Pass">Dynamic Decal</option>
+        <option value="28" name="Parallax_Occulsion">Parallax Occlusion</option>
+        <option value="29" name="External_Emittance">External Emittance</option>
+        <option value="30" name="Shadow_Map">Shadow Map</option>
+        <option value="31" name="ZBuffer_Test">ZBuffer Test (1=on)</option>
     </bitflags>
 
-    <bitflags name="BSShaderFlags2" storage="uint">
+    <bitflags name="BSShaderFlags2" storage="uint" prefix="F3SF2">
         Shader Property Flags 2
-        <option value="0" name="SF2_ZBuffer_Write">ZBuffer Write</option>
-        <option value="1" name="SF2_LOD_Landscape">LOD Landscape</option>
-        <option value="2" name="SF2_LOD_Building">LOD Building</option>
-        <option value="3" name="SF2_No_Fade">No Fade</option>
-        <option value="4" name="SF2_Refraction_Tint">Refraction Tint</option>
-        <option value="5" name="SF2_Vertex_Colors">Has Vertex Colors</option>
-        <option value="6" name="SF2_Unknown1">Unknown</option>
-        <option value="7" name="SF2_1st_Light_is_Point_Light">1st Light is Point Light</option>
-        <option value="8" name="SF2_2nd_Light">2nd Light</option>
-        <option value="9" name="SF2_3rd_Light">3rd Light</option>
-        <option value="10" name="SF2_Vertex_Lighting">Vertex Lighting</option>
-        <option value="11" name="SF2_Uniform_Scale">Uniform Scale</option>
-        <option value="12" name="SF2_Fit_Slope">Fit Slope</option>
-        <option value="13" name="SF2_Billboard_and_Envmap_Light_Fade">Billboard and Envmap Light Fade</option>
-        <option value="14" name="SF2_No_LOD_Land_Blend">No LOD Land Blend</option>
-        <option value="15" name="SF2_Envmap_Light_Fade">Envmap Light Fade</option>
-        <option value="16" name="SF2_Wireframe">Wireframe</option>
-        <option value="17" name="SF2_VATS_Selection">VATS Selection</option>
-        <option value="18" name="SF2_Show_in_Local_Map">Show in Local Map</option>
-        <option value="19" name="SF2_Premult_Alpha">Premult Alpha</option>
-        <option value="20" name="SF2_Skip_Normal_Maps">Skip Normal Maps</option>
-        <option value="21" name="SF2_Alpha_Decal">Alpha Decal</option>
-        <option value="22" name="SF2_No_Transparecny_Multisampling">No Transparency MultiSampling</option>
-        <option value="23" name="SF2_Unknown2">Unknown</option>
-        <option value="24" name="SF2_Unknown3">Unknown</option>
-        <option value="25" name="SF2_Unknown4">Unknown</option>
-        <option value="26" name="SF2_Unknown5">Unknown</option>
-        <option value="27" name="SF2_Unknown6">Unknown</option>
-        <option value="28" name="SF2_Unknown7">Unknown</option>
-        <option value="29" name="SF2_Unknown8">Unknown</option>
-        <option value="30" name="SF2_Unknown9">Unknown</option>
-        <option value="31" name="SF2_Unknown10">Unknown</option>
+        <option value="0" name="ZBuffer_Write">ZBuffer Write</option>
+        <option value="1" name="LOD_Landscape">LOD Landscape</option>
+        <option value="2" name="LOD_Building">LOD Building</option>
+        <option value="3" name="No_Fade">No Fade</option>
+        <option value="4" name="Refraction_Tint">Refraction Tint</option>
+        <option value="5" name="Vertex_Colors">Has Vertex Colors</option>
+        <option value="6" name="Unknown1">Unknown</option>
+        <option value="7" name="1st_Light_is_Point_Light">1st Light is Point Light</option>
+        <option value="8" name="2nd_Light">2nd Light</option>
+        <option value="9" name="3rd_Light">3rd Light</option>
+        <option value="10" name="Vertex_Lighting">Vertex Lighting</option>
+        <option value="11" name="Uniform_Scale">Uniform Scale</option>
+        <option value="12" name="Fit_Slope">Fit Slope</option>
+        <option value="13" name="Billboard_and_Envmap_Light_Fade">Billboard and Envmap Light Fade</option>
+        <option value="14" name="No_LOD_Land_Blend">No LOD Land Blend</option>
+        <option value="15" name="Envmap_Light_Fade">Envmap Light Fade</option>
+        <option value="16" name="Wireframe">Wireframe</option>
+        <option value="17" name="VATS_Selection">VATS Selection</option>
+        <option value="18" name="Show_in_Local_Map">Show in Local Map</option>
+        <option value="19" name="Premult_Alpha">Premult Alpha</option>
+        <option value="20" name="Skip_Normal_Maps">Skip Normal Maps</option>
+        <option value="21" name="Alpha_Decal">Alpha Decal</option>
+        <option value="22" name="No_Transparecny_Multisampling">No Transparency MultiSampling</option>
+        <option value="23" name="Unknown2">Unknown</option>
+        <option value="24" name="Unknown3">Unknown</option>
+        <option value="25" name="Unknown4">Unknown</option>
+        <option value="26" name="Unknown5">Unknown</option>
+        <option value="27" name="Unknown6">Unknown</option>
+        <option value="28" name="Unknown7">Unknown</option>
+        <option value="29" name="Unknown8">Unknown</option>
+        <option value="30" name="Unknown9">Unknown</option>
+        <option value="31" name="Unknown10">Unknown</option>
     </bitflags>
     
     <niobject name="BSShaderProperty" abstract="0" inherit="NiShadeProperty">
@@ -5472,148 +5472,148 @@
         Bethesda-specific property.
     </niobject>
 
-    <bitflags name="SkyrimShaderPropertyFlags1" storage="uint">
+    <bitflags name="SkyrimShaderPropertyFlags1" storage="uint" prefix="SLSF1">
         Skyrim Shader Property Flags 1
-        <option value="0" name="SLSF1_Specular">Enables Specularity</option>
-        <option value="1" name="SLSF1_Skinned">Required For Skinned Meshes.</option>
-        <option value="2" name="SLSF1_Temp_Refraction"></option>
-        <option value="3" name="SLSF1_Vertex_Alpha">Enables using alpha component of vertex colors.</option>
-        <option value="4" name="SLSF1_Greyscale_To_PaletteColor">in EffectShaderProperty</option>
-        <option value="5" name="SLSF1_Greyscale_To_PaletteAlpha">in EffectShaderProperty</option>
-        <option value="6" name="SLSF1_Use_Falloff">Use Falloff value in EffectShaderProperty</option>
-        <option value="7" name="SLSF1_Environment_Mapping">Environment mapping (uses Envmap Scale).</option>
-        <option value="8" name="SLSF1_Recieve_Shadows">Object can recieve shadows.</option>
-        <option value="9" name="SLSF1_Cast_Shadows">Can cast shadows</option>
-        <option value="10" name="SLSF1_Facegen_Detail_Map">Use a face detail map in the 4th texture slot.</option>
-        <option value="11" name="SLSF1_Parallax">Unused?</option>
-        <option value="12" name="SLSF1_Model_Space_Normals">Use Model space normals and an external Specular Map.</option>
-        <option value="13" name="SLSF1_Non_Projective_Shadows"></option>
-        <option value="14" name="SLSF1_Landscape"></option>
-        <option value="15" name="SLSF1_Refraction">Use normal map for refraction effect.</option>
-        <option value="16" name="SLSF1_Fire_Refraction"></option>
-        <option value="17" name="SLSF1_Eye_Environment_Mapping">Eye Environment Mapping (Must use the Eye shader and the model must be skinned)</option>
-        <option value="18" name="SLSF1_Hair_Soft_Lighting">Keeps from going too bright under lights (hair shader only)</option>
-        <option value="19" name="SLSF1_Screendoor_Alpha_Fade"></option>
-        <option value="20" name="SLSF1_Localmap_Hide_Secret">Object and anything it is positioned above will not render on local map view.</option>
-        <option value="21" name="SLSF1_FaceGen_RGB_Tint">Use tintmask for Face.</option>
-        <option value="22" name="SLSF1_Own_Emit">Provides its own emittance color. (will not absorb light/ambient color?)</option>
-        <option value="23" name="SLSF1_Projected_UV">Used for decalling?</option>
-        <option value="24" name="SLSF1_Multiple_Textures"></option>
-        <option value="25" name="SLSF1_Remappable_Textures"></option>
-        <option value="26" name="SLSF1_Decal"></option>
-        <option value="27" name="SLSF1_Dynamic_Decal"></option>
-        <option value="28" name="SLSF1_Parallax_Occlusion"></option>
-        <option value="29" name="SLSF1_External_Emittance"></option>
-        <option value="30" name="SLSF1_Soft_Effect"></option>
-        <option value="31" name="SLSF1_ZBuffer_Test">ZBuffer Test (1=on)</option>
+        <option value="0" name="Specular">Enables Specularity</option>
+        <option value="1" name="Skinned">Required For Skinned Meshes.</option>
+        <option value="2" name="Temp_Refraction"></option>
+        <option value="3" name="Vertex_Alpha">Enables using alpha component of vertex colors.</option>
+        <option value="4" name="Greyscale_To_PaletteColor">in EffectShaderProperty</option>
+        <option value="5" name="Greyscale_To_PaletteAlpha">in EffectShaderProperty</option>
+        <option value="6" name="Use_Falloff">Use Falloff value in EffectShaderProperty</option>
+        <option value="7" name="Environment_Mapping">Environment mapping (uses Envmap Scale).</option>
+        <option value="8" name="Recieve_Shadows">Object can recieve shadows.</option>
+        <option value="9" name="Cast_Shadows">Can cast shadows</option>
+        <option value="10" name="Facegen_Detail_Map">Use a face detail map in the 4th texture slot.</option>
+        <option value="11" name="Parallax">Unused?</option>
+        <option value="12" name="Model_Space_Normals">Use Model space normals and an external Specular Map.</option>
+        <option value="13" name="Non_Projective_Shadows"></option>
+        <option value="14" name="Landscape"></option>
+        <option value="15" name="Refraction">Use normal map for refraction effect.</option>
+        <option value="16" name="Fire_Refraction"></option>
+        <option value="17" name="Eye_Environment_Mapping">Eye Environment Mapping (Must use the Eye shader and the model must be skinned)</option>
+        <option value="18" name="Hair_Soft_Lighting">Keeps from going too bright under lights (hair shader only)</option>
+        <option value="19" name="Screendoor_Alpha_Fade"></option>
+        <option value="20" name="Localmap_Hide_Secret">Object and anything it is positioned above will not render on local map view.</option>
+        <option value="21" name="FaceGen_RGB_Tint">Use tintmask for Face.</option>
+        <option value="22" name="Own_Emit">Provides its own emittance color. (will not absorb light/ambient color?)</option>
+        <option value="23" name="Projected_UV">Used for decalling?</option>
+        <option value="24" name="Multiple_Textures"></option>
+        <option value="25" name="Remappable_Textures"></option>
+        <option value="26" name="Decal"></option>
+        <option value="27" name="Dynamic_Decal"></option>
+        <option value="28" name="Parallax_Occlusion"></option>
+        <option value="29" name="External_Emittance"></option>
+        <option value="30" name="Soft_Effect"></option>
+        <option value="31" name="ZBuffer_Test">ZBuffer Test (1=on)</option>
     </bitflags>
     
-    <bitflags name="SkyrimShaderPropertyFlags2" storage="uint">
+    <bitflags name="SkyrimShaderPropertyFlags2" storage="uint" prefix="SLSF2">
         Skyrim Shader Property Flags 2
-        <option value="0" name="SLSF2_ZBuffer_Write">Enables writing to the Z-Buffer</option>
-        <option value="1" name="SLSF2_LOD_Landscape"></option>
-        <option value="2" name="SLSF2_LOD_Objects"></option>
-        <option value="3" name="SLSF2_No_Fade"></option>
-        <option value="4" name="SLSF2_Double_Sided">Double-sided rendering.</option>
-        <option value="5" name="SLSF2_Vertex_Colors">Has Vertex Colors.</option>
-        <option value="6" name="SLSF2_Glow_Map">Use Glow Map in the third texture slot.</option>
-        <option value="7" name="SLSF2_Assume_Shadowmask"></option>
-        <option value="8" name="SLSF2_Packed_Tangent"></option>
-        <option value="9" name="SLSF2_Multi_Index_Snow"></option>
-        <option value="10" name="SLSF2_Vertex_Lighting"></option>
-        <option value="11" name="SLSF2_Uniform_Scale"></option>
-        <option value="12" name="SLSF2_Fit_Slope"></option>
-        <option value="13" name="SLSF2_Billboard"></option>
-        <option value="14" name="SLSF2_No_LOD_Land_Blend"></option>
-        <option value="15" name="SLSF2_EnvMap_Light_Fade"></option>
-        <option value="16" name="SLSF2_Wireframe">Wireframe (Seems to only work on particles)</option>
-        <option value="17" name="SLSF2_Weapon_Blood">Used for blood decals on weapons.</option>
-        <option value="18" name="SLSF2_Hide_On_Local_Map">Similar to hide secret, but only for self?</option>
-        <option value="19" name="SLSF2_Premult_Alpha">Has Premultiplied Alpha</option>
-        <option value="20" name="SLSF2_Cloud_LOD"></option>
-        <option value="21" name="SLSF2_Anisotropic_Lighting">Hair only?</option>
-        <option value="22" name="SLSF2_No_Transparency_Multisampling"></option>
-        <option value="23" name="SLSF2_Unused01">Unused?</option>
-        <option value="24" name="SLSF2_Multi_Layer_Parallax">Use Multilayer (inner-layer) Map</option>
-        <option value="25" name="SLSF2_Soft_Lighting">Use Soft Lighting Map</option>
-        <option value="26" name="SLSF2_Rim_Lighting">Use Rim Lighting Map</option>
-        <option value="27" name="SLSF2_Back_Lighting">Use Back Lighting Map</option>
-        <option value="28" name="SLSF2_Unused02">Unused?</option>
-        <option value="29" name="SLSF2_Tree_Anim">Enables Vertex Animation, Flutter Animation</option>
-        <option value="30" name="SLSF2_Effect_Lighting"></option>
-        <option value="31" name="SLSF2_HD_LOD_Objects"></option>
+        <option value="0" name="ZBuffer_Write">Enables writing to the Z-Buffer</option>
+        <option value="1" name="LOD_Landscape"></option>
+        <option value="2" name="LOD_Objects"></option>
+        <option value="3" name="No_Fade"></option>
+        <option value="4" name="Double_Sided">Double-sided rendering.</option>
+        <option value="5" name="Vertex_Colors">Has Vertex Colors.</option>
+        <option value="6" name="Glow_Map">Use Glow Map in the third texture slot.</option>
+        <option value="7" name="Assume_Shadowmask"></option>
+        <option value="8" name="Packed_Tangent"></option>
+        <option value="9" name="Multi_Index_Snow"></option>
+        <option value="10" name="Vertex_Lighting"></option>
+        <option value="11" name="Uniform_Scale"></option>
+        <option value="12" name="Fit_Slope"></option>
+        <option value="13" name="Billboard"></option>
+        <option value="14" name="No_LOD_Land_Blend"></option>
+        <option value="15" name="EnvMap_Light_Fade"></option>
+        <option value="16" name="Wireframe">Wireframe (Seems to only work on particles)</option>
+        <option value="17" name="Weapon_Blood">Used for blood decals on weapons.</option>
+        <option value="18" name="Hide_On_Local_Map">Similar to hide secret, but only for self?</option>
+        <option value="19" name="Premult_Alpha">Has Premultiplied Alpha</option>
+        <option value="20" name="Cloud_LOD"></option>
+        <option value="21" name="Anisotropic_Lighting">Hair only?</option>
+        <option value="22" name="No_Transparency_Multisampling"></option>
+        <option value="23" name="Unused01">Unused?</option>
+        <option value="24" name="Multi_Layer_Parallax">Use Multilayer (inner-layer) Map</option>
+        <option value="25" name="Soft_Lighting">Use Soft Lighting Map</option>
+        <option value="26" name="Rim_Lighting">Use Rim Lighting Map</option>
+        <option value="27" name="Back_Lighting">Use Back Lighting Map</option>
+        <option value="28" name="Unused02">Unused?</option>
+        <option value="29" name="Tree_Anim">Enables Vertex Animation, Flutter Animation</option>
+        <option value="30" name="Effect_Lighting"></option>
+        <option value="31" name="HD_LOD_Objects"></option>
     </bitflags>
 
-    <bitflags name="Fallout4ShaderPropertyFlags1" storage="uint">
+    <bitflags name="Fallout4ShaderPropertyFlags1" storage="uint" prefix="F4SF1">
         Fallout 4 Shader Property Flags 1
-        <option value="0" name="FSF1_Specular" />
-        <option value="1" name="FSF1_Skinned" />
-        <option value="2" name="FSF1_Temp_Refraction" />
-        <option value="3" name="FSF1_Vertex_Alpha" />
-        <option value="4" name="FSF1_GreyscaleToPalette_Color" />
-        <option value="5" name="FSF1_GreyscaleToPalette_Alpha" />
-        <option value="6" name="FSF1_Use_Falloff" />
-        <option value="7" name="FSF1_Environment_Mapping" />
-        <option value="8" name="FSF1_RGB_Falloff" />
-        <option value="9" name="FSF1_Cast_Shadows" />
-        <option value="10" name="FSF1_Face" />
-        <option value="11" name="FSF1_UI_Mask_Rects" />
-        <option value="12" name="FSF1_Model_Space_Normals" />
-        <option value="13" name="FSF1_Non_Projective_Shadows" />
-        <option value="14" name="FSF1_Landscape" />
-        <option value="15" name="FSF1_Refraction" />
-        <option value="16" name="FSF1_Fire_Refraction" />
-        <option value="17" name="FSF1_Eye_Environment_Mapping" />
-        <option value="18" name="FSF1_Hair" />
-        <option value="19" name="FSF1_Screendoor_Alpha_Fade" />
-        <option value="20" name="FSF1_Localmap_Hide_Secret" />
-        <option value="21" name="FSF1_Skin_Tint" />
-        <option value="22" name="FSF1_Own_Emit" />
-        <option value="23" name="FSF1_Projected_UV" />
-        <option value="24" name="FSF1_Multiple_Textures" />
-        <option value="25" name="FSF1_Tessellate" />
-        <option value="26" name="FSF1_Decal" />
-        <option value="27" name="FSF1_Dynamic_Decal" />
-        <option value="28" name="FSF1_Character_Lighting" />
-        <option value="29" name="FSF1_External_Emittance" />
-        <option value="30" name="FSF1_Soft_Effect" />
-        <option value="31" name="FSF1_ZBuffer_Test" />
+        <option value="0" name="Specular" />
+        <option value="1" name="Skinned" />
+        <option value="2" name="Temp_Refraction" />
+        <option value="3" name="Vertex_Alpha" />
+        <option value="4" name="GreyscaleToPalette_Color" />
+        <option value="5" name="GreyscaleToPalette_Alpha" />
+        <option value="6" name="Use_Falloff" />
+        <option value="7" name="Environment_Mapping" />
+        <option value="8" name="RGB_Falloff" />
+        <option value="9" name="Cast_Shadows" />
+        <option value="10" name="Face" />
+        <option value="11" name="UI_Mask_Rects" />
+        <option value="12" name="Model_Space_Normals" />
+        <option value="13" name="Non_Projective_Shadows" />
+        <option value="14" name="Landscape" />
+        <option value="15" name="Refraction" />
+        <option value="16" name="Fire_Refraction" />
+        <option value="17" name="Eye_Environment_Mapping" />
+        <option value="18" name="Hair" />
+        <option value="19" name="Screendoor_Alpha_Fade" />
+        <option value="20" name="Localmap_Hide_Secret" />
+        <option value="21" name="Skin_Tint" />
+        <option value="22" name="Own_Emit" />
+        <option value="23" name="Projected_UV" />
+        <option value="24" name="Multiple_Textures" />
+        <option value="25" name="Tessellate" />
+        <option value="26" name="Decal" />
+        <option value="27" name="Dynamic_Decal" />
+        <option value="28" name="Character_Lighting" />
+        <option value="29" name="External_Emittance" />
+        <option value="30" name="Soft_Effect" />
+        <option value="31" name="ZBuffer_Test" />
     </bitflags>
     
-    <bitflags name="Fallout4ShaderPropertyFlags2" storage="uint">
+    <bitflags name="Fallout4ShaderPropertyFlags2" storage="uint" prefix="F4SF2">
         Fallout 4 Shader Property Flags 2
-        <option value="0" name="FSF2_ZBuffer_Write" />
-        <option value="1" name="FSF2_LOD_Landscape" />
-        <option value="2" name="FSF2_LOD_Objects" />
-        <option value="3" name="FSF2_No_Fade" />
-        <option value="4" name="FSF2_Double_Sided" />
-        <option value="5" name="FSF2_Vertex_Colors" />
-        <option value="6" name="FSF2_Glow_Map" />
-        <option value="7" name="FSF2_Transform_Changed" />
-        <option value="8" name="FSF2_Dismemberment_Meatcuff" />
-        <option value="9" name="FSF2_Tint" />
-        <option value="10" name="FSF2_Grass_Vertex_Lighting" />
-        <option value="11" name="FSF2_Grass_Uniform_Scale" />
-        <option value="12" name="FSF2_Grass_Fit_Slope" />
-        <option value="13" name="FSF2_Grass_Billboard" />
-        <option value="14" name="FSF2_No_LOD_Land_Blend" />
-        <option value="15" name="FSF2_Dismemberment" />
-        <option value="16" name="FSF2_Wireframe" />
-        <option value="17" name="FSF2_Weapon_Blood" />
-        <option value="18" name="FSF2_Hide_On_Local_Map" />
-        <option value="19" name="FSF2_Premult_Alpha" />
-        <option value="20" name="FSF2_VATS_Target" />
-        <option value="21" name="FSF2_Anisotropic_Lighting" />
-        <option value="22" name="FSF2_Skew_Specular_Alpha" />
-        <option value="23" name="FSF2_Menu_Screen" />
-        <option value="24" name="FSF2_Multi_Layer_Parallax" />
-        <option value="25" name="FSF2_Alpha_Test" />
-        <option value="26" name="FSF2_Gradient_Remap" />
-        <option value="27" name="FSF2_VATS_Target_Draw_All" />
-        <option value="28" name="FSF2_Pipboy_Screen" />
-        <option value="29" name="FSF2_Tree_Anim" />
-        <option value="30" name="FSF2_Effect_Lighting" />
-        <option value="31" name="FSF2_Refraction_Writes_Depth" />
+        <option value="0" name="ZBuffer_Write" />
+        <option value="1" name="LOD_Landscape" />
+        <option value="2" name="LOD_Objects" />
+        <option value="3" name="No_Fade" />
+        <option value="4" name="Double_Sided" />
+        <option value="5" name="Vertex_Colors" />
+        <option value="6" name="Glow_Map" />
+        <option value="7" name="Transform_Changed" />
+        <option value="8" name="Dismemberment_Meatcuff" />
+        <option value="9" name="Tint" />
+        <option value="10" name="Grass_Vertex_Lighting" />
+        <option value="11" name="Grass_Uniform_Scale" />
+        <option value="12" name="Grass_Fit_Slope" />
+        <option value="13" name="Grass_Billboard" />
+        <option value="14" name="No_LOD_Land_Blend" />
+        <option value="15" name="Dismemberment" />
+        <option value="16" name="Wireframe" />
+        <option value="17" name="Weapon_Blood" />
+        <option value="18" name="Hide_On_Local_Map" />
+        <option value="19" name="Premult_Alpha" />
+        <option value="20" name="VATS_Target" />
+        <option value="21" name="Anisotropic_Lighting" />
+        <option value="22" name="Skew_Specular_Alpha" />
+        <option value="23" name="Menu_Screen" />
+        <option value="24" name="Multi_Layer_Parallax" />
+        <option value="25" name="Alpha_Test" />
+        <option value="26" name="Gradient_Remap" />
+        <option value="27" name="VATS_Target_Draw_All" />
+        <option value="28" name="Pipboy_Screen" />
+        <option value="29" name="Tree_Anim" />
+        <option value="30" name="Effect_Lighting" />
+        <option value="31" name="Refraction_Writes_Depth" />
     </bitflags>
 
     <niobject name="BSLightingShaderProperty"  abstract="0" inherit="BSShaderProperty">

--- a/nif.xml
+++ b/nif.xml
@@ -169,7 +169,7 @@
         <option value="4" name="GLOW_MAP">Creates a glowing effect.  Basically an incandescence map.</option>
         <option value="5" name="BUMP_MAP">Used to make the object appear to have more detail than it really does.</option>
         <option value="6" name="NORMAL_MAP">Used to make the object appear to have more detail than it really does.</option>
-        <option value="7" name="UNKNOWN2_MAP">Unknown map.</option>
+        <option value="7" name="PARALLAX_MAP">Parallax map.</option>
         <option value="8" name="DECAL_0_MAP">For placing images on the object like stickers.</option>
         <option value="9" name="DECAL_1_MAP">For placing images on the object like stickers.</option>
         <option value="10" name="DECAL_2_MAP">For placing images on the object like stickers.</option>
@@ -603,25 +603,96 @@
         <option value="2" name="MIP_FMT_DEFAULT">Use default setting.</option>
     </enum>
 
-    <enum name="PixelFormat" storage="uint">
-        Specifies the pixel format used by the NiPixelData object to store a texture.
-        <option value="0" name="PX_FMT_RGB8">24-bit color: uses 8 bit to store each red, blue, and green component.</option>
-        <option value="1" name="PX_FMT_RGBA8">32-bit color with alpha: uses 8 bits to store each red, blue, green, and alpha component.</option>
-        <option value="2" name="PX_FMT_PAL8">8-bit palette index: uses 8 bits to store an index into the palette stored in a NiPalette object.</option>
-        <option value="4" name="PX_FMT_DXT1">DXT1 compressed texture.</option>
-        <option value="5" name="PX_FMT_DXT5">DXT5 compressed texture.</option>
-        <option value="6" name="PX_FMT_DXT5_ALT">DXT5 compressed texture. It is not clear what the difference is with PX_FMT_DXT5.</option>
+    <enum name="PlatformID" storage="uint" prefix="PLATFORM">
+        <option value="0" name="ANY" />
+        <option value="1" name="XENON" />
+        <option value="2" name="PS3" />
+        <option value="3" name="DX9" />
+        <option value="4" name="WII" />
+        <option value="5" name="D3D10" />
     </enum>
 
-    <enum name="PixelLayout" storage="uint">
+    <enum name="RendererID" storage="uint" prefix="RENDERER">
+        <option value="0" name="XBOX360" />
+        <option value="1" name="PS3" />
+        <option value="2" name="DX9" />
+        <option value="3" name="D3D10" />
+        <option value="4" name="WII" />
+        <option value="5" name="GENERIC" />
+        <option value="6" name="D3D11" />
+    </enum>
+
+    <enum name="PixelFormat" storage="uint" prefix="PX">
+        Specifies the pixel format used by the NiPixelData object to store a texture.
+        <option value="0" name="FMT_RGB8">24-bit color: uses 8 bit to store each red, blue, and green component.</option>
+        <option value="1" name="FMT_RGBA8">32-bit color with alpha: uses 8 bits to store each red, blue, green, and alpha component.</option>
+        <option value="2" name="FMT_PAL8">8-bit palette index: uses 8 bits to store an index into the palette stored in a NiPalette object.</option>
+        <option value="3" name="FMT_PALA" />
+        <option value="4" name="FMT_DXT1">DXT1 compressed texture.</option>
+        <option value="5" name="FMT_DXT3">DXT3 compressed texture.</option>
+        <option value="6" name="FMT_DXT5">DXT5 compressed texture.</option>
+        <option value="7" name="FMT_RGB24NONINT">24-bit noninterleaved texture.</option>
+        <option value="8" name="FMT_BUMP" />
+        <option value="9" name="FMT_BUMPLUMA" />
+        <option value="10" name="FMT_RENDERSPEC" />
+        <option value="11" name="FMT_1CH" />
+        <option value="12" name="FMT_2CH" />
+        <option value="13" name="FMT_3CH" />
+        <option value="14" name="FMT_4CH" />
+        <option value="15" name="FMT_DEPTH_STENCIL" />
+        <option value="16" name="FMT_UNKNOWN" />
+    </enum>
+
+    <enum name="PixelTiling" storage="uint" prefix="PX">
+        <option value="0" name="TILE_NONE" />
+        <option value="1" name="TILE_XENON" />
+        <option value="2" name="TILE_WII" />
+        <option value="3" name="TILE_NV_SWIZZLED" />
+    </enum>
+
+    <enum name="PixelComponent" storage="uint" prefix="PX">
+        Specifies the pixel format used by the NiPixelData object to store a texture.
+        <option value="0" name="COMP_RED" />
+        <option value="1" name="COMP_GREEN" />
+        <option value="2" name="COMP_BLUE" />
+        <option value="3" name="COMP_ALPHA" />
+        <option value="4" name="COMP_COMPRESSED" />
+        <option value="5" name="COMP_OFFSET_U" />
+        <option value="6" name="COMP_OFFSET_V" />
+        <option value="7" name="COMP_OFFSET_W" />
+        <option value="8" name="COMP_OFFSET_Q" />
+        <option value="9" name="COMP_LUMA" />
+        <option value="10" name="COMP_HEIGHT" />
+        <option value="11" name="COMP_VECTOR_X" />
+        <option value="12" name="COMP_VECTOR_Y" />
+        <option value="13" name="COMP_VECTOR_Z" />
+        <option value="14" name="COMP_PADDING" />
+        <option value="15" name="COMP_INTENSITY" />
+        <option value="16" name="COMP_INDEX" />
+        <option value="17" name="COMP_DEPTH" />
+        <option value="18" name="COMP_STENCIL" />
+        <option value="19" name="COMP_EMPTY" />
+    </enum>
+
+    <enum name="PixelRepresentation" storage="uint" prefix="PX">
+        <option value="0" name="REP_NORM_INT" />
+        <option value="1" name="REP_HALF" />
+        <option value="2" name="REP_FLOAT" />
+        <option value="3" name="REP_INDEX" />
+        <option value="4" name="REP_COMPRESSED" />
+        <option value="5" name="REP_UNKNOWN" />
+        <option value="6" name="REP_INT" />
+    </enum>
+
+    <enum name="PixelLayout" storage="uint" prefix="PX">
         An unsigned 32-bit integer, describing the color depth of a texture.
-        <option value="0" name="PIX_LAY_PALETTISED">Texture is in 8-bit paletized format.</option>
-        <option value="1" name="PIX_LAY_HIGH_COLOR_16">Texture is in 16-bit high color format.</option>
-        <option value="2" name="PIX_LAY_TRUE_COLOR_32">Texture is in 32-bit true color format.</option>
-        <option value="3" name="PIX_LAY_COMPRESSED">Texture is compressed.</option>
-        <option value="4" name="PIX_LAY_BUMPMAP">Texture is a grayscale bump map.</option>
-        <option value="5" name="PIX_LAY_PALETTISED_4">Texture is in 4-bit paletized format.</option>
-        <option value="6" name="PIX_LAY_DEFAULT">Use default setting.</option>
+        <option value="0" name="LAY_PALETTISED">Texture is in 8-bit paletized format.</option>
+        <option value="1" name="LAY_HIGH_COLOR_16">Texture is in 16-bit high color format.</option>
+        <option value="2" name="LAY_TRUE_COLOR_32">Texture is in 32-bit true color format.</option>
+        <option value="3" name="LAY_COMPRESSED">Texture is compressed.</option>
+        <option value="4" name="LAY_BUMPMAP">Texture is a grayscale bump map.</option>
+        <option value="5" name="LAY_PALETTISED_4">Texture is in 4-bit paletized format.</option>
+        <option value="6" name="LAY_DEFAULT">Use default setting.</option>
     </enum>
 
     <enum name="TexClampMode" storage="uint">
@@ -1432,11 +1503,12 @@
 
     <compound name="TexDesc">
         Texture description.
-        <add name="Source" type="Ref" template="NiSourceTexture">NiSourceTexture object index.</add>
+        <add name="Image" type="Ref" template="NiImage" ver2="3.1">Link to the texture image.</add>
+        <add name="Source" type="Ref" template="NiSourceTexture" ver1="3.3.0.13">NiSourceTexture object index.</add>
         <add name="Clamp Mode" type="TexClampMode" default="WRAP_S_WRAP_T" ver2="20.0.0.5">0=clamp S clamp T, 1=clamp S wrap T, 2=wrap S clamp T, 3=wrap S wrap T</add>
         <add name="Filter Mode" type="TexFilterMode" default="FILTER_TRILERP" ver2="20.0.0.5">0=nearest, 1=bilinear, 2=trilinear, 3=..., 4=..., 5=...</add>
         <add name="Flags" type="Flags" ver1="20.1.0.3">Texture mode flags; clamp and filter mode stored in upper byte with 0xYZ00 = clamp mode Y, filter mode Z.</add>
-        <add name="Unknown short" type="short" ver1="20.6.0.0">Unknown, seems to always be 1</add>
+        <add name="Max Anisotropy" type="ushort" ver1="20.5.0.4" />
         <add name="UV Set" type="uint" default="0" ver2="20.0.0.5">The texture coordinate set in NiGeometryData that this texture slot will use.</add>
         <add name="PS2 L" type="short" default="0" ver2="10.4.0.1">PS2 only; from the Freedom Force docs, &quot;L values can range from 0 to 3 and are used to specify how fast a texture gets blurry&quot;.</add>
         <add name="PS2 K" type="short" default="-75" ver2="10.4.0.1">PS2 only; from the Freedom Force docs, &quot;The K value is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.&quot; -75 for most v4.0.0.2 meshes.</add>
@@ -1928,17 +2000,6 @@
         <add name="Vertex Weight" type="float">The amount that this bone affects the vertex.</add>
         <add name="Vertex Index" type="ushort">The index of the vertex that this weight applies to.</add>
         <add name="Unknown Vector" type="Vector3">Unknown.  Perhaps some sort of offset?</add>
-    </compound>
-
-    <compound name="MultiTextureElement">
-        <add name="Has Image" type="bool">Looks like a memory address, so probably a bool.</add>
-        <add name="Image" type="Ref" template="NiImage" cond="Has Image">Link to the texture image.</add>
-        <add name="Clamp?" type="TexClampMode" cond="Has Image" default="WRAP_S_WRAP_T">May be texture clamp mode.</add>
-        <add name="Filter?" type="TexFilterMode" cond="Has Image" default="FILTER_TRILERP">May be texture filter mode.</add>
-        <add name="UV Set?" type="uint" cond="Has Image" default="1">This may be the UV set counting from 1 instead of zero.</add>
-        <add name="PS2 L" type="short" cond="Has Image" default="0" ver1="3.03" ver2="10.2.0.0">0?</add>
-        <add name="PS2 K" type="short" cond="Has Image" default="-75" ver1="3.03" ver2="10.2.0.0">-75?</add>
-        <add name="Unknown Short 3" type="short" cond="Has Image" default="0" ver1="3.03">Unknown.  Usually 0 but sometimes 257</add>
     </compound>
 
     <enum name="ImageType" storage="uint">
@@ -3810,73 +3871,64 @@
         <add name="Float Data" type="Ref" template="NiFloatData">Path controller data index (float data). ?</add>
     </niobject>
 
-    <enum name="ChannelType" storage="uint">
-        <option value="0" name="CHNL_RED">Red</option>
-        <option value="1" name="CHNL_GREEN">Green</option>
-        <option value="2" name="CHNL_BLUE">Blue</option>
-        <option value="3" name="CHNL_ALPHA">Alpha</option>
-        <option value="4" name="CHNL_COMPRESSED">Compressed</option>
-        <option value="16" name="CHNL_INDEX">Index</option>
-        <option value="19" name="CHNL_EMPTY">Empty</option>
-    </enum>
-
-    <enum name="ChannelConvention" storage="uint">
-        <option value="0" name="CC_FIXED">Fixed</option>
-        <option value="3" name="CC_INDEX">Palettized</option>
-        <option value="4" name="CC_COMPRESSED">Compressed</option>
-        <option value="5" name="CC_EMPTY">Empty</option>
-    </enum>
-
-    <compound name="ChannelData">
-        Channel data
-        <add name="Type" type="ChannelType">Channel Type</add>
-        <add name="Convention" type="ChannelConvention">Data Storage Convention</add>
-        <add name="Bits Per Channel" type="byte">Bits per channel</add>
-        <add name="Unknown Byte 1" type="byte">Unknown</add>
+    <compound name="PixelFormatComponent">
+        <add name="Type" type="PixelComponent">Component Type</add>
+        <add name="Convention" type="PixelRepresentation">Data Storage Convention</add>
+        <add name="Bits Per Channel" type="byte">Bits per component</add>
+        <add name="Signed" type="bool" />
     </compound>
 
-    <niobject name="ATextureRenderData" abstract="1" inherit="NiObject">
+    <!--
+        NiPixelFormat is not the parent to NiPixelData/NiPersistentSrcTextureRendererData,
+        but actually a member class loaded at the top of each. The two classes are not related.
+        However, faking this inheritance is useful for several things.    
+    -->
+    <niobject name="NiPixelFormat" abstract="1" inherits="NiObject">
         <add name="Pixel Format" type="PixelFormat">The format of the pixels in this internally stored image.</add>
-        <add name="Red Mask" type="uint" ver2="10.2.0.0">0x000000ff (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
-        <add name="Green Mask" type="uint" ver2="10.2.0.0">0x0000ff00 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
-        <add name="Blue Mask" type="uint" ver2="10.2.0.0">0x00ff0000 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
-        <add name="Alpha Mask" type="uint" ver2="10.2.0.0">0xff000000 (for 32bpp) or 0x00000000 (for 24bpp and 8bpp)</add>
-        <add name="Bits Per Pixel" type="byte" ver2="10.2.0.0">Bits per pixel, 0 (?), 8, 24 or 32.</add>
-        <add name="Unknown 3 Bytes" type="byte" arr1="3" ver2="10.2.0.0">Zero?</add>
-        <add name="Unknown 8 Bytes" type="byte" arr1="8" ver2="10.2.0.0">
+        <add name="Red Mask" type="uint" ver2="10.3.0.2">0x000000ff (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
+        <add name="Green Mask" type="uint" ver2="10.3.0.2">0x0000ff00 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
+        <add name="Blue Mask" type="uint" ver2="10.3.0.2">0x00ff0000 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
+        <add name="Alpha Mask" type="uint" ver2="10.3.0.2">0xff000000 (for 32bpp) or 0x00000000 (for 24bpp and 8bpp)</add>
+        <add name="Bits Per Pixel" type="uint" ver2="10.3.0.2">Bits per pixel, 0 (Compressed), 8, 24 or 32.</add>
+        <add name="Old Fast Compare" type="byte" arr1="8" ver2="10.3.0.2">
             [96,8,130,0,0,65,0,0] if 24 bits per pixel
             [129,8,130,32,0,65,12,0] if 32 bits per pixel
             [34,0,0,0,0,0,0,0] if 8 bits per pixel
-            [4,0,0,0,0,0,0,0] if 0 (?) bits per pixel
+            [X,0,0,0,0,0,0,0] if 0 (Compressed) bits per pixel where X = PixelFormat
         </add>
-        <add name="Unknown Int" type="uint" ver1="10.1.0.0" ver2="10.2.0.0">Seems to always be zero.</add>
-        <add name="Bits Per Pixel" type="byte" ver1="20.0.0.4">Bits per pixel, 0 (?), 8, 24 or 32.</add>
-        <add name="Unknown Int 2" type="int" ver1="20.0.0.4">Unknown.  Could be reference pointer.</add>
-        <add name="Unknown Int 3" type="uint" ver1="20.0.0.4">Seems to always be zero.</add>
-        <add name="Flags" type="byte" ver1="20.0.0.4">Flags</add>
-        <add name="Unknown Int 4" type="uint" ver1="20.0.0.4">Unkown. Often zero.</add>
-        <add name="Unknown Byte 1" type="byte" ver1="20.3.0.6">Unknown.</add>
-        <add name="Channels" type="ChannelData" arr1="4" ver1="20.0.0.4">Channel Data</add>
-        <add name="Palette" type="Ref" template="NiPalette">Link to NiPalette, for 8-bit textures.</add>
-        <add name="Num Mipmaps" type="uint">Number of mipmaps in the texture.</add>
-        <add name="Bytes Per Pixel" type="uint">Bytes per pixel (Bits Per Pixel / 8).</add>
-        <add name="Mipmaps" type="MipMap" arr1="Num Mipmaps">Mipmap descriptions (width, height, offset).</add>
+        <add name="Tiling" type="PixelTiling" ver1="10.1.0.0" ver2="10.3.0.2">Seems to always be zero.</add>
+        <add name="Bits Per Pixel" type="byte" ver1="10.3.0.3">Bits per pixel, 0 (Compressed), 8, 24 or 32.</add>
+        <add name="Renderer Hint" type="uint" ver1="10.3.0.3" />
+        <add name="Extra Data" type="uint" ver1="10.3.0.3" />
+        <add name="Flags" type="byte" ver1="10.3.0.3">Flags</add>
+        <add name="Tiling" type="PixelTiling" ver1="10.3.0.3" />
+        <add name="sRGB Space" type="bool" ver1="20.3.0.4" />
+        <add name="Channels" type="PixelFormatComponent" arr1="4" ver1="10.3.0.3">Channel Data</add>
     </niobject>
 
-    <niobject name="NiPersistentSrcTextureRendererData" inherit="ATextureRenderData">
-        <add name="Num Pixels" type="uint">Unknown</add>
-        <add name="Unknown Int 6" type="uint">Unknown, same as the number of pixels? / number of blocks?</add>
-        <add name="Num Faces" type="uint">Unknown</add>
-        <add name="Unknown Int 7" type="uint">Unknown</add>
-        <add name="Pixel Data" type="byte" binary="1" arr1="Num Faces" arr2="Num Pixels">Raw pixel data holding the mipmaps.  Mipmap zero is the full-size texture and they get smaller by half as the number increases.</add>
+    <niobject name="NiPersistentSrcTextureRendererData" inherit="NiPixelFormat">
+        <add name="Palette" type="Ref" template="NiPalette" />
+        <add name="Num Mipmaps" type="uint" />
+        <add name="Bytes Per Pixel" type="uint" />
+        <add name="Mipmaps" type="MipMap" arr1="Num Mipmaps" />
+        <add name="Num Pixels" type="uint" />
+        <add name="Pad Num Pixels" type="uint" ver1="20.2.0.6" />
+        <add name="Num Faces" type="uint" />
+        <add name="Platform" type="PlatformID" ver2="30.1.0.0" />
+        <add name="Renderer" type="RendererID" ver1="30.1.0.1" />
+        <add name="Pixel Data" type="byte" binary="1" arr1="Num Pixels * Num Faces" />
     </niobject>
 
-    <niobject name="NiPixelData" abstract="0" inherit="ATextureRenderData">
+    <niobject name="NiPixelData" abstract="0" inherit="NiPixelFormat">
         A texture.
-        <add name="Num Pixels" type="uint">Total number of pixels</add>
-        <add name="Num Faces" type="uint" ver1="20.0.0.4" default="1">Unknown</add>
-        <add name="Pixel Data" type="byte" binary="1" arr1="Num Faces" arr2="Num Pixels" ver1="20.0.0.4">Raw pixel data holding the mipmaps.  Mipmap zero is the full-size texture and they get smaller by half as the number increases.</add>
-        <add name="Pixel Data" type="byte" binary="1" arr1="1" arr2="Num Pixels" ver2="10.2.0.0">Raw pixel data holding the mipmaps.  Mipmap zero is the full-size texture and they get smaller by half as the number increases.</add>
+        <add name="Palette" type="Ref" template="NiPalette" />
+        <add name="Num Mipmaps" type="uint" />
+        <add name="Bytes Per Pixel" type="uint" />
+        <add name="Mipmaps" type="MipMap" arr1="Num Mipmaps" />
+        <add name="Num Pixels" type="uint" />
+        <add name="Num Faces" type="uint" ver1="10.3.0.6" default="1" />
+        <add name="Pixel Data" type="byte" binary="1" arr1="Num Pixels" ver2="10.3.0.5" />
+        <add name="Pixel Data" type="byte" binary="1" arr1="Num Pixels * Num Faces" ver1="10.3.0.6" />
     </niobject>
 
     <niobject name="NiPlanarCollider" abstract="0" inherit="NiParticleModifier">
@@ -4317,13 +4369,13 @@
         <add name="Unknown Link" type="Ref" template="NiObject" cond="Use External == 1" ver1="10.1.0.0">Unknown.</add>
         <add name="Unknown Byte" type="byte" default="1" cond="Use External == 0" ver2="10.0.1.0">Unknown. Seems to be set if Pixel Data is present?</add>
         <add name="File Name" type="FilePath" cond="Use External == 0" ver1="10.1.0.0">The original source filename of the image embedded by the referred NiPixelData object.</add>
-        <add name="Pixel Data" type="Ref" template="ATextureRenderData" cond="Use External == 0">Pixel data object index. NiPixelData or NiPersistentSrcTextureRendererData</add>
+        <add name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0">Pixel data object index. NiPixelData or NiPersistentSrcTextureRendererData</add>
         <add name="Pixel Layout" type="PixelLayout" default="PIX_LAY_PALETTISED_4">Specifies the way the image will be stored.</add>
         <add name="Use Mipmaps" type="MipMapFormat" default="MIP_FMT_DEFAULT">Specifies whether mip maps are used.</add>
         <add name="Alpha Format" type="AlphaFormat" default="ALPHA_DEFAULT"> Note: the NiTriShape linked to this object must have a NiAlphaProperty in its list of properties to enable material and/or texture transparency.</add>
         <add name="Is Static" type="byte" default="1">Is Static?</add>
-        <add name="Direct Render" type="bool" default="1" ver1="10.1.0.106">Load direct to renderer</add>
-        <add name="Persist Render Data" type="bool" default="0" ver1="20.2.0.7">Render data is persistant</add>
+        <add name="Direct Render" type="bool" default="1" ver1="10.1.0.103">Load direct to renderer</add>
+        <add name="Persist Render Data" type="bool" default="0" ver1="20.2.0.4">Render data is persistant</add>
     </niobject>
 
     <niobject name="NiSpecularProperty" abstract="0" inherit="NiProperty">
@@ -4440,19 +4492,12 @@
         <add name="Unknown Ints 2" type="uint" arr1="2" ver1="3.0" ver2="3.03">Unknown.  0?</add>
     </niobject>
 
-    <niobject name="NiMultiTextureProperty" abstract="0" inherit="NiProperty">
-        (note: not quite complete yet... but already reads most of the DAoC ones)
-        <add name="Flags" type="Flags">Property flags.</add>
-        <add name="Unknown Int" type="uint">Unknown. Always 5 for DAoC files, and always 6 for Bridge Commander.  Seems to have nothing to do with the number of Texture Element slots that follow.</add>
-        <add name="Texture Elements" type="MultiTextureElement" arr1="5">Describes the various textures used by this mutli-texture property.  Each slot probably has special meaning like thoes in NiTexturingProperty.</add>
-    </niobject>
-
     <niobject name="NiTexturingProperty" abstract="0" inherit="NiProperty">
         Describes an object&#039;s textures.
         <add name="Flags" type="Flags" ver2="10.0.1.2">Property flags.</add>
-        <add name="Flags" type="Flags" ver1="20.1.0.3">Property flags.</add>
-        <add name="Apply Mode" type="ApplyMode" default="APPLY_MODULATE" ver2="20.0.0.5">Determines how the texture will be applied.  Seems to have special functions in Oblivion.</add>
-        <add name="Texture Count" type="uint" default="7">Number of textures. Always 7 in versions &lt; 20.0.0.4. Can also be 8 in &gt;= 20.0.0.4.</add>
+        <add name="Flags" type="Flags" ver1="20.1.0.2">Property flags.</add>
+        <add name="Apply Mode" type="ApplyMode" default="APPLY_MODULATE" ver1="3.3.0.13" ver2="20.1.0.1">Determines how the texture will be applied.  Seems to have special functions in Oblivion.</add>
+        <add name="Texture Count" type="uint" default="7">Number of textures.</add>
         <add name="Has Base Texture" type="bool">Do we have a base texture?</add>
         <add name="Base Texture" type="TexDesc" cond="Has Base Texture">The base texture.</add>
         <add name="Has Dark Texture" type="bool">Do we have a dark texture?</add>
@@ -4463,30 +4508,33 @@
         <add name="Gloss Texture" type="TexDesc" cond="Has Gloss Texture">The gloss texture.</add>
         <add name="Has Glow Texture" type="bool">Do we have a glow texture?</add>
         <add name="Glow Texture" type="TexDesc" cond="Has Glow Texture">The glowing texture.</add>
-        <add name="Has Bump Map Texture" type="bool">Do we have a bump map texture?</add>
+        <add name="Has Bump Map Texture" type="bool" ver1="3.3.0.13" cond="Texture Count &gt; 5">Do we have a bump map texture?</add>
         <add name="Bump Map Texture" type="TexDesc" cond="Has Bump Map Texture">The bump map texture.</add>
         <add name="Bump Map Luma Scale" type="float" cond="Has Bump Map Texture">Unknown.</add>
         <add name="Bump Map Luma Offset" type="float" cond="Has Bump Map Texture">Unknown.</add>
         <add name="Bump Map Matrix" type="Matrix22" cond="Has Bump Map Texture">Unknown.</add>
-        <add name="Has Normal Texture" type="bool" ver1="20.2.0.7">Do we have a normal texture?  (Noraml guess based on file suffix in sample files)</add>
-        <add name="Normal Texture" type="TexDesc" cond="Has Normal Texture" ver1="20.2.0.7">Normal texture.</add>
-        <add name="Has Unknown2 Texture" type="bool" ver1="20.2.0.7">Do we have a unknown texture 2?</add>
-        <add name="Unknown2 Texture" type="TexDesc" cond="Has Unknown2 Texture" ver1="20.2.0.7">Unknown texture 2.</add>
-        <add name="Unknown2 Float" type="float" cond="Has Unknown2 Texture">Unknown.</add>
-        <add name="Has Decal 0 Texture" type="bool">Do we have a decal 0 texture?</add>
+        <add name="Has Normal Texture" type="bool" cond="Texture Count &gt; 6" ver1="20.2.0.5">Do we have a normal texture?</add>
+        <add name="Normal Texture" type="TexDesc" cond="Has Normal Texture">Normal texture.</add>
+        <add name="Has Parallax Texture" type="bool" cond="Texture Count &gt; 7" ver1="20.2.0.5" />
+        <add name="Parallax Texture" type="TexDesc" cond="Has Parallax Texture" />
+        <add name="Parallax Offset" type="float" cond="Has Parallax Texture" />
+        <add name="Has Decal 0 Texture" type="bool" cond="Texture Count &gt; 6" ver2="20.2.0.4">Do we have a decal 0 texture?</add>
+        <add name="Has Decal 0 Texture" type="bool" cond="Texture Count &gt; 8" ver1="20.2.0.5">Do we have a decal 0 texture?</add>
         <add name="Decal 0 Texture" type="TexDesc" cond="Has Decal 0 Texture">The decal texture.</add>
-        <add name="Has Decal 1 Texture" type="bool" cond="Texture Count &gt;= 8" ver2="20.1.0.3">Do we have a decal 1 texture?</add>
-        <add name="Has Decal 1 Texture" type="bool" cond="Texture Count &gt;= 10" ver1="20.2.0.7">Do we have a decal 1 texture?</add>
+        <add name="Has Decal 1 Texture" type="bool" cond="Texture Count &gt; 7" ver2="20.2.0.4">Do we have a decal 1 texture?</add>
+        <add name="Has Decal 1 Texture" type="bool" cond="Texture Count &gt; 9" ver1="20.2.0.5">Do we have a decal 1 texture?</add>
         <add name="Decal 1 Texture" type="TexDesc" cond="Has Decal 1 Texture">Another decal texture.</add>
-        <add name="Has Decal 2 Texture" type="bool" cond="Texture Count &gt;= 9" ver2="20.1.0.3">Do we have a decal 2 texture?</add>
-        <add name="Has Decal 2 Texture" type="bool" cond="Texture Count &gt;= 11" ver1="20.2.0.7">Do we have a decal 2 texture?</add>
+        <add name="Has Decal 2 Texture" type="bool" cond="Texture Count &gt; 8" ver2="20.2.0.4">Do we have a decal 2 texture?</add>
+        <add name="Has Decal 2 Texture" type="bool" cond="Texture Count &gt; 10" ver1="20.2.0.5">Do we have a decal 2 texture?</add>
         <add name="Decal 2 Texture" type="TexDesc" cond="Has Decal 2 Texture">Another decal texture.</add>
-        <add name="Has Decal 3 Texture" type="bool" cond="Texture Count &gt;= 10" ver2="20.1.0.3">Do we have a decal 3 texture?</add>
-        <add name="Has Decal 3 Texture" type="bool" cond="Texture Count &gt;= 12" ver1="20.2.0.7">Do we have a decal 3 texture?</add>
+        <add name="Has Decal 3 Texture" type="bool" cond="Texture Count &gt; 9" ver2="20.2.0.4">Do we have a decal 3 texture?</add>
+        <add name="Has Decal 3 Texture" type="bool" cond="Texture Count &gt; 11" ver1="20.2.0.5">Do we have a decal 3 texture?</add>
         <add name="Decal 3 Texture" type="TexDesc" cond="Has Decal 3 Texture">Another decal texture. Who knows the limit.</add>
         <add name="Num Shader Textures" type="uint" ver1="10.0.1.0">Number of Shader textures that follow.</add>
         <add name="Shader Textures" type="ShaderTexDesc" arr1="Num Shader Textures" ver1="10.0.1.0">Shader textures.</add>
     </niobject>
+
+    <niobject name="NiMultiTextureProperty" abstract="0" inherit="NiTexturingProperty" />
 
     <niobject name="NiTransformData" abstract="0" inherit="NiKeyframeData">
         Mesh animation keyframe data.

--- a/nif.xml
+++ b/nif.xml
@@ -738,7 +738,7 @@
     </enum>
 
     <enum name="FieldType" storage="uint">
-        The force field&#039;s type.
+        The force field type.
         <option value="0" name="FIELD_WIND">Wind (fixed direction)</option>
         <option value="1" name="FIELD_POINT">Point (fixed origin)</option>
     </enum>
@@ -2240,7 +2240,7 @@
 
 
     <niobject name="NiParticleModifier" abstract="1" inherit="NiObject">
-        A particle system modifier.
+        LEGACY (pre-10.1). Abstract base class for particle system modifiers.
         <add name="Next Modifier" type="Ref" template="NiParticleModifier">Next particle modifier.</add>
         <add name="Controller" type="Ptr" template="NiParticleSystemController" ver1="4.0.0.2">Points to the particle system controller parent.</add>
     </niobject>
@@ -2360,7 +2360,7 @@
     </niobject>
 
     <niobject name="bhkRigidBodyT" abstract="0" inherit="bhkRigidBody">
-        Unknown.
+        The "T" suffix marks this body as active for translation and rotation.
     </niobject>
 
     <niobject name="bhkConstraint" abstract="1" inherit="bhkSerializable">
@@ -2585,15 +2585,15 @@
     </niobject>
 
     <niobject name="NiInterpolator" abstract="1" inherit="NiObject">
-        Interpolator objects - function unknown.
+        Abstract base class for all interpolators of bool, float, NiQuaternion, NiPoint3, NiColorA, and NiQuatTransform data.
     </niobject>
 
     <niobject name="NiKeyBasedInterpolator" abstract="1" inherit="NiInterpolator">
-        Interpolator objects that use keys?
+        Abstract base class for interpolators that use NiAnimationKeys (Key, KeyGrp) for interpolation.
     </niobject>
 
     <niobject name="NiFloatInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
-        Unknown.
+        Uses NiFloatKeys to animate a float value over time.
         <add name="Float Value" type="float">Value when posed?  At time 0?</add>
         <add name="Data" type="Ref" template="NiFloatData">Float data?</add>
     </niobject>
@@ -2609,7 +2609,7 @@
     </niobject>
 
     <niobject name="NiPoint3Interpolator" abstract="0" inherit="NiKeyBasedInterpolator">
-        Unknown.
+        Uses NiPosKeys to animate an NiPoint3 value over time.
         <add name="Point 3 Value" type="Vector3">Value when posed?  Value at time 0?</add>
         <add name="Data" type="Ref" template="NiPosData">Reference to NiPosData.</add>
     </niobject>
@@ -2625,7 +2625,7 @@
     </enum>
 
     <niobject name="NiPathInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
-        Unknown interpolator.
+        Used to make an object follow a predefined spline path.
         <add name="Flags" type="PathFlags" />
         <add name="Bank Dir" type="uint" />
         <add name="Max Bank Angle" type="float" />
@@ -2636,13 +2636,14 @@
     </niobject>
 
     <niobject name="NiBoolInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
-        Unknown.
+        Uses NiBoolKeys to animate a bool value over time.
         <add name="Bool Value" type="bool">Value when posed?  At time 0?</add>
         <add name="Data" type="Ref" template="NiBoolData">Refers to a NiBoolData object.</add>
     </niobject>
 
     <niobject name="NiBoolTimelineInterpolator" abstract="0" inherit="NiBoolInterpolator">
-        Unknown.
+        Uses NiBoolKeys to animate a bool value over time.
+        Unlike NiBoolInterpolator, it ensures that keys have not been missed between two updates.
     </niobject>
 
     <enum name="InterpBlendFlags" storage="byte">
@@ -2659,7 +2660,7 @@
     </compound>
 
     <niobject name="NiBlendInterpolator" abstract="1" inherit="NiInterpolator">
-        An extended type of interpolater.
+        Abstract base class for all NiInterpolators that blend the results of sub-interpolators together to compute a final weighted value.
         <add name="Flags" type="InterpBlendFlags" />
         <add name="Array Size" type="byte" />
         <add name="Weight Threshold" type="float" />
@@ -2675,7 +2676,7 @@
     </niobject>
 
     <niobject name="NiBSplineInterpolator" abstract="1" inherit="NiInterpolator">
-        For interpolators storing data via a B-spline.
+        Abstract base class for interpolators storing data via a B-spline.
         <add name="Start Time" type="float">Animation start time.</add>
         <add name="Stop Time" type="float">Animation stop time.</add>
         <add name="Spline Data" type="Ref" template="NiBSplineData">Refers to NiBSplineData.</add>
@@ -2683,7 +2684,7 @@
     </niobject>
 
     <niobject name="NiObjectNET" abstract="1" inherit="NiObject">
-        An object that can be controlled by a controller.
+        Abstract base class for NiObjects that support names, extra data, and time controllers.
         <add name="Skyrim Shader Type" type="BSLightingShaderPropertyShaderType" vercond="User Version >= 12" cond="BSLightingShaderProperty">Configures the main shader path</add>
         <add name="Name" type="string">Name of this controllable object, used to refer to the object in .kf files.</add>
         <add name="Has Old Extra Data" type="bool" ver2="2.3">Extra data for pre-3.0 versions.</add>
@@ -2756,7 +2757,7 @@
     </niobject>
 
     <niobject name="NiAVObject" abstract="1" inherit="NiObjectNET">
-        Base audiovisual object.
+        Abstract audio-visual base class from which all of Gamebryo's scene graph objects inherit.
         <add name="Flags" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects.</add>
         <add name="Flags" type="Flags" ver1="3.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26))">Basic flags for AV objects; commonly 0x000C or 0x000A.</add>
         <!-- TODO use MTransform -->
@@ -2774,7 +2775,7 @@
     </niobject>
 
     <niobject name="NiDynamicEffect" abstract="1" inherit="NiAVObject">
-        A dynamic effect such as a light or environment map.
+        Abstract base class for dynamic effects such as NiLights or projected texture effects.
         <add name="Switch State" type="bool" ver1="10.1.0.106" vercond="User Version 2 &lt; 130">Turns effect on and off?  Switches list to list of unaffected nodes?</add>
         <add name="Num Affected Node List Pointers" type="uint" ver2="4.0.0.2" >The number of affected nodes referenced.</add>
         <add name="Affected Node List Pointers" type="uint" arr1="Num Affected Node List Pointers" ver2="4.0.0.2">This is probably the list of affected nodes. For some reason i do not know the max exporter seems to write pointers instead of links. But it doesn&#039;t matter because at least in version 4.0.0.2 the list is automagically updated by the engine during the load stage.</add>
@@ -2783,7 +2784,7 @@
     </niobject>
 
     <niobject name="NiLight" abstract="1" inherit="NiDynamicEffect">
-        Light source.
+        Abstract base class that represents light sources in a scene graph.
         <add name="Dimmer" type="float">Dimmer.</add>
         <add name="Ambient Color" type="Color3">Ambient color.</add>
         <add name="Diffuse Color" type="Color3">Diffuse color.</add>
@@ -2791,7 +2792,7 @@
     </niobject>
 
     <niobject name="NiProperty" abstract="1" inherit="NiObjectNET">
-        A generic property object.
+        Abstract base class representing all rendering properties. Subclasses are attached to NiAVObjects to control their rendering.
     </niobject>
 
     <niobject name="NiTransparentProperty" abstract="0" inherit="NiProperty">
@@ -2800,7 +2801,7 @@
     </niobject>
 
     <niobject name="NiPSysModifier" abstract="1" inherit="NiObject">
-        Generic particle system modifier object.
+        Abstract base class for all particle system modifiers.
         <add name="Name" type="string">The object name.</add>
         <add name="Order" type="uint">Modifier ID in the particle modifier chain (always a multiple of 1000)?</add>
         <add name="Target" type="Ptr" template="NiParticleSystem">NiParticleSystem parent of this modifier.</add>
@@ -2808,7 +2809,7 @@
     </niobject>
 
     <niobject name="NiPSysEmitter" abstract="1" inherit="NiPSysModifier">
-        A particle emitter?
+        Abstract base class for all particle system emitters.
         <add name="Speed" type="float">Speed / Inertia of particle movement.</add>
         <add name="Speed Variation" type="float">Adds an amount of randomness to Speed.</add>
         <add name="Declination" type="float">Declination / First axis.</add>
@@ -2823,12 +2824,12 @@
     </niobject>
 
     <niobject name="NiPSysVolumeEmitter" abstract="1" inherit="NiPSysEmitter">
-        An emitter that emits meshes?
+        Abstract base class for particle emitters that emit particles from a volume.
         <add name="Emitter Object" type="Ptr" template="NiNode" ver1="10.1.0.0">Node parent of this modifier?</add>
     </niobject>
 
     <niobject name="NiTimeController" abstract="1" inherit="NiObject">
-        A generic time controller object.
+        Abstract base class that provides the base timing and update functionality for all the Gamebryo animation controllers.
         <add name="Next Controller" type="Ref" template="NiTimeController">Index of the next controller.</add>
         <add name="Flags" type="Flags">
             Controller flags.
@@ -2849,16 +2850,17 @@
 
 
     <niobject name="NiInterpController" abstract="1" inherit="NiTimeController">
-        A controller capable of interpolation?
+        Abstract base class for all NiTimeController objects using NiInterpolator objects to animate their target objects.
     </niobject>
 
     <niobject name="NiMultiTargetTransformController" abstract="0" inherit="NiInterpController">
-        Unknown.
+        DEPRECATED (20.6)
         <add name="Num Extra Targets" type="ushort">The number of target pointers that follow.</add>
         <add name="Extra Targets" type="Ptr" template="NiAVObject" arr1="Num Extra Targets">NiNode Targets to be controlled.</add>
     </niobject>
 
     <niobject name="NiGeomMorpherController" abstract="0" inherit="NiInterpController">
+        DEPRECATED (20.5), replaced by NiMorphMeshModifier.
         Time controller for geometry morphing.
         <add name="Extra Flags" type="Flags" ver1="10.0.1.2">Unknown.</add>
         <add name="Unknown 2" type="byte" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
@@ -2881,17 +2883,18 @@
     </niobject>
 
     <niobject name="NiSingleInterpController" abstract="1" inherit="NiInterpController">
-        A controller referring to a single interpolator.
+        Uses a single NiInterpolator to animate its target value.
         <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.2.0.0">Link to interpolator.</add>
     </niobject>
 
     <niobject name="NiKeyframeController" abstract="0" inherit="NiSingleInterpController">
+        DEPRECATED (10.2), RENAMED (10.2) to NiTransformController
         A time controller object for animation key frames.
         <add name="Data" type="Ref" template="NiKeyframeData" ver2="10.1.0.0">Keyframe controller data index.</add>
     </niobject>
 
     <niobject name="NiTransformController" abstract="0" inherit="NiKeyframeController">
-        NiTransformController replaces the NiKeyframeController.
+        NiTransformController replaces NiKeyframeController.
     </niobject>
 
     <niobject name="NiPSysModifierCtlr" abstract="1" inherit="NiSingleInterpController">
@@ -2906,16 +2909,16 @@
     </niobject>
 
     <niobject name="NiPSysModifierBoolCtlr" abstract="1" inherit="NiPSysModifierCtlr">
-        A particle system modifier controller that deals with boolean data?
+        A particle system modifier controller that animates a boolean value for particles.
     </niobject>
 
     <niobject name="NiPSysModifierActiveCtlr" abstract="0" inherit="NiPSysModifierBoolCtlr">
-        Unknown.
+        A particle system modifier controller that animates active/inactive state for particles.
         <add name="Data" type="Ref" template="NiVisData" ver2="10.1.0.0">This controller's data.</add>
     </niobject>
 
     <niobject name="NiPSysModifierFloatCtlr" abstract="1" inherit="NiPSysModifierCtlr">
-        A particle system modifier controller that deals with floating point data?
+        A particle system modifier controller that animates a floating point value for particles.
         <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0">This controller's data.</add>
     </niobject>
 
@@ -2945,11 +2948,12 @@
 
 
     <niobject name="NiFloatInterpController" abstract="1" inherit="NiSingleInterpController">
-        A controller that interpolates floating point numbers?
+        Abstract base class for all NiInterpControllers that use an NiInterpolator to animate their target float value.
     </niobject>
 
     <niobject name="NiFlipController" abstract="0" inherit="NiFloatInterpController">
-        Texture flipping controller.
+        Changes the image a Map (TexDesc) will use. Uses a float interpolator to animate the texture index.
+        Often used for performing flipbook animation.
         <add name="Texture Slot" type="TexType">Target texture slot (0=base, 4=glow).</add>
         <add name="Unknown Int 2" type="uint" ver1="4.0.0.0" ver2="10.1.0.0">0?</add>
         <add name="Delta" type="float" ver2="10.1.0.0">
@@ -2962,7 +2966,7 @@
     </niobject>
 
     <niobject name="NiAlphaController" abstract="0" inherit="NiFloatInterpController">
-        Time controller for transparency.
+        Animates the alpha value of a property using an interpolator.
         <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0">Alpha controller data index.</add>
     </niobject>
 
@@ -2979,16 +2983,16 @@
     </niobject>
 
     <niobject name="NiBoolInterpController" abstract="1" inherit="NiSingleInterpController">
-        A controller that interpolates floating point numbers?
+        Abstract base class for all NiInterpControllers that use a NiInterpolator to animate their target boolean value.
     </niobject>
 
     <niobject name="NiVisController" abstract="0" inherit="NiBoolInterpController">
-        Time controller for visibility.
+        Animates the visibility of an NiAVObject.
         <add name="Data" type="Ref" template="NiVisData" ver2="10.1.0.0">Visibility controller data object index.</add>
     </niobject>
 
     <niobject name="NiPoint3InterpController" abstract="1" inherit="NiSingleInterpController">
-        A controller that interpolates point 3 data?
+        Abstract base class for all NiInterpControllers that use a NiInterpolator to animate their target NiPoint3 value.
         <add name="Target Color" type="TargetColor" ver1="10.1.0.0">Selects which color to control.</add>
         <add name="Data" type="Ref" template="NiPosData" ver2="10.1.0.0">Material color controller data object index. Points to NiPosData.</add>
     </niobject>
@@ -3000,16 +3004,16 @@
     </niobject>
 
     <niobject name="NiLightColorController" abstract="0" inherit="NiPoint3InterpController">
-        Light color animation controller.
+        Animates the ambient, diffuse and specular colors of an NiLight.
     </niobject>
 
 
     <niobject name="NiExtraDataController" abstract="1" inherit="NiSingleInterpController">
-        An controller for extra data.
+        Abstract base class for all extra data controllers.
     </niobject>
 
     <niobject name="NiFloatExtraDataController" abstract="0" inherit="NiExtraDataController">
-        Unknown.
+        Animates an NiFloatExtraData object attached to an NiAVObject.
         <add name="Controller Data" type="string" ver1="10.2.0.0">Refers to a NiFloatExtraData name.</add>
         <add name="Num Extra Bytes" type="byte" ver2="10.1.0.0">Number of extra bytes.</add>
         <add name="Unknown Bytes" type="byte" arr1="7" ver2="10.1.0.0">Unknown.</add>
@@ -3017,6 +3021,7 @@
     </niobject>
 
     <niobject name="NiBoneLODController" abstract="0" inherit="NiTimeController">
+        DEPRECATED (20.5), Replaced by NiSkinningLODController.
         Level of detail controller for bones.  Priority is arranged from low to high.
         <add name="LOD" type="uint">Unknown.</add>
         <add name="Num LODs" type="uint">Number of LODs.</add>
@@ -3334,26 +3339,26 @@
     </niobject>
 
     <niobject name="NiBlendBoolInterpolator" abstract="0" inherit="NiBlendInterpolator">
-        An interpolator for a bool.
+        Blends bool values together.
         <add name="Bool Value" type="byte">The interpolated bool?</add>
     </niobject>
 
     <niobject name="NiBlendFloatInterpolator" abstract="0" inherit="NiBlendInterpolator">
-        An interpolator for a float.
+        Blends float values together.
         <add name="Float Value" type="float">The interpolated float?</add>
     </niobject>
 
     <niobject name="NiBlendPoint3Interpolator" abstract="0" inherit="NiBlendInterpolator">
-        Interpolates a point?
+        Blends NiPoint3 values together.
         <add name="Point Value" type="Vector3">The interpolated point?</add>
     </niobject>
 
     <niobject name="NiBlendTransformInterpolator" abstract="0" inherit="NiBlendInterpolator">
-        Unknown.
+        Blends NiQuatTransform values together.
     </niobject>
 
     <niobject name="NiBoolData" abstract="0" inherit="NiObject">
-        Timed boolean data.
+        Wrapper for boolean animation keys.
         <add name="Data" type="KeyGroup" template="byte">The boolean keys.</add>
     </niobject>
 
@@ -3363,16 +3368,16 @@
     </niobject>
 
     <niobject name="NiBSplineBasisData" abstract="0" inherit="NiObject">
-        Stores the number of control points of a B-spline.
+        Contains an NiBSplineBasis for use in interpolation of open, uniform B-Splines.
         <add name="Num Control Points" type="uint">The number of control points of the B-spline (number of frames of animation plus degree of B-spline minus one).</add>
     </niobject>
 
     <niobject name="NiBSplineFloatInterpolator" abstract="1" inherit="NiBSplineInterpolator">
-        Unknown.
+        Uses B-Splines to animate a float value over time.
     </niobject>
 
     <niobject name="NiBSplineCompFloatInterpolator" abstract="0" inherit="NiBSplineFloatInterpolator">
-        Unknown.
+        NiBSplineFloatInterpolator plus the information required for using compact control points.
         <add name="Base" type="float">Base value when curve not defined.</add>
         <add name="Offset" type="uint">Starting offset for the data. (USHRT_MAX for no data.)</add>
         <add name="Bias" type="float">Bias</add>
@@ -3380,16 +3385,17 @@
     </niobject>
 
     <niobject name="NiBSplinePoint3Interpolator" abstract="1" inherit="NiBSplineInterpolator">
-        Unknown.
+        Uses B-Splines to animate an NiPoint3 value over time.
         <add name="Unknown Floats" type="float" arr1="6">Unknown.</add>
     </niobject>
 
     <niobject name="NiBSplineCompPoint3Interpolator" abstract="0" inherit="NiBSplinePoint3Interpolator">
-        Unknown.
+        NiBSplinePoint3Interpolator plus the information required for using compact control points.
     </niobject>
 
     <niobject name="NiBSplineTransformInterpolator" abstract="0" inherit="NiBSplineInterpolator">
-        An interpolator for storing transform keyframes via a B-spline.
+        Supports the animation of position, rotation, and scale using an NiQuatTransform.
+        The NiQuatTransform can be an unchanging pose or interpolated from B-Spline control point channels.
         <!-- TODO use QTransform -->
         <add name="Translation" type="Vector3">Base translation when translate curve not defined.</add>
         <add name="Rotation" type="Quaternion">Base rotation when rotation curve not defined.</add>
@@ -3400,9 +3406,7 @@
     </niobject>
 
     <niobject name="NiBSplineCompTransformInterpolator" abstract="0" inherit="NiBSplineTransformInterpolator">
-        An interpolator for storing transform keyframes via a compressed
-        B-spline (that is, using shorts rather than floats in the B-spline
-        data).
+        NiBSplineTransformInterpolator plus the information required for using compact control points.
         <add name="Translation Bias" type="float">Translation Bias</add>
         <add name="Translation Multiplier" type="float">Translation Multiplier</add>
         <add name="Rotation Bias" type="float">Rotation Bias</add>
@@ -3415,7 +3419,7 @@
 	</niobject>
 
     <niobject name="NiBSplineData" abstract="0" inherit="NiObject">
-        B-spline data points as floats, or as shorts for compressed B-splines.
+        Contains one or more sets of control points for use in interpolation of open, uniform B-Splines, stored as either float or compact.
         <add name="Num Float Control Points" type="uint">Number of Float Data Points</add>
         <add name="Float Control Points" type="float" arr1="Num Float Control Points">Float values representing the control data.</add>
         <add name="Num Short Control Points" type="uint">Number of Short Data Points</add>
@@ -3444,17 +3448,17 @@
     </niobject>
 
     <niobject name="NiColorData" abstract="0" inherit="NiObject">
-        Color data for material color controller.
+        Wrapper for color animation keys.
         <add name="Data" type="KeyGroup" template="Color4">The color keys.</add>
     </niobject>
 
     <niobject name="NiColorExtraData" abstract="0" inherit="NiExtraData">
-        Unknown.
+        Extra data in the form of NiColorA (red, green, blue, alpha).
         <add name="Data" type="Color4">RGBA Color?</add>
     </niobject>
 
     <niobject name="NiControllerManager" abstract="0" inherit="NiTimeController">
-        Unknown. Root of all controllers?
+        Controls animation sequences on a specific branch of the scene graph.
         <add name="Cumulative" type="bool">Designates whether animation sequences are cumulative?</add>
         <add name="Num Controller Sequences" type="uint">The number of controller sequence objects.</add>
         <add name="Controller Sequences" type="Ref" template="NiControllerSequence" arr1="Num Controller Sequences">Refers to a list of NiControllerSequence object.</add>
@@ -3494,11 +3498,11 @@
     </niobject>
 
     <niobject name="NiAVObjectPalette" abstract="1" inherit="NiObject">
-        Abstract type for object palettes.
+        Abstract base class for indexing NiAVObject by name.
     </niobject>
 
     <niobject name="NiDefaultAVObjectPalette" abstract="0" inherit="NiAVObjectPalette">
-        Refers to a list of objects. Used by NiControllerManager.
+        NiAVObjectPalette implementation. Used to quickly look up objects by name.
         <add name="Scene" type="Ptr" template="NiAVObject">Scene root of the object palette.</add>
         <add name="Num Objs" type="uint">Number of objects.</add>
         <add name="Objs" type="AVObject" arr1="Num Objs">The objects.</add>
@@ -3509,33 +3513,33 @@
     </niobject>
 
     <niobject name="NiDitherProperty" abstract="0" inherit="NiProperty">
-        Unknown.
+        NiDitherProperty allows the application to turn the dithering of interpolated colors and fog values on and off.
         <add name="Flags" type="Flags">1&#039;s Bit: Enable dithering</add>
     </niobject>
 
     <niobject name="NiRollController" abstract="0" inherit="NiSingleInterpController">
-        Unknown.
+        DEPRECATED (10.2), REMOVED (20.5). Replaced by NiTransformController and NiLookAtInterpolator.
         <add name="Data" type="Ref" template="NiFloatData">The data for the controller.</add>
     </niobject>
 
     <niobject name="NiFloatData" abstract="0" inherit="NiObject">
-        Possibly the 1D position along a 3D path.
+        Wrapper for 1D (one-dimensional) floating point animation keys.
         <add name="Data" type="KeyGroup" template="float">The keys.</add>
     </niobject>
 
     <niobject name="NiFloatExtraData" abstract="0" inherit="NiExtraData">
-        Float extra data.
+        Extra float data.
         <add name="Float Data" type="float">The float data.</add>
     </niobject>
 
     <niobject name="NiFloatsExtraData" abstract="0" inherit="NiExtraData">
-        Unknown.
+        Extra float array data.
         <add name="Num Floats" type="uint">Number of floats in the next field.</add>
         <add name="Data" type="float" arr1="Num Floats">Float data.</add>
     </niobject>
 
     <niobject name="NiFogProperty" abstract="0" inherit="NiProperty">
-        Describes... fog?
+        NiFogProperty allows the application to enable, disable and control the appearance of fog.
         <add name="Flags" type="Flags">
             1&#039;s bit: Enables Fog
             2&#039;s bit: Sets Fog Function to FOG_RANGE_SQ
@@ -3548,7 +3552,7 @@
     </niobject>
 
     <niobject name="NiGravity" abstract="0" inherit="NiParticleModifier">
-        A particle modifier; applies a gravitational field on the particles.
+        LEGACY (pre-10.1) particle modifier. Applies a gravitational field on the particles.
         <add name="Unknown Float 1" type="float" ver1="4.0.0.2">Unknown.</add>
         <add name="Force" type="float">The strength/force of this gravity.</add>
         <add name="Type" type="FieldType">The force field&#039;s type.</add>
@@ -3580,7 +3584,7 @@
     </niobject>
 
     <niobject name="NiIntegersExtraData" abstract="0" inherit="NiExtraData">
-        Integers data.
+        Extra integer array data.
         <add name="Num Integers" type="uint">Number of integers.</add>
         <add name="Data" type="uint" arr1="Num Integers">Integers.</add>
     </niobject>
@@ -3591,7 +3595,8 @@
     </niobject>
 
     <niobject name="NiKeyframeData" abstract="0" inherit="NiObject">
-        Keyframes for mesh animation.
+        DEPRECATED (10.2), RENAMED (10.2) to NiTransformData.
+        Wrapper for transformation animation keys.
         <add name="Num Rotation Keys" type="uint">The number of quaternion rotation keys. If the rotation type is XYZ (type 4) then this *must* be set to 1, and in this case the actual number of keys is stored in the XYZ Rotations field.</add>
         <add name="Rotation Type" type="KeyType" cond="Num Rotation Keys != 0">The type of interpolation to use for rotation.  Can also be 4 to indicate that separate X, Y, and Z values are used for the rotation instead of Quaternions.</add>
         <add name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" arr1="Num Rotation Keys" cond="Rotation Type != 4">The rotation keys if Quaternion rotation is used.</add>
@@ -3610,13 +3615,14 @@
     </enum>
 
     <niobject name="NiLookAtController" abstract="0" inherit="NiTimeController">
-        Unknown. Start time is 3.4e+38 and stop time is -3.4e+38.
+        DEPRECATED (10.2), REMOVED (20.5)
+        Replaced by NiTransformController and NiLookAtInterpolator.
         <add name="Unknown1" type="ushort" ver1="10.1.0.0">Unknown.</add>
         <add name="Look At Node" type="Ptr" template="NiNode">Link to the node to look at?</add>
     </niobject>
 
     <niobject name="NiLookAtInterpolator" abstract="0" inherit="NiInterpolator">
-        Unknown.
+        NiLookAtInterpolator rotates an object so that it always faces a target object.
         <add name="Flags" type="LookAtFlags" />
         <add name="Look At" type="Ptr" template="NiNode">Refers to a Node to focus on.</add>
         <add name="Look At Name" type="string">Target node name.</add>
@@ -3630,7 +3636,7 @@
     </niobject>
 
     <niobject name="NiMaterialProperty" abstract="0" inherit="NiProperty">
-        Describes the material shading properties.
+        Describes the surface properties of an object e.g. translucency, ambient color, diffuse color, emissive color, and specular color.
         <add name="Flags" type="Flags" ver1="3.0" ver2="10.0.1.2">Property flags.</add>
         <add name="Ambient Color" type="Color3" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21))">How much the material reflects ambient light.</add>
         <add name="Diffuse Color" type="Color3" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21))">How much the material reflects diffuse light.</add>
@@ -3642,6 +3648,7 @@
     </niobject>
 
     <niobject name="NiMorphData" abstract="0" inherit="NiObject">
+        DEPRECATED (20.5), replaced by NiMorphMeshModifier.
         Geometry morphing data.
         <add name="Num Morphs" type="uint">Number of morphing object.</add>
         <add name="Num Vertices" type="uint">Number of vertices.</add>
@@ -3662,7 +3669,7 @@
     </niobject>
 
     <niobject name="AvoidNode" abstract="0" inherit="NiNode">
-        Morrowind specific?
+        Morrowind specific.
     </niobject>
 
     <niobject name="FxWidget" abstract="0" inherit="NiNode">
@@ -3722,7 +3729,7 @@
     </bitflags>
 
     <niobject name="NiSwitchNode" abstract="0" inherit="NiNode">
-        A node used to switch between branches, such as for LOD levels?
+        Represents groups of multiple scenegraph subtrees, only one of which (the "active child") is drawn at any given time.
         <add name="Switch Node Flags" type="NiSwitchFlags" ver1="10.1.0.0" />
         <add name="Index" type="uint" />
     </niobject>
@@ -3738,14 +3745,14 @@
     </niobject>
 
     <niobject name="NiPalette" abstract="0" inherit="NiObject">
-        A color palette.
+        NiPalette objects represent mappings from 8-bit indices to 24-bit RGB or 32-bit RGBA colors.
         <add name="Unknown Byte" type="byte">Unknown, Usually = 0.</add>
         <add name="Num Entries" type="uint" default="256">The number of palette entries.  Always = 256.</add>
         <add name="Palette" type="ByteColor4" arr1="256">The color palette.</add>
     </niobject>
 
     <niobject name="NiParticleBomb" abstract="0" inherit="NiParticleModifier">
-        A particle modifier.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Decay?" type="float">Unknown.</add>
         <add name="Duration?" type="float">Unknown.</add>
         <add name="DeltaV?" type="float">Unknown.</add>
@@ -3757,24 +3764,24 @@
     </niobject>
 
     <niobject name="NiParticleColorModifier" abstract="0" inherit="NiParticleModifier">
-        Unknown.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Color Data" type="Ref" template="NiColorData">Color data index.</add>
     </niobject>
 
     <niobject name="NiParticleGrowFade" abstract="0" inherit="NiParticleModifier">
-        This particle system modifier controls the particle size. If it is present the particles start with size 0.0 . Then they grow to their original size and stay there until they fade to zero size again at the end of their lifetime cycle.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Grow" type="float">The time from the beginning of the particle lifetime during which the particle grows.</add>
         <add name="Fade" type="float">The time from the end of the particle lifetime during which the particle fades.</add>
     </niobject>
 
     <niobject name="NiParticleMeshModifier" abstract="0" inherit="NiParticleModifier">
-        Unknown.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Num Particle Meshes" type="uint">The number of particle mesh references that follow.</add>
         <add name="Particle Meshes" arr1="Num Particle Meshes" type="Ref" template="NiAVObject">Links to nodes of particle meshes?</add>
     </niobject>
 
     <niobject name="NiParticleRotation" abstract="0" inherit="NiParticleModifier">
-        Unknown.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Random Initial Axis?" type="byte">Unknown.</add>
         <add name="Initial Axis?" type="Vector3">Unknown.</add>
         <add name="Rotation Speed?" type="float">Unknown.</add>
@@ -3785,15 +3792,15 @@
     </niobject>
 
     <niobject name="NiAutoNormalParticles" abstract="0" inherit="NiParticles">
-        Unknown.
+        LEGACY (pre-10.1). NiParticles which do not house normals and generate them at runtime.
     </niobject>
 
     <niobject name="NiParticleMeshes" abstract="0" inherit="NiParticles">
-        Mesh particle node?
+        LEGACY (pre-10.1). Particle meshes.
     </niobject>
 
     <niobject name="NiParticleMeshesData" abstract="0" inherit="NiRotatingParticlesData">
-        Particle meshes data.
+        LEGACY (pre-10.1). Particle meshes data.
         <add name="Unknown Link 2" type="Ref" template="NiAVObject">Refers to the mesh that makes up a particle?</add>
     </niobject>
 
@@ -3872,6 +3879,7 @@
     </niobject>
 
     <niobject name="NiPathController" abstract="0" inherit="NiTimeController">
+        DEPRECATED (10.2), REMOVED (20.5). Replaced by NiTransformController and NiPathInterpolator.
         Time controller for a path.
         <add name="Unknown Short 2" type="ushort" ver1="10.1.0.0">Unknown.</add>
         <add name="Unknown Int 1" type="uint">Unknown, always 1?</add>
@@ -3943,7 +3951,7 @@
     </niobject>
 
     <niobject name="NiPlanarCollider" abstract="0" inherit="NiParticleModifier">
-        Unknown.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Unknown Short" type="ushort" ver1="10.0.1.0">Usually 0?</add>
         <add name="Unknown Float 1" type="float">Unknown.</add>
         <add name="Unknown Float 2" type="float">Unknown.</add>
@@ -3972,18 +3980,18 @@
     </niobject>
 
     <niobject name="NiPosData" abstract="0" inherit="NiObject">
-        Position data.
+        Wrapper for position animation keys.
         <add name="Data" type="KeyGroup" template="Vector3">The position keys.</add>
     </niobject>
 
     <niobject name="NiPSysAgeDeathModifier" abstract="0" inherit="NiPSysModifier">
-        Unknown particle modifier.
+        Particle modifier that controls and updates the age of particles in the system.
         <add name="Spawn on Death" type="bool">Unknown.</add>
         <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">Link to NiPSysSpawnModifier object?</add>
     </niobject>
 
     <niobject name="NiPSysBombModifier" abstract="0" inherit="NiPSysModifier">
-        Particle modifier that uses a NiNode to use as a "Bomb Object" to alter the path of particles.
+        Particle modifier that applies an explosive force to particles.
         <add name="Bomb Object" type="Ptr" template="NiNode">Link to a NiNode for bomb to function.</add>
         <add name="Bomb Axis" type="Vector3">Orientation of bomb object.</add>
         <add name="Decay" type="float">Falloff rate of the bomb object.</add>
@@ -3993,12 +4001,12 @@
     </niobject>
 
     <niobject name="NiPSysBoundUpdateModifier" abstract="0" inherit="NiPSysModifier">
-        Unknown particle system modifier.
+        Particle modifier that creates and updates bound volumes.
         <add name="Update Skip" type="ushort">Unknown.</add>
     </niobject>
 
     <niobject name="NiPSysBoxEmitter" abstract="0" inherit="NiPSysVolumeEmitter">
-        Particle emitter that uses points within a defined Box shape to emit from..
+        Particle emitter that uses points within a defined Box shape to emit from.
         <add name="Width" type="float">Defines the Width of the box area.</add>
         <add name="Height" type="float">Defines the Height of the box area.</add>
         <add name="Depth" type="float">Defines the Depth of the box area.</add>
@@ -4021,7 +4029,7 @@
     </niobject>
 
     <niobject name="NiPSysDragModifier" abstract="0" inherit="NiPSysModifier">
-        Unknown.
+        Particle modifier that applies a linear drag force to particles.
         <add name="Parent" type="Ptr" template="NiObject">Parent reference.</add>
         <add name="Drag Axis" type="Vector3">The drag axis.</add>
         <add name="Percentage" type="float">Drag percentage.</add>
@@ -4030,14 +4038,14 @@
     </niobject>
 
     <niobject name="NiPSysEmitterCtlrData" abstract="0" inherit="NiObject">
-        Particle system emitter controller data.
+        DEPRECATED (10.2). Particle system emitter controller data.
         <add name="Float Keys?" type="KeyGroup" template="float">Unknown.</add>
         <add name="Num Visibility Keys?" type="uint">Number of keys.</add>
         <add name="Visibility Keys?" type="Key" arg="1" template="byte" arr1="Num Visibility Keys?">Unknown.</add>
     </niobject>
 
     <niobject name="NiPSysGravityModifier" abstract="0" inherit="NiPSysModifier">
-        Adds gravity to a particle system, when linked to a NiNode to use as a Gravity Object.
+        Particle modifier that applies a gravitational force to particles.
         <add name="Gravity Object" type="Ptr" template="NiNode">Refers to a NiNode for gravity location.</add>
         <add name="Gravity Axis" type="Vector3">Orientation of gravity.</add>
         <add name="Decay" type="float">Falloff range.</add>
@@ -4068,7 +4076,7 @@
     </niobject>
 
     <niobject name="NiPSysMeshUpdateModifier" abstract="0" inherit="NiPSysModifier">
-        Unknown.
+        Particle modifier that updates mesh particles using the age of each particle.
         <add name="Num Meshes" type="uint">The number of object references that follow.</add>
         <add name="Meshes" type="Ref" template="NiAVObject" arr1="Num Meshes">Group of target NiNodes or NiTriShapes?</add>
     </niobject>
@@ -4093,7 +4101,7 @@
     </niobject> 
     
     <niobject name="BSPSysSubTexModifier"  abstract="0" inherit="NiPSysModifier">
-    Similar to a Flip Controller, this handles particle texture animation on a single texture atlas
+        Similar to a Flip Controller, this handles particle texture animation on a single texture atlas
         <add name="Start Frame" type="uint">Starting frame/position on atlas</add>
         <add name="Start Frame Fudge" type="float">Random chance to start on a different frame?</add>
         <add name="End Frame" type="float">Ending frame/position on atlas</add>
@@ -4117,11 +4125,11 @@
     </niobject>
 
     <niobject name="NiPSysPositionModifier" abstract="0" inherit="NiPSysModifier">
-        Unknown particle system modifier.
+        Particle modifier that updates the particle positions based on velocity and last update time.
     </niobject>
 
     <niobject name="NiPSysResetOnLoopCtlr" abstract="0" inherit="NiTimeController">
-        Unknown.
+        Particle modifier that calls reset on a target upon looping.
     </niobject>
 
     <niobject name="NiPSysRotationModifier" abstract="0" inherit="NiPSysModifier">
@@ -4136,7 +4144,7 @@
     </niobject>
 
     <niobject name="NiPSysSpawnModifier" abstract="0" inherit="NiPSysModifier">
-        Unknown particle modifier.
+        Particle modifier that spawns additional copies of a particle.
         <add name="Num Spawn Generations" type="ushort">Unknown.</add>
         <add name="Percentage Spawned" type="float">Unknown.</add>
         <add name="Min Num to Spawn" type="ushort">Unknown.</add>
@@ -4154,7 +4162,7 @@
     </niobject>
 
     <niobject name="NiPSysUpdateCtlr" abstract="0" inherit="NiTimeController">
-        Particle system controller, used for ???.
+        Particle system controller, tells the system to update its simulation.
     </niobject>
 
     <niobject name="NiPSysFieldModifier" abstract="1" inherit="NiPSysModifier">
@@ -4167,23 +4175,23 @@
     </niobject>
 
     <niobject name="NiPSysVortexFieldModifier" inherit="NiPSysFieldModifier">
-        Particle system modifier, used for controlling the particle velocity in force field.
+        Particle system modifier, implements a vortex field force for particles.
         <add name="Direction" type="Vector3">Direction of the particle velocity</add>
     </niobject>
 
     <niobject name="NiPSysGravityFieldModifier" inherit="NiPSysFieldModifier">
-        Particle system modifier, used for controlling the particle velocity in gravity field.
+        Particle system modifier, implements a gravity field force for particles.
         <add name="Direction" type="Vector3">Direction of the particle velocity</add>
     </niobject>
 
     <niobject name="NiPSysDragFieldModifier" inherit="NiPSysFieldModifier">
-        Particle system modifier, used for controlling the particle velocity in drag space warp.
+        Particle system modifier, implements a drag field force for particles.
         <add name="Use Direction?" type="bool">Whether to use the direction field?</add>
         <add name="Direction" type="Vector3">Direction of the particle velocity</add>
     </niobject>
 
     <niobject name="NiPSysTurbulenceFieldModifier" inherit="NiPSysFieldModifier">
-        Particle system modifier, used for controlling the particle velocity in drag space warp.
+        Particle system modifier, implements a turbulence field force for particles.
         <add name="Frequency" type="float">Frequency of the update.</add>
     </niobject>
 
@@ -4249,7 +4257,7 @@
     </niobject>
 
     <niobject name="NiPSysAirFieldModifier" inherit="NiPSysFieldModifier">
-        Particle system modifier, used for controlling the particle velocity in a field like wind.
+        Particle system modifier, updates the particle velocity to simulate the effects of air movements like wind, fans, or wake.
         <add name="Direction" type="Vector3">Direction of the particle velocity</add>
         <add name="Unknown Float 2" type="float">Unknown</add>
         <add name="Unknown Float 3" type="float">Unknown</add>
@@ -4279,8 +4287,7 @@
     </niobject>
 
     <niobject name="NiPSysRadialFieldModifier" inherit="NiPSysFieldModifier">
-        Particle system modifier, used for controlling the particle
-        velocity in force field.
+        Particle system modifier, updates the particle velocity to simulate the effects of point gravity.
         <add name="Radial Type" type="int">Unknown Enums?</add>
     </niobject>
 
@@ -4289,14 +4296,14 @@
     </niobject>
 
     <niobject name="NiRangeLODData" abstract="0" inherit="NiLODData">
-        Describes levels of detail based on distance of object from camera.
+        NiRangeLODData controls switching LOD levels based on Z depth from the camera to the NiLODNode.
         <add name="LOD Center" type="Vector3">?</add>
         <add name="Num LOD Levels" type="uint">Number of levels of detail.</add>
         <add name="LOD Levels" type="LODRange" arr1="Num LOD Levels">The ranges of distance that each level of detail applies in.</add>
     </niobject>
 
     <niobject name="NiScreenLODData" abstract="0" inherit="NiLODData">
-        Describes levels of detail based on size of object on screen?
+        NiScreenLODData controls switching LOD levels based on proportion of the screen that a bound would include.
         <add name="Bound Center" type="Vector3">The center of the bounding sphere?</add>
         <add name="Bound Radius" type="float">The radius of the bounding sphere?</add>
         <add name="World Center" type="Vector3">The center of the bounding sphere in world space?</add>
@@ -4310,6 +4317,7 @@
     </niobject>
 
     <niobject name="NiSequenceStreamHelper" abstract="0" inherit="NiObjectNET">
+        DEPRECATED (pre-10.1), REMOVED (20.3).
         Keyframe animation root node, in .kf files.
     </niobject>
 
@@ -4395,7 +4403,7 @@
     </niobject>
 
     <niobject name="NiSphericalCollider" abstract="0" inherit="NiParticleModifier">
-        Unknown.
+        LEGACY (pre-10.1) particle modifier.
         <add name="Unknown Float 1" type="float">Unknown.</add>
         <add name="Unknown Short 1" type="ushort">Unknown.</add>
         <add name="Unknown Float 2" type="float">Unknown.</add>
@@ -4462,7 +4470,7 @@
     </niobject>
 
     <niobject name="NiTextureEffect" abstract="0" inherit="NiDynamicEffect">
-        Enables environment mapping. Should be in both the children list and effects list of the NiTriShape object. For Morrowind: the bump map can be used to bump the environment map (note that the bump map is ignored if no NiTextureEffect object is present).
+        Represents an effect that uses projected textures such as projected lights (gobos), environment maps, and fog maps.
         <add name="Model Projection Matrix" type="Matrix33">Model projection matrix.  Always identity?</add>
         <add name="Model Projection Transform" type="Vector3">Model projection transform.  Always (0,0,0)?</add>
         <add name="Texture Filtering" type="TexFilterMode" default="FILTER_TRILERP">Texture Filtering mode.</add>
@@ -4481,7 +4489,7 @@
     </niobject>
 
     <niobject name="NiTextureModeProperty" abstract="0" inherit="NiProperty">
-        Unknown
+        LEGACY (pre-10.1)
         <add name="Unknown Ints" type="uint" arr1="3" ver2="2.3" />
         <add name="Unknown Short" type="short" ver1="3.0">Unknown. Either 210 or 194.</add>
         <add name="PS2 L" type="short" default="0" ver1="3.1" ver2="10.2.0.0">0?</add>
@@ -4489,6 +4497,7 @@
     </niobject>
 
     <niobject name="NiImage" abstract="0" inherit="NiObject">
+        LEGACY (pre-10.1)
         <add name="Use External" type="byte">0 if the texture is internal to the NIF file.</add>
         <add name="File Name" type="FilePath" cond="Use External != 0">The filepath to the texture.</add>
         <add name="Image Data" type="Ref" template="NiRawImageData" cond="Use External == 0">Link to the internally stored image data.</add>
@@ -4497,6 +4506,7 @@
     </niobject>
 
     <niobject name="NiTextureProperty" abstract="0" inherit="NiProperty">
+        LEGACY (pre-10.1)
         <add name="Unknown Ints 1" type="uint" arr1="2" ver2="2.3">Property flags.</add>
         <add name="Flags" type="Flags" ver1="3.0">Property flags.</add>
         <add name="Image" type="Ref" template="NiImage">Link to the texture image.</add>
@@ -4504,7 +4514,7 @@
     </niobject>
 
     <niobject name="NiTexturingProperty" abstract="0" inherit="NiProperty">
-        Describes an object&#039;s textures.
+        Describes how a fragment shader should be configured for a given piece of geometry.
         <add name="Flags" type="Flags" ver2="10.0.1.2">Property flags.</add>
         <add name="Flags" type="Flags" ver1="20.1.0.2">Property flags.</add>
         <add name="Apply Mode" type="ApplyMode" default="APPLY_MODULATE" ver1="3.3.0.13" ver2="20.1.0.1">Determines how the texture will be applied.  Seems to have special functions in Oblivion.</add>
@@ -4548,7 +4558,7 @@
     <niobject name="NiMultiTextureProperty" abstract="0" inherit="NiTexturingProperty" />
 
     <niobject name="NiTransformData" abstract="0" inherit="NiKeyframeData">
-        Mesh animation keyframe data.
+        Wrapper for transformation animation keys.
     </niobject>
 
     <niobject name="NiTriShape" abstract="0" inherit="NiTriBasedGeom">
@@ -4603,6 +4613,7 @@
     </niobject>
 
     <niobject name="NiBezierTriangle4" abstract="0" inherit="NiObject">
+        LEGACY (pre-10.1)
         Sub data of NiBezierMesh
         <add name="Unknown 1" type="uint" arr1="6">unknown</add>
         <add name="Unknown 2" type="ushort">unknown</add>
@@ -4616,6 +4627,7 @@
     </niobject>
 
     <niobject name="NiBezierMesh" abstract="0" inherit="NiAVObject">
+        LEGACY (pre-10.1)
         Unknown
         <add name="Num Bezier Triangles" type="uint">references.</add>
         <add name="Bezier Triangle" type="Ref" template="NiBezierTriangle4" arr1="Num Bezier Triangles">unknown</add>
@@ -4642,7 +4654,6 @@
         Pesumably a progressive mesh with triangles specified by edge splits.
         Seems to be specific to Freedom Force.
         The structure of this is uncertain and highly experimental at this point.
-        No file with this data can currently be read properly.
         <add name="Unknown Shorts" type="ushort"></add>
         <add name="Unknown Count 1" type ="ushort"></add>
         <add name="Unknown Count 2" type ="ushort"></add>
@@ -4655,12 +4666,14 @@
     </niobject>
 
     <niobject name="NiUVController" abstract="0" inherit="NiTimeController">
+        DEPRECATED (pre-10.1), REMOVED (20.3).
         Time controller for texture coordinates.
         <add name="Unknown Short" type="ushort">Always 0?</add>
         <add name="Data" type="Ref" template="NiUVData">Texture coordinate controller data index.</add>
     </niobject>
 
     <niobject name="NiUVData" abstract="0" inherit="NiObject">
+        DEPRECATED (pre-10.1), REMOVED (20.3)
         Texture coordinate data.
         <add name="UV Groups" type="KeyGroup" template="float" arr1="4">
             Four UV data groups. Appear to be U translation, V translation, U scaling/tiling, V scaling/tiling.
@@ -4668,7 +4681,8 @@
     </niobject>
 
     <niobject name="NiVectorExtraData" abstract="0" inherit="NiExtraData">
-        Extra vector data.
+        DEPRECATED (20.5).
+        Extra data in the form of a vector (as x, y, z, w components).
         <add name="Vector Data" type="Vector3">The vector data.</add>
         <add name="Unknown Float" type="float">Not sure whether this comes before or after the vector data.</add>
     </niobject>
@@ -4691,6 +4705,7 @@
     </niobject>
 
     <niobject name="NiVertWeightsExtraData" abstract="0" inherit="NiExtraData">
+        DEPRECATED (10.x), REMOVED (?)
         Not used in skinning.
         Unsure of use - perhaps for morphing animation or gravity.
         <add name="Num Bytes" type="uint">Number of bytes in this data object.</add>
@@ -4699,13 +4714,14 @@
     </niobject>
 
     <niobject name="NiVisData" abstract="0" inherit="NiObject">
+        DEPRECATED (10.2), REMOVED (?), Replaced by NiBoolData.
         Visibility data for a controller.
         <add name="Num Keys" type="uint">The number of visibility keys that follow.</add>
         <add name="Keys" type="Key" arg="1" template="byte" arr1="Num Keys">The visibility keys.</add>
     </niobject>
 
     <niobject name="NiWireframeProperty" abstract="0" inherit="NiProperty">
-        Unknown.
+        Allows applications to switch between drawing solid geometry or wireframe outlines.
         <add name="Flags" type="Flags">
             Property flags.
             0 - Wireframe Mode Disabled
@@ -4714,7 +4730,7 @@
     </niobject>
 
     <niobject name="NiZBufferProperty" abstract="0" inherit="NiProperty">
-        This Property controls the Z buffer (OpenGL: depth buffer).
+        Allows applications to set the test and write modes of the renderer's Z-buffer and to set the comparison function used for the Z-buffer test.
         <add name="Flags" type="Flags" default="3">
             Bit 0 enables the z test
             Bit 1 controls wether the Z buffer is read only (0) or read/write (1)
@@ -4729,6 +4745,7 @@
     </niobject>
 
     <niobject name="NiRawImageData" abstract="0" inherit="NiObject">
+        LEGACY (pre-10.1)
         Raw image data.
         <add name="Width" type="uint">Image width</add>
         <add name="Height" type="uint">Image height</add>
@@ -4738,13 +4755,13 @@
     </niobject>
 
     <niobject name="NiSortAdjustNode" abstract="0" inherit="NiNode">
-        Unknown node.  Found in Loki.
+        Used to turn sorting off for individual subtrees in a scene. Useful if objects must be drawn in a fixed order.
         <add name="Sorting Mode" type="SortingMode" default="SORTING_INHERIT">Sorting</add>
         <add name="Unknown Int 2" type="int" default="-1" ver2="10.2.0.0">Unknown.</add>
     </niobject>
 
     <niobject name="NiSourceCubeMap" abstract="0" inherit="NiSourceTexture">
-        Unknown node.  Found in Emerge Demo.
+        Represents cube maps that are created from either a set of six image files, six blocks of pixel data, or a single pixel data with six faces.
     </niobject>
 
     <niobject name="NiPhysXProp" abstract="0" inherit="NiObjectNET">
@@ -5123,6 +5140,7 @@
     </compound>
 
     <niobject name="NiScreenElementsData" inherit="NiTriShapeData">
+        DEPRECATED (20.5), functionality included in NiMeshScreenElements.
         Two dimensional screen elements.
         <add name="Max Polygons" type="ushort">Maximum number of polygons?</add>
         <add name="Polygons" type="Polygon" arr1="Max Polygons">Polygons</add>
@@ -5136,18 +5154,19 @@
     </niobject>
 
     <niobject name="NiScreenElements" inherit="NiTriShape">
+        DEPRECATED (20.5), replaced by NiMeshScreenElements.
         Two dimensional screen elements.
     </niobject>
 
     <niobject name="NiRoomGroup" inherit="NiNode">
-        Grouping node for nodes in a Portal
+        NiRoomGroup represents a set of connected rooms i.e. a game level.
         <add name="Shell Link" type="Ptr" template="NiNode" >Outer Shell Geometry Node?</add>
         <add name="Num Rooms" type="int">Number of rooms in this group</add>
         <add name="Rooms" type="Ptr" template="NiRoom" arr1="Num Rooms">Rooms associated with this group.</add>
     </niobject>
 
     <niobject name="NiRoom" inherit="NiNode">
-        Grouping node for nodes in a Portal
+        NiRoom objects represent cells in a cell-portal culling system.
         <add name="Num Walls" type="int">Number of walls in a room?</add>
         <add name="Wall Plane" type="Vector4" arr1="Num Walls">Face normal and unknown value.</add>
         <add name="Num In Portals" type="int">Number of doors into room</add>
@@ -5159,7 +5178,8 @@
     </niobject>
 
     <niobject name="NiPortal" inherit="NiAVObject">
-        A Portal
+        NiPortal objects are grouping nodes that support aggressive visibility culling.
+        They represent flat polygonal regions through which a part of a scene graph can be viewed.
         <add name="Unknown Flags" type="Flags">Unknown flags.</add>
         <add name="Unknown Short 2" type="short">Unknown</add>
         <add name="Num Vertices" type="ushort">Number of vertices in this polygon</add>
@@ -5286,7 +5306,7 @@
     </bitflags>
     
     <niobject name="BSShaderProperty" abstract="0" inherit="NiProperty">
-        Bethesda-specific Property node
+        Bethesda-specific property.
         <add name="Smooth" type="Flags" default="1">Unknown.
             0: smooth no
             1: smooth yes
@@ -5312,7 +5332,7 @@
     </niobject>
 
     <niobject name="BSShaderPPLightingProperty" abstract="0" inherit="BSShaderLightingProperty">
-        Bethesda-specific Shade node.
+        Bethesda-specific property.
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set</add>
         <add name="Refraction Strength" type="float" default="0.0" vercond="(User Version == 11) &amp;&amp; (User Version 2 &gt; 14)">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
         <add name="Refraction Fire Period" type="int" default="0" vercond="(User Version == 11) &amp;&amp; (User Version 2 &gt; 14)">Rate of texture movement for refraction shader.</add>
@@ -5323,28 +5343,26 @@
 
     <!-- Skyrim specific Node -->
     <niobject name="BSEffectShaderPropertyFloatController" abstract="0" inherit="NiFloatInterpController">
-    This controller is used to animate float variables in BSEffectShaderProperty.
+        This controller is used to animate float variables in BSEffectShaderProperty.
         <add name="Type of Controlled Variable" type="EffectShaderControlledVariable">Which float variable in BSEffectShaderProperty to animate:</add>
     </niobject>
 	
 	<niobject name="BSEffectShaderPropertyColorController" inherit="NiFloatInterpController">
-    This controller is used to animate colors in BSEffectShaderProperty.
+		This controller is used to animate colors in BSEffectShaderProperty.
 		<add name="Type of Controlled Color" type="EffectShaderControlledColor">Which color in BSEffectShaderProperty to animate:</add>
 	</niobject>
 	
 	<niobject name="BSLightingShaderPropertyFloatController" abstract="0" inherit="NiFloatInterpController">
-    This controller is used to animate float variables in BSLightingShaderProperty.
+		This controller is used to animate float variables in BSLightingShaderProperty.
 		<add name="Type of Controlled Variable" type="LightingShaderControlledVariable">Which float variable in BSLightingShaderProperty to animate:</add>
 	</niobject>
 	
 	<niobject name="BSLightingShaderPropertyColorController" abstract="0" inherit="NiFloatInterpController">
-    This controller is used to animate colors in BSLightingShaderProperty.
+		This controller is used to animate colors in BSLightingShaderProperty.
 		<add name="Type of Controlled Color" type="LightingShaderControlledColor">Which color in BSLightingShaderProperty to animate:</add>
 	</niobject>	
 	
-	<niobject name="BSNiAlphaPropertyTestRefController" inherit="NiAlphaController">
-    Unkown
-	</niobject>
+	<niobject name="BSNiAlphaPropertyTestRefController" inherit="NiAlphaController" />
 	
 	<niobject name="BSProceduralLightningController" abstract="0" inherit="NiTimeController">
     Skyrim, Paired with dummy TriShapes, this controller generates lightning shapes for special effects.
@@ -5388,7 +5406,7 @@
     </niobject>
 
     <niobject name="WaterShaderProperty" abstract="0" inherit="BSShaderProperty">
-        Bethesda-specific node? Found in Fallout3
+        Bethesda-specific property. Found in Fallout3
     </niobject>
 
     <enum name="SkyObjectType" storage="uint">
@@ -5401,39 +5419,39 @@
         <option value="7" name="BSSM_SKY_MOON_STARS_MASK">BSSM_Sky_Moon_Stars_Mask</option>
     </enum>
     <niobject name="SkyShaderProperty" abstract="0" inherit="BSShaderLightingProperty">
-        Bethesda-specific node? Found in Fallout3
+        Bethesda-specific property. Found in Fallout3
         <add name="File Name" type="SizedString">The texture.</add>
         <add name="Sky Object Type" type="SkyObjectType">Sky Object Type</add>
     </niobject>
 
     <niobject name="TileShaderProperty" abstract="0" inherit="BSShaderLightingProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
         <add name="File Name" type="SizedString">Texture file name</add>
     </niobject>
 
     <niobject name="DistantLODShaderProperty" abstract="0" inherit="BSShaderProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
     </niobject>
 
     <niobject name="BSDistantTreeShaderProperty" abstract="0" inherit="BSShaderProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
     </niobject>
 
     <niobject name="TallGrassShaderProperty" abstract="0" inherit="BSShaderProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
         <add name="File Name" type="SizedString">Texture file name</add>
     </niobject>
 
     <niobject name="VolumetricFogShaderProperty" abstract="0" inherit="BSShaderProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
     </niobject>
 
     <niobject name="HairShaderProperty" abstract="0" inherit="BSShaderProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
     </niobject>
 
     <niobject name="Lighting30ShaderProperty" abstract="0" inherit="BSShaderPPLightingProperty">
-        Bethesda-specific node.
+        Bethesda-specific property.
     </niobject>
 
     <bitflags name="SkyrimShaderPropertyFlags1" storage="uint">
@@ -5689,20 +5707,20 @@
     </niobject>
 
     <niobject name="BSDismemberSkinInstance" abstract="0" inherit="NiSkinInstance">
-        Bethesda-specific node.
+        Bethesda-specific skin instance.
         <add name="Num Partitions" type="int">Unknown</add>
 
         <add name="Partitions" type="BodyPartList" arr1="Num Partitions">Unknown</add>
     </niobject>
 
     <niobject name="BSDecalPlacementVectorExtraData" inherit="NiFloatExtraData">
-        Bethesda-specific node. (for dynamic decal projection?)
+        Bethesda-specific extra data. (for dynamic decal projection?)
         <add name="Num Vector Blocks" type="short">Number of groups</add>
         <add name="Vector Blocks" type="DecalVectorArray" arr1="Num Vector Blocks">Number of Blocks</add>
     </niobject>
 
     <niobject name="BSPSysSimpleColorModifier" inherit="NiPSysModifier">
-        Bethesda-Specific Particle node.
+        Bethesda-specific particle modifier.
         <add name="Fade In Percent" type="float">Unknown</add>
         <add name="Fade out Percent" type="float">Unknown</add>
         <add name="Color 1 End Percent" type="float">Unknown</add>
@@ -5720,7 +5738,7 @@
     </bitflags>
 
     <niobject name="BSValueNode" inherit="NiNode">
-        Bethesda-Specific node. Found on fxFire effects
+        Bethesda-specific node. Found on fxFire effects
         <add name="Value" type="uint">Value</add>
         <add name="Value Node Flags" type="BSValueNodeFlags">Value node flags.</add>
     </niobject>
@@ -5747,13 +5765,13 @@
 
 
     <niobject name="BSMaterialEmittanceMultController" inherit="NiFloatInterpController">
-        Bethesda-Specific node.
+        Bethesda-Specific time controller.
     </niobject>
 
 
 
     <niobject name="BSMasterParticleSystem" inherit="NiNode">
-        Bethesda-Specific node.
+        Bethesda-Specific particle system.
         <add name="Max Emitter Objects" type="ushort">Unknown</add>
         <add name="Num Particle Systems" type="int">Unknown</add>
         <add name="Particle Systems" type="Ref" template="NiAVObject" arr1="Num Particle Systems">Unknown</add>
@@ -5771,7 +5789,7 @@
 
 
     <niobject name="BSRefractionStrengthController" inherit="NiFloatInterpController">
-        Bethesda-Specific node.
+        Bethesda-Specific time controller.
     </niobject>
 
 
@@ -5799,8 +5817,7 @@
 
 
     <niobject name="BSRefractionFirePeriodController" abstract="0" inherit="NiTimeController">
-        Bethesda-specific node.
-        <!-- interpolator present in fallout new vegas; potential issues with fallout 3? -->
+        Bethesda-specific time controller.
         <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="20.2.0.7">Link to Interpolator.</add>
     </niobject>
 
@@ -5833,14 +5850,14 @@
     </compound>
 
     <compound name="BSTreadTransform">
-        Bethesda-specific node.
+        Bethesda-specific compound.
         <add name="Name" type="string">Name of affected node?</add>
         <add name="Transform 1" type="BSTreadTransformData">Transform data.</add>
         <add name="Transform 2" type="BSTreadTransformData">Transform data.</add>
     </compound>
 
     <niobject name="BSTreadTransfInterpolator" abstract="0" inherit="NiInterpolator">
-        Bethesda-specific node.
+        Bethesda-specific interpolator.
         <add name="Num Tread Transforms" type="int">Unknown.</add>
         <add name="Tread Transforms" type="BSTreadTransform" arr1="Num Tread Transforms">Unknown.</add>
         <add name="Data" type="Ref" template="NiFloatData">Unknown float data.</add>
@@ -5854,7 +5871,7 @@
     </enum>
 
     <niobject name="BSAnimNote" abstract="0" inherit="NiObject">
-        Bethesda-specific node.
+        Bethesda-specific object.
         <add name="Type" type="AnimNoteType">Type of this note.</add>
         <add name="Time" type="float">Location in time.</add>
         <add name="Arm" type="uint" cond="Type == 1">Unknown.</add>
@@ -5863,13 +5880,13 @@
     </niobject>
 
     <niobject name="BSAnimNotes" abstract="0" inherit="NiObject">
-        Bethesda-specific node.
+        Bethesda-specific object.
         <add name="Num Anim Notes" type="ushort">Number of BSAnimNote objects.</add>
         <add name="Anim Notes" type="Ref" template="BSAnimNote" arr1="Num Anim Notes">BSAnimNote objects.</add>
     </niobject>
 
     <niobject name="bhkLiquidAction" inherit="bhkSerializable">
-        Bethesda-specific node.
+        Bethesda-specific Havok serializable.
         <add name="User Data" type="uint" />
         <add name="Unknown Int 2" type="int">Unknown Flag</add>
         <add name="Unknown Int 3" type="int">Unknown Flag</add>
@@ -5895,7 +5912,7 @@
     </niobject>
 
     <niobject name="BSMultiBound" inherit="NiObject">
-        Bethesda-specific node.
+        Bethesda-specific object.
         <add name="Data" type="Ref" template="BSMultiBoundData" />
     </niobject>
 
@@ -5911,19 +5928,19 @@
     </niobject>
     
     <niobject name="BSMultiBoundSphere" inherit="BSMultiBoundData">
-        Bethesda-specific node.
+        Bethesda-specific object.
         <add name="Center" type="Vector3">Center</add>
         <add name="Radius" type="float">Radius</add>
     </niobject>
 
     <niobject name="BSSegmentedTriShape" inherit="NiTriShape">
-        Bethesda-specific node.
+        Bethesda-specific AV object.
         <add name="Num Segments" type="int" >Number of segments in the square grid</add>
         <add name="Segment" type="BSGeometrySegmentData" arr1="Num Segments">Configuration of each segment</add>
     </niobject>
 
     <niobject name="BSMultiBoundAABB" inherit="BSMultiBoundData">
-        Bethesda-specific node.
+        Bethesda-specific object.
         <add name="Position" type="Vector3">Position of the AABB's center</add>
         <add name="Extent" type="Vector3">Extent of the AABB in all directions</add>
     </niobject>
@@ -5982,20 +5999,20 @@
     </niobject>
 
     <niobject name="BSWArray" inherit="NiExtraData">
-        Bethesda-specific node.
+        Bethesda-specific extra data.
         <add name="Num Items" type="int">Unknown</add>
         <add name="Items" type="int" arr1="Num Items">Unknown</add>
     </niobject>
 
     <niobject name="bhkAabbPhantom" inherit="bhkShapePhantom">
-        Bethesda-specific node.
+        Bethesda-specific Havok serializable.
         <add name="Unused" type="byte" arr1="8" />
         <add name="AABB Min" type="Vector4" />
         <add name="AABB Max" type="Vector4" />
     </niobject>
 
     <niobject name="BSFrustumFOVController" inherit="NiTimeController">
-        Bethesda-specific node.
+        Bethesda-specific time controller.
         <add name="Interpolator" type="Ref" template="NiFloatInterpolator">Frustrum field of view animation interpolater and data.</add>
     </niobject>
 
@@ -6011,7 +6028,7 @@
     </niobject>
 
     <niobject name="bhkOrientHingedBodyAction" abstract="0" inherit="bhkSerializable">
-        Bethesda-Specific node.
+        Bethesda-Specific Havok serializable.
         <add name="Body" type="Ptr" template="NiObject" />
         <add name="Unknown Int 1" type="uint" />
         <add name="Unknown Int 2" type="uint" />
@@ -6803,22 +6820,22 @@
 	</niobject>
 
 	<niobject name="BSLODTriShape" inherit="NiTriBasedGeom">
-    A variation on NiTriShape, for visibility control over vertex groups.
+		A variation on NiTriShape, for visibility control over vertex groups.
 		<add name="Level 0 Size" type="uint">Unknown</add>
 		<add name="Level 1 Size" type="uint">Unknown</add>
 		<add name="Level 2 Size" type="uint">Unknown</add>
 	</niobject>
 
 	<niobject name="BSFurnitureMarkerNode" inherit="BSFurnitureMarker">
-    Furniture Marker for actors
+        Furniture Marker for actors
     </niobject>
 	
     <niobject name="BSLeafAnimNode" inherit="NiNode">
-    Unknown, related to trees.
+        Unknown, related to trees.
     </niobject>
     
     <niobject name="BSTreeNode" inherit="NiNode">
-    Node for handling Trees, Switches branch configurations for variation?
+        Node for handling Trees, Switches branch configurations for variation?
         <add name="Num Bones 1" type="uint">Unknown</add>
         <add name="Bones 1" type="Ref" arr1="Num Bones 1" template="NiNode">Unknown</add>
         <add name="Num Bones 2" type="uint">Unknown</add>

--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.8.6.0">
+<niftoolsxml version="0.9.0.0">
     <!--These are the version numbers marked as supported by NifSkope.
         The num argument is the numeric representation created by storing
         each part of the version in a byte.  For example, 4.0.0.2 is

--- a/nif.xml
+++ b/nif.xml
@@ -115,8 +115,8 @@
     <basic name="HeaderString" count="0" niflibtype="HeaderString">
         A variable length string that ends with a newline character (0x0A).  The string starts as follows depending on the version:
 
-        Version &lt;= 10.0.1.0:  &#039;NetImmerse File Format&#039;
-        Version &gt;= 10.1.0.0:  &#039;Gamebryo File Format&#039;
+        Version &lt;= 10.0.1.0:  'NetImmerse File Format'
+        Version &gt;= 10.1.0.0:  'Gamebryo File Format'
     </basic>
 
     <basic name="LineString" count="0" niflibtype="LineString">
@@ -830,8 +830,9 @@
         <option value="9" name="MO_SYS_CHARACTER">A specialized motion used for character controllers</option>
     </enum>
 
-    <enum name="DeactivatorType" storage="byte">
-        Bethesda Havok.
+    <enum name="hkDeactivatorType" storage="byte">
+        Bethesda Havok, based on hkpRigidBodyDeactivator::DeactivatorType.
+        Deactivator Type determines which mechanism Havok will use to classify the body as deactivated.
         <option value="0" name="DEACTIVATOR_INVALID">Invalid</option>
         <option value="1" name="DEACTIVATOR_NEVER">This will force the rigid body to never deactivate.</option>
         <option value="2" name="DEACTIVATOR_SPATIAL">Tells Havok to use a spatial deactivation scheme. This makes use of high and low frequencies of positional motion to determine when deactivation should occur.</option>
@@ -1471,7 +1472,7 @@
     <!-- Don't use vercond in Header, it breaks niflib -->
     <compound name="Header">
         The NIF file header.
-        <add name="Header String" type="HeaderString">&#039;NetImmerse File Format x.x.x.x&#039; (versions &lt;= 10.0.1.2) or &#039;Gamebryo File Format x.x.x.x&#039; (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</add>
+        <add name="Header String" type="HeaderString">'NetImmerse File Format x.x.x.x' (versions &lt;= 10.0.1.2) or 'Gamebryo File Format x.x.x.x' (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</add>
         <add name="Copyright" type="LineString" arr1="3" ver2="3.1.0.0" />
         <add name="Version" type="FileVersion" default="0x04000002" ver1="3.1.0.1">The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002, 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...</add>
         <add name="Endian Type" type="EndianType" default="ENDIAN_LITTLE" ver1="20.0.0.3">Determines the endianness of the data in the file.</add>
@@ -1513,7 +1514,7 @@
         <add name="Value" type="TEMPLATE">The key value.</add>
         <add name="Forward" type="TEMPLATE" cond="ARG == 2">Key forward tangent.</add>
         <add name="Backward" type="TEMPLATE" cond="ARG == 2">The key backward tangent.</add>
-        <add name="TBC" type="TBC" cond="ARG == 3">The key&#039;s TBC.</add>
+        <add name="TBC" type="TBC" cond="ARG == 3">The TBC of the key.</add>
     </compound>
 
     <compound name="KeyGroup" istemplate="1">
@@ -1560,15 +1561,16 @@
         <add name="Flags" type="Flags" ver1="20.1.0.3">Texture mode flags; clamp and filter mode stored in upper byte with 0xYZ00 = clamp mode Y, filter mode Z.</add>
         <add name="Max Anisotropy" type="ushort" ver1="20.5.0.4" />
         <add name="UV Set" type="uint" default="0" ver2="20.0.0.5">The texture coordinate set in NiGeometryData that this texture slot will use.</add>
-        <add name="PS2 L" type="short" default="0" ver2="10.4.0.1">PS2 only; from the Freedom Force docs, &quot;L values can range from 0 to 3 and are used to specify how fast a texture gets blurry&quot;.</add>
-        <add name="PS2 K" type="short" default="-75" ver2="10.4.0.1">PS2 only; from the Freedom Force docs, &quot;The K value is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.&quot; -75 for most v4.0.0.2 meshes.</add>
+        <add name="PS2 L" type="short" default="0" ver2="10.4.0.1">L can range from 0 to 3 and are used to specify how fast a texture gets blurry.</add>
+        <add name="PS2 K" type="short" default="-75" ver2="10.4.0.1">K is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.</add>
         <add name="Unknown1" type="ushort" ver2="4.1.0.12">Unknown, 0 or 0x0101?</add>
-        <add name="Has Texture Transform" type="bool" default="false" ver1="10.1.0.0">Determines whether or not the texture&#039;s coordinates are transformed.</add>
-        <add name="Translation" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The amount to translate the texture coordinates in each direction?</add>
-        <add name="Tiling" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0" default="1.0, 1.0">The number of times the texture is tiled in each direction?</add>
-        <add name="W Rotation" type="float" default="0.0" cond="Has Texture Transform" ver1="10.1.0.0">2D Rotation of texture image around third W axis after U and V.</add>
+        <!-- NiTextureTransform -->
+        <add name="Has Texture Transform" type="bool" default="false" ver1="10.1.0.0">Whether or not the texture coordinates are transformed.</add>
+        <add name="Translation" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The UV translation.</add>
+        <add name="Scale" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0" default="1.0, 1.0">The UV scale.</add>
+        <add name="Rotation" type="float" default="0.0" cond="Has Texture Transform" ver1="10.1.0.0">The W axis rotation in texture space.</add>
         <add name="Transform Method" type="TransformMethod" default="0" cond="Has Texture Transform" ver1="10.1.0.0">Depending on the source, scaling can occur before or after rotation.</add>
-        <add name="Center Offset" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The offset from the origin?</add>
+        <add name="Center" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The origin around which the texture rotates.</add>
     </compound>
 
     <compound name="ShaderTexDesc">
@@ -1657,7 +1659,7 @@
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Num Strips == 0" ver2="10.0.1.2">The triangles.</add>
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="(Has Faces) &amp;&amp; (Num Strips == 0)" ver1="10.1.0.0">The triangles.</add>
         <add name="Has Bone Indices" type="bool">Do we have bone indices?</add>
-        <add name="Bone Indices" type="byte" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into &#039;Bones&#039;.</add>
+        <add name="Bone Indices" type="byte" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into 'Bones'.</add>
 		<add name="Unknown Short" type="ushort" vercond="User Version >= 12">Unknown</add>
 		<add name="Vertex Size" type="byte" ver="20.2.0.7" userver2="100" />
 		<add name="Float Size" type="byte" ver="20.2.0.7" userver2="100" />
@@ -1771,7 +1773,7 @@
         particle array entry
         <add name="Velocity" type="Vector3">Particle velocity</add>
         <add name="Unknown Vector" type="Vector3">Unknown</add>
-        <add name="Lifetime" type="float">The particle&#039;s age.</add>
+        <add name="Lifetime" type="float">The particle age.</add>
         <add name="Lifespan" type="float">Maximum age of the particle.</add>
         <add name="Timestamp" type="float">Timestamp of the last update.</add>
         <add name="Unknown Short" type="ushort" default="0">Unknown short</add>
@@ -1800,9 +1802,9 @@
         	Bit 6: turns collision off (not used for Layer BIPED).
         	Bit 5: sets the SCALED property.
 
-					PART NUMBER is stored in bits 0-4. Used only when Layer is set to BIPED.
+        	PART NUMBER is stored in bits 0-4. Used only when Layer is set to BIPED.
 
-					Part Numbers for Oblivion, Fallout 3, Skyrim:
+        	Part Numbers for Oblivion, Fallout 3, Skyrim:
         	0 - OTHER
         	1 - HEAD
         	2 - BODY
@@ -1834,7 +1836,7 @@
         	28 - ADDONLEG
         	29-31 - NULL
         </add>
-        <add name="Group" type="ushort">Unknown.</add>
+        <add name="Group" type="ushort" />
     </compound>
 
     <compound name="HavokMaterial">
@@ -1865,8 +1867,8 @@
         <add name="Min Force" type="float" default="-1000000.0">Minimum motor force</add>
         <add name="Max Force" type="float" default="1000000.0">Maximum motor force</add>
         <add name="Tau" type="float" default="0">Relative stiffness</add>
-        <add name="Target Velocity" type="float" default="0">Unknown</add>
-        <add name="Use Velocity Target" type="bool" default="0">Unknown</add>
+        <add name="Target Velocity" type="float" default="0" />
+        <add name="Use Velocity Target" type="bool" default="0" />
         <add name="Motor Enabled" type="bool" default="0">Is Motor enabled</add>
     </compound>
 
@@ -2023,9 +2025,9 @@
     </compound>
 
     <compound name="StiffSpringDescriptor">
-        <add name="Pivot A" type="Vector4">Pivot A.</add>
-        <add name="Pivot B" type="Vector4">Pivot B.</add>
-        <add name="Length" type="float">Length.</add>
+        <add name="Pivot A" type="Vector4" />
+        <add name="Pivot B" type="Vector4" />
+        <add name="Length" type="float" />
     </compound>
 
     <compound name="OldSkinData">
@@ -2043,9 +2045,9 @@
 
     <compound name="BoxBV">
         Box Bounding Volume
-        <add name="Center" type="Vector3">Center</add>
-        <add name="Axis" type="Vector3" arr1="3">Axis</add>
-        <add name="Extent" type="float" arr1="3">Extent</add>
+        <add name="Center" type="Vector3" />
+        <add name="Axis" type="Vector3" arr1="3" />
+        <add name="Extent" type="Vector3" />
     </compound>
 
     <compound name="CapsuleBV">
@@ -2063,21 +2065,21 @@
 
     <compound name="BoundingVolume">
         <add name="Collision Type" type="BoundVolumeType">Type of collision data.</add>
-        <add name="Sphere" type="NiBound" cond="Collision Type == 0">Sphere</add>
-        <add name="Box" type="BoxBV" cond="Collision Type == 1">Box</add>
-        <add name="Capsule" type="CapsuleBV" cond="Collision Type == 2">Capsule</add>
-        <add name="Union" type="UnionBV" cond="Collision Type == 4">Union</add>
-        <add name="HalfSpace" type="HalfSpaceBV" cond="Collision Type == 5">Half Space</add>
+        <add name="Sphere" type="NiBound" cond="Collision Type == 0" />
+        <add name="Box" type="BoxBV" cond="Collision Type == 1" />
+        <add name="Capsule" type="CapsuleBV" cond="Collision Type == 2" />
+        <add name="Union" type="UnionBV" cond="Collision Type == 4" />
+        <add name="Half Space" type="HalfSpaceBV" cond="Collision Type == 5" />
     </compound>
 
     <compound name="UnionBV">
-        <add name="Num BV" type="uint">Number of Bounding Volumes.</add>
-        <add name="Bounding Volumes" type="BoundingVolume" arr1="Num BV">Bounding Volume.</add>
+        <add name="Num BV" type="uint" />
+        <add name="Bounding Volumes" type="BoundingVolume" arr1="Num BV" />
     </compound>
 
     <compound name="MorphWeight">
-        <add name="Interpolator" type="Ref" template="NiInterpolator">Interpolator</add>
-        <add name="Weight?" type="float">Weight</add>
+        <add name="Interpolator" type="Ref" template="NiInterpolator" />
+        <add name="Weight" type="float" />
     </compound>
 
     <compound name="ArkTexture">
@@ -2104,7 +2106,7 @@
 
     <compound name="DecalVectorArray">
         Array of Vectors for Decal placement in BSDecalPlacementVectorExtraData.
-        <add name="Num Vectors" type="short">Number of sets</add>
+        <add name="Num Vectors" type="short" />
         <add name="Points" type="Vector3" arr1="Num Vectors">Vector XYZ coords</add>
         <add name="Normals" type="Vector3" arr1="Num Vectors">Vector Normals</add>
     </compound>
@@ -2130,8 +2132,8 @@
     
     <compound name="BoneLOD">
         Stores Bone Level of Detail info in a BSBoneLODExtraData
-        <add name="Distance" type="uint">Distance to cull?</add>
-        <add name="Bone Name" type="string">The bones name</add>
+        <add name="Distance" type="uint" />
+        <add name="Bone Name" type="string" />
     </compound>
 
     <compound name="bhkCMSDMaterial">
@@ -2142,11 +2144,11 @@
 
     <compound name="bhkCMSDBigTris">
         Triangle indices used in pair with "Big Verts" in a bhkCompressedMeshShapeData.
-        <add name="Triangle 1" type="ushort"></add>
-        <add name="Triangle 2" type="ushort"></add>
-        <add name="Triangle 3" type="ushort"></add>
+        <add name="Triangle 1" type="ushort" />
+        <add name="Triangle 2" type="ushort" />
+        <add name="Triangle 3" type="ushort" />
         <add name="Material" type="uint">Always 0?</add>
-        <add name="Welding Info" type="ushort"></add>
+        <add name="Welding Info" type="ushort" />
     </compound>
     
     <compound name="bhkCMSDTransform">
@@ -2157,18 +2159,18 @@
     
     <compound name="bhkCMSDChunk">
         Defines subshape chunks in bhkCompressedMeshShapeData
-        <add name="Translation" type="Vector4">Local translation</add>
+        <add name="Translation" type="Vector4" />
         <add name="Material Index" type="uint">Index of material in bhkCompressedMeshShapeData::Chunk Materials</add>
         <add name="Reference" type="ushort">Always 65535?</add>
         <add name="Transform Index" type="ushort">Index of transformation in bhkCompressedMeshShapeData::Chunk Transforms</add>
-        <add name="Num Vertices" type="uint">Number of compressed vertices</add>
-        <add name="Vertices" type="ushort" arr1="Num Vertices">Compressed vertices</add>
-        <add name="Num Indices" type="uint"></add>
-        <add name="Indices" type="ushort" arr1="Num Indices"></add>
-        <add name="Num Strips" type="uint">Number of compressed strips</add>
-        <add name="Strips" type="ushort" arr1="Num Strips">Compressed strips</add>
-        <add name="Num Indices 2" type="uint">Number of </add>
-        <add name="Indices 2" type="ushort" arr1="Num Indices 2">Compressed </add>
+        <add name="Num Vertices" type="uint" />
+        <add name="Vertices" type="ushort" arr1="Num Vertices" />
+        <add name="Num Indices" type="uint" />
+        <add name="Indices" type="ushort" arr1="Num Indices" />
+        <add name="Num Strips" type="uint" />
+        <add name="Strips" type="ushort" arr1="Num Strips" />
+        <add name="Num Welding Info" type="uint" />
+        <add name="Welding Info" type="ushort" arr1="Num Welding Info" />
     </compound>
 
     <compound name="MalleableDescriptor">
@@ -2262,13 +2264,13 @@
 
     <niobject name="NiPSysCollider" abstract="1" inherit="NiObject">
         Particle system collider.
-        <add name="Bounce" type="float">Defines amount of bounce the collider object has.</add>
-        <add name="Spawn on Collide" type="bool">Unknown.</add>
-        <add name="Die on Collide" type="bool">Kill particles on impact if set to yes.</add>
-        <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">Link to NiPSysSpawnModifier object?</add>
+        <add name="Bounce" type="float">Amount of bounce for the collider.</add>
+        <add name="Spawn on Collide" type="bool">Spawn particles on impact?</add>
+        <add name="Die on Collide" type="bool">Kill particles on impact?</add>
+        <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">Spawner to use for the collider.</add>
         <add name="Parent" type="Ptr" template="NiObject">Link to parent.</add>
         <add name="Next Collider" type="Ref" template="NiObject">The next collider.</add>
-        <add name="Collider Object" type="Ptr" template="NiNode">Links to a NiNode that will define where in object space the collider is located/oriented.</add>
+        <add name="Collider Object" type="Ptr" template="NiNode">The object whose position and orientation are the basis of the collider.</add>
     </niobject>
 
     <enum name="BroadPhaseType" storage="byte">
@@ -2323,11 +2325,10 @@
     <niobject name="bhkRigidBody" abstract="0" inherit="bhkEntity">
         This is the default body type for all "normal" usable and static world objects. The "T" suffix
         marks this body as active for translation and rotation, a normal bhkRigidBody ignores those
-        properties. Because the properties are equal, a bhkRigidBody may be renamed
-        into a bhkRigidBodyT and vice-versa.
-        <add name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT">The collision response. See hkResponseType for hkpWorld default implementations.</add>
+        properties. Because the properties are equal, a bhkRigidBody may be renamed into a bhkRigidBodyT and vice-versa.
+        <add name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT">How the body reacts to collisions. See hkResponseType for hkpWorld default implementations.</add>
         <add name="Unused Byte 1" type="byte">Skipped over when writing Collision Response and Callback Delay.</add>
-        <add name="Process Contact Callback Delay" type="ushort" default="0xffff">Lowers the frequency for processContactCallbacks. A value of 5 means that a callback is raised every 5th frame.</add>
+        <add name="Process Contact Callback Delay" type="ushort" default="0xffff">Lowers the frequency for processContactCallbacks. A value of 5 means that a callback is raised every 5th frame. The default is once every 65535 frames.</add>
         <add name="Unknown Int 1" type="uint">Unknown.</add>
         <add name="Havok Filter Copy" type="HavokFilter">Copy of Havok Filter</add>
         <add name="Unused 2" type="byte" arr1="4">Garbage data from memory. Matches previous Unused value.</add>
@@ -2340,19 +2341,18 @@
         <add name="Rotation" type="hkQuaternion">The rotation Yaw/Pitch/Roll to apply to the body. Only enabled in bhkRigidBodyT objects.</add>
         <add name="Linear Velocity" type="Vector4">Linear velocity.</add>
         <add name="Angular Velocity" type="Vector4">Angular velocity.</add>
-        <add name="Inertia Tensor" type="hkMatrix3">Defines how the mass is distributed among the body.</add>
-        <add name="Center" type="Vector4"> This seems to be used to relocate the object's center of mass. Useful for balancing objects in contraints.</add>
+        <add name="Inertia Tensor" type="hkMatrix3">Defines how the mass is distributed among the body, i.e. how difficult it is to rotate around any given axis.</add>
+        <add name="Center" type="Vector4">The body's center of mass.</add>
         <add name="Mass" type="float" default="1.0">The body's mass in kg. A mass of zero represents an immovable object.</add>
-        <add name="Linear Damping" type="float" default="0.1"> Damping value for linear movement. A value that is too small fixes the object in place.</add>
-        <add name="Angular Damping" type="float" default="0.05"> Damping value for angular movement.</add>
+        <add name="Linear Damping" type="float" default="0.1">Reduces the movement of the body over time. A value of 0.1 will remove 10% of the linear velocity every second.</add>
+        <add name="Angular Damping" type="float" default="0.05">Reduces the movement of the body over time. A value of 0.05 will remove 5% of the angular velocity every second.</add>
         <add name="Time Factor" type="float" default="1.0" vercond="(User Version 2 &gt; 34)" />
         <add name="Gravity Factor" type="float" default="1.0" vercond="(User Version 2 &gt; 34)" />
-        <add name="Friction" type="float" default="0.5">The body&#039;s friction.</add>
+        <add name="Friction" type="float" default="0.5">How smooth its surfaces is and how easily it will slide along other bodies.</add>
         <add name="Rolling Friction Multiplier" type="float" vercond="(User Version 2 &gt; 34)" />
         <add name="Restitution" type="float" default="0.4">
-            The body&#039;s restitution (elasticity).
+            How "bouncy" the body is, i.e. how much energy it has after colliding. Less than 1.0 loses energy, greater than 1.0 gains energy.
             If the restitution is not 0.0 the object will need extra CPU for all new collisions.
-            Try to set restitution to 0 for maximum performance (e.g. collapsing buildings)
         </add>
         <add name="Max Linear Velocity" type="float" default="104.4">Maximal linear velocity.</add>
         <add name="Max Angular Velocity" type="float" default="31.57">Maximal angular velocity.</add>
@@ -2368,8 +2368,8 @@
         <add name="Quality Type" type="hkQualityType" default="MO_QUAL_FIXED">The type of interaction with other objects.</add>
         <add name="Unknown Bytes 1" type="byte" arr1="12">Unknown.</add>
         <add name="Unknown Bytes 2" type="byte" arr1="4" vercond="(User Version 2 &gt; 34)">Unknown. Skyrim only.</add>
-        <add name="Num Constraints" type="uint"> The number of constraints this object is bound to.</add>
-        <add name="Constraints" type="Ref" template="bhkSerializable" arr1="Num Constraints">Unknown.</add>
+        <add name="Num Constraints" type="uint" />
+        <add name="Constraints" type="Ref" template="bhkSerializable" arr1="Num Constraints" />
         <add name="Body Flags" type="uint" vercond="(User Version 2 &lt; 76)">1 = respond to wind</add>
         <add name="Body Flags" type="ushort" vercond="(User Version 2 &gt;= 76)">1 = respond to wind</add>
     </niobject>
@@ -2568,8 +2568,8 @@
 
     <niobject name="bhkPackedNiTriStripsShape" abstract="0" inherit="bhkShapeCollection">
         A shape constructed from strips data.
-        <add name="Num Sub Shapes" type="ushort" ver2="20.0.0.5">Number of subparts.</add>
-        <add name="Sub Shapes" type="OblivionSubShape" arr1="Num Sub Shapes" ver2="20.0.0.5">The subparts.</add>
+        <add name="Num Sub Shapes" type="ushort" ver2="20.0.0.5" />
+        <add name="Sub Shapes" type="OblivionSubShape" arr1="Num Sub Shapes" ver2="20.0.0.5" />
         <add name="User Data" type="uint" default="0" />
         <add name="Unused 1" type="uint">Looks like a memory pointer and may be garbage.</add>
         <add name="Radius" type="float" default="0.1" />
@@ -2577,7 +2577,7 @@
         <add name="Scale" type="Vector4" default="1.0, 1.0, 1.0, 0.0" />
         <add name="Radius Copy" type="float" default="0.1">Same as radius</add>
         <add name="Scale Copy" type="Vector4" default="1.0, 1.0, 1.0, 0.0">Same as scale.</add>
-        <add name="Data" type="Ref" template="hkPackedNiTriStripsData">A link to the shape&#039;s NiTriStripsData.</add>
+        <add name="Data" type="Ref" template="hkPackedNiTriStripsData" />
     </niobject>
 
     <niobject name="bhkNiTriStripsShape" abstract="0" inherit="bhkShapeCollection">
@@ -2609,20 +2609,20 @@
 
     <niobject name="NiFloatInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiFloatKeys to animate a float value over time.
-        <add name="Float Value" type="float">Value when posed?  At time 0?</add>
-        <add name="Data" type="Ref" template="NiFloatData">Float data?</add>
+        <add name="Pose Value" type="float">Value if lacking NiFloatData.</add>
+        <add name="Data" type="Ref" template="NiFloatData" />
     </niobject>
 
     <niobject name="NiTransformInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         An interpolator for transform keyframes.
         <add name="Transform" type="NiQuatTransform" />
-        <add name="Data" type="Ref" template="NiTransformData">Refers to NiTransformData.</add>
+        <add name="Data" type="Ref" template="NiTransformData" />
     </niobject>
 
     <niobject name="NiPoint3Interpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiPosKeys to animate an NiPoint3 value over time.
-        <add name="Point 3 Value" type="Vector3">Value when posed?  Value at time 0?</add>
-        <add name="Data" type="Ref" template="NiPosData">Reference to NiPosData.</add>
+        <add name="Pose Value" type="Vector3">Value if lacking NiPosData.</add>
+        <add name="Data" type="Ref" template="NiPosData" />
     </niobject>
 
     <bitflags name="PathFlags" storage="ushort" prefix="NIPI">
@@ -2638,18 +2638,18 @@
     <niobject name="NiPathInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Used to make an object follow a predefined spline path.
         <add name="Flags" type="PathFlags" />
-        <add name="Bank Dir" type="uint" />
-        <add name="Max Bank Angle" type="float" />
+        <add name="Bank Dir" type="int">-1 = Negative, 1 = Positive</add>
+        <add name="Max Bank Angle" type="float">Max angle in radians.</add>
         <add name="Smoothing" type="float" />
-        <add name="Follow Axis" type="ushort">Unknown. Zero.</add>
-        <add name="Path Data" type="Ref" template="NiPosData">Refers to NiPosData.</add>
-        <add name="Percent Data" type="Ref" template="NiFloatData">Refers to NiFloatData.</add>
+        <add name="Follow Axis" type="short">0, 1, or 2 representing X, Y, or Z.</add>
+        <add name="Path Data" type="Ref" template="NiPosData" />
+        <add name="Percent Data" type="Ref" template="NiFloatData" />
     </niobject>
 
     <niobject name="NiBoolInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiBoolKeys to animate a bool value over time.
-        <add name="Bool Value" type="bool">Value when posed?  At time 0?</add>
-        <add name="Data" type="Ref" template="NiBoolData">Refers to a NiBoolData object.</add>
+        <add name="Pose Value" type="bool">Value if lacking NiBoolData.</add>
+        <add name="Data" type="Ref" template="NiBoolData" />
     </niobject>
 
     <niobject name="NiBoolTimelineInterpolator" abstract="0" inherit="NiBoolInterpolator">
@@ -2690,8 +2690,8 @@
         Abstract base class for interpolators storing data via a B-spline.
         <add name="Start Time" type="float">Animation start time.</add>
         <add name="Stop Time" type="float">Animation stop time.</add>
-        <add name="Spline Data" type="Ref" template="NiBSplineData">Refers to NiBSplineData.</add>
-        <add name="Basis Data" type="Ref" template="NiBSplineBasisData">Refers to NiBSPlineBasisData.</add>
+        <add name="Spline Data" type="Ref" template="NiBSplineData" />
+        <add name="Basis Data" type="Ref" template="NiBSplineBasisData" />
     </niobject>
 
     <niobject name="NiObjectNET" abstract="1" inherit="NiObject">
@@ -2719,10 +2719,10 @@
 
     <niobject name="NiCollisionData" abstract="0" inherit="NiCollisionObject">
         Collision box.
-        <add name="Propagation Mode" type="PropagationMode">Propagation Mode</add>
-        <add name="Collision Mode" type="CollisionMode" ver1="10.1.0.0">Collision Mode</add>
+        <add name="Propagation Mode" type="PropagationMode" />
+        <add name="Collision Mode" type="CollisionMode" ver1="10.1.0.0" />
         <add name="Use ABV" type="byte">Use Alternate Bounding Volume.</add>
-        <add name="Bounding Volume" type="BoundingVolume" cond="Use ABV == 1">Collision data.</add>
+        <add name="Bounding Volume" type="BoundingVolume" cond="Use ABV == 1" />
     </niobject>
 
     <bitflags name="bhkCOFlags" storage="ushort">
@@ -2746,7 +2746,7 @@
         <add name="Flags" type="bhkCOFlags" default="1">
             Set to 1 for most objects, and to 41 for animated objects (ANIM_STATIC). Bits: 0=Active 2=Notify 3=Set Local 6=Reset.
         </add>
-        <add name="Body" type="Ref" template="NiObject">Links to the collision object data</add>
+        <add name="Body" type="Ref" template="NiObject" />
     </niobject>
 
     <niobject name="bhkCollisionObject" abstract="0" inherit="bhkNiCollisionObject">
@@ -2769,19 +2769,19 @@
 
     <niobject name="NiAVObject" abstract="1" inherit="NiObjectNET">
         Abstract audio-visual base class from which all of Gamebryo's scene graph objects inherit.
-        <add name="Flags" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects.</add>
+        <add name="Flags" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects. For Bethesda streams above 26 only.</add>
         <add name="Flags" type="Flags" ver1="3.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26))">Basic flags for AV objects; commonly 0x000C or 0x000A.</add>
         <add name="Translation" type="Vector3">The translation vector.</add>
         <add name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</add>
         <add name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</add>
         <add name="Velocity" type="Vector3" ver2="4.2.2.0">Unknown function. Always seems to be (0, 0, 0)</add>
-        <add name="Num Properties" type="uint" vercond="((Version &lt; 20.2.0.7) || (User Version &lt;= 11))">The number of property objects referenced.</add>
-        <add name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="((Version &lt; 20.2.0.7) || (User Version &lt;= 11))">List of node properties.</add>
+        <add name="Num Properties" type="uint" vercond="((Version &lt; 20.2.0.7) || (User Version &lt;= 11))" />
+        <add name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="((Version &lt; 20.2.0.7) || (User Version &lt;= 11))">All rendering properties attached to this object.</add>
         <add name="Unknown 1" type="uint" arr1="4" ver2="2.3">Always 2,0,2,0.</add>
         <add name="Unknown 2" type="byte" ver2="2.3">0 or 1.</add>
-        <add name="Has Bounding Box" type="bool" ver1="3.0" ver2="4.2.2.0">Do we have a bounding box?</add>
-        <add name="Bounding Box" type="BoundingBox" cond="Has Bounding Box" ver1="3.0" ver2="4.2.2.0">The bounding box.</add>
-        <add name="Collision Object" type="Ref" template="NiCollisionObject" ver1="10.0.1.0">Refers to NiCollisionObject, which is usually a bounding box or other simple collision shape.  In Oblivion this links the Havok objects.</add>
+        <add name="Has Bounding Box" type="bool" ver1="3.0" ver2="4.2.2.0" />
+        <add name="Bounding Box" type="BoundingBox" cond="Has Bounding Box" ver1="3.0" ver2="4.2.2.0" />
+        <add name="Collision Object" type="Ref" template="NiCollisionObject" ver1="10.0.1.0" />
     </niobject>
 
     <niobject name="NiDynamicEffect" abstract="1" inherit="NiAVObject">
@@ -2814,10 +2814,10 @@
 
     <niobject name="NiPSysModifier" abstract="1" inherit="NiObject">
         Abstract base class for all particle system modifiers.
-        <add name="Name" type="string">The object name.</add>
+        <add name="Name" type="string">Used to locate the modifier.</add>
         <add name="Order" type="uint">Modifier ID in the particle modifier chain (always a multiple of 1000)?</add>
         <add name="Target" type="Ptr" template="NiParticleSystem">NiParticleSystem parent of this modifier.</add>
-        <add name="Active" type="bool">Whether the modifier is currently in effect?  Usually true.</add>
+        <add name="Active" type="bool">Whether or not the modifier is active.</add>
     </niobject>
 
     <niobject name="NiPSysEmitter" abstract="1" inherit="NiPSysModifier">
@@ -2874,14 +2874,14 @@
     <niobject name="NiGeomMorpherController" abstract="0" inherit="NiInterpController">
         DEPRECATED (20.5), replaced by NiMorphMeshModifier.
         Time controller for geometry morphing.
-        <add name="Extra Flags" type="Flags" ver1="10.0.1.2">Unknown.</add>
+        <add name="Extra Flags" type="Flags" ver1="10.0.1.2">1 = UPDATE NORMALS</add>
         <add name="Unknown 2" type="byte" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
         <add name="Data" type="Ref" template="NiMorphData">Geometry morphing data index.</add>
         <add name="Always Update" type="byte" ver1="4.0.0.1" />
-        <add name="Num Interpolators" type="uint" ver1="10.1.0.106">The number of interpolator objects.</add>
-        <add name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" ver1="10.1.0.106" ver2="20.0.0.5">List of interpolators.</add>
-        <add name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" ver1="20.1.0.3">Weighted Interpolators?</add>
-        <add name="Num Unknown Ints" type="uint" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version >= 10)">A count.</add>
+        <add name="Num Interpolators" type="uint" ver1="10.1.0.106" />
+        <add name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" ver1="10.1.0.106" ver2="20.0.0.5" />
+        <add name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" ver1="20.1.0.3" />
+        <add name="Num Unknown Ints" type="uint" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version >= 10)" />
         <add name="Unknown Ints" type="uint" arr1="Num Unknown Ints" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version >= 10)">Unknown.</add>
     </niobject>
 
@@ -2896,7 +2896,7 @@
 
     <niobject name="NiSingleInterpController" abstract="1" inherit="NiInterpController">
         Uses a single NiInterpolator to animate its target value.
-        <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.2.0.0">Link to interpolator.</add>
+        <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.2.0.0" />
     </niobject>
 
     <niobject name="NiKeyframeController" abstract="0" inherit="NiSingleInterpController">
@@ -2977,7 +2977,7 @@
             Time between two flips.
             delta = (start_time - stop_time) / sources.num_indices
         </add>
-        <add name="Num Sources" type="uint">The number of source objects.</add>
+        <add name="Num Sources" type="uint" />
         <add name="Sources" type="Ref" template="NiSourceTexture" arr1="Num Sources" ver1="4.0.0.0">The texture sources.</add>
         <add name="Images" type="Ref" template="NiImage" arr1="Num Sources" ver2="3.1">The image sources</add>
     </niobject>
@@ -2991,7 +2991,7 @@
         Used to animate a single member of an NiTextureTransform.
         NiInterpController::GetCtlrID() string formats:
             ['%1-%2-TT_TRANSLATE_U', '%1-%2-TT_TRANSLATE_V', '%1-%2-TT_ROTATE', '%1-%2-TT_SCALE_U', '%1-%2-TT_SCALE_V']
-        (Depending on "Operation" enumeration, %1 = Value of "Shader Map", Value of %2 = "Texture Slot")
+        (Depending on "Operation" enumeration, %1 = Value of "Shader Map", %2 = Value of "Texture Slot")
         <add name="Shader Map" type="bool">Is the target map a shader map?</add>
         <add name="Texture Slot" type="TexType">The target texture slot.</add>
         <add name="Operation" type="TransformMember">Controls which aspect of the texture transform to modify.</add>
@@ -3242,7 +3242,7 @@
         <add name="Triangles" type="TriangleData" arr1="Num Triangles" />
         <add name="Num Vertices" type="uint" />
         <add name="Unknown Byte 1" type="byte" ver1="20.2.0.7">Unknown.</add>
-        <add name="Vertices" type="Vector3" arr1="Num Vertices">The vertices?</add>
+        <add name="Vertices" type="Vector3" arr1="Num Vertices" />
         <add name="Num Sub Shapes" type="ushort" ver1="20.2.0.7">Number of subparts.</add>
         <add name="Sub Shapes" type="OblivionSubShape" arr1="Num Sub Shapes" ver1="20.2.0.7">The subparts.</add>
     </niobject>
@@ -3292,7 +3292,7 @@
     <niobject name="NiParticlesData" abstract="0" inherit="NiGeometryData">
         Generic rotating particles data object.
         <add name="Num Particles" type="ushort" ver2="4.0.0.2">The maximum number of particles (matches the number of vertices).</add>
-        <add name="Particle Radius" type="float" ver2="10.0.1.0">The particles&#039; size.</add>
+        <add name="Particle Radius" type="float" ver2="10.0.1.0">The particles' size.</add>
         <add name="Has Radii" type="bool" ver1="10.1.0.0">Is the particle size array present?</add>
         <add name="Radii" type="float" arr1="Num Vertices" cond="Has Radii" ver1="10.1.0.0" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">The individual particel sizes.</add>
         <add name="Num Active" type="ushort">The number of active particles at the time the system was saved. This is also the number of valid entries in the following arrays.</add>
@@ -3506,10 +3506,10 @@
 
     <niobject name="NiControllerManager" abstract="0" inherit="NiTimeController">
         Controls animation sequences on a specific branch of the scene graph.
-        <add name="Cumulative" type="bool">Designates whether animation sequences are cumulative?</add>
-        <add name="Num Controller Sequences" type="uint">The number of controller sequence objects.</add>
-        <add name="Controller Sequences" type="Ref" template="NiControllerSequence" arr1="Num Controller Sequences">Refers to a list of NiControllerSequence object.</add>
-        <add name="Object Palette" type="Ref" template="NiDefaultAVObjectPalette">Refers to a NiDefaultAVObjectPalette.</add>
+        <add name="Cumulative" type="bool">Whether transformation accumulation is enabled. If accumulation is not enabled, the manager will treat all sequence data on the accumulation root as absolute data instead of relative delta values.</add>
+        <add name="Num Controller Sequences" type="uint" />
+        <add name="Controller Sequences" type="Ref" template="NiControllerSequence" arr1="Num Controller Sequences" />
+        <add name="Object Palette" type="Ref" template="NiDefaultAVObjectPalette" />
     </niobject>
 
     <niobject name="NiSequence" abstract="0" inherit="NiObject">
@@ -3561,7 +3561,7 @@
 
     <niobject name="NiDitherProperty" abstract="0" inherit="NiProperty">
         NiDitherProperty allows the application to turn the dithering of interpolated colors and fog values on and off.
-        <add name="Flags" type="Flags">1&#039;s Bit: Enable dithering</add>
+        <add name="Flags" type="Flags">1 = Enable dithering</add>
     </niobject>
 
     <niobject name="NiRollController" abstract="0" inherit="NiSingleInterpController">
@@ -3588,13 +3588,13 @@
     <niobject name="NiFogProperty" abstract="0" inherit="NiProperty">
         NiFogProperty allows the application to enable, disable and control the appearance of fog.
         <add name="Flags" type="Flags">
-            1&#039;s bit: Enables Fog
-            2&#039;s bit: Sets Fog Function to FOG_RANGE_SQ
-            4&#039;s bit: Sets Fog Function to FOG_VERTEX_ALPHA
+            Bit 0: Enables Fog
+            Bit 1: Sets Fog Function to FOG_RANGE_SQ
+            Bit 2: Sets Fog Function to FOG_VERTEX_ALPHA
 
-            If 2&#039;s and 4&#039;s bit are not set, but fog is enabled, Fog function is FOG_Z_LINEAR.
+            If Bit 1 and Bit 2 are not set, but fog is enabled, Fog function is FOG_Z_LINEAR.
         </add>
-        <add name="Fog Depth" type="float">The thickness of the fog?  Default is 1.0</add>
+        <add name="Fog Depth" type="float">Depth of the fog in normalized units. 1.0 = begins at near plane. 0.5 = begins halfway between the near and far planes.</add>
         <add name="Fog Color" type="Color3">The color of the fog.</add>
     </niobject>
 
@@ -3602,8 +3602,8 @@
         LEGACY (pre-10.1) particle modifier. Applies a gravitational field on the particles.
         <add name="Unknown Float 1" type="float" ver1="3.3.0.13">Unknown.</add>
         <add name="Force" type="float">The strength/force of this gravity.</add>
-        <add name="Type" type="FieldType">The force field&#039;s type.</add>
-        <add name="Position" type="Vector3">The position of the mass point relative to the particle system. (TODO: check for versions &lt;= 3.1)</add>
+        <add name="Type" type="FieldType">The force field type.</add>
+        <add name="Position" type="Vector3">The position of the mass point relative to the particle system.</add>
         <add name="Direction" type="Vector3">The direction of the applied acceleration.</add>
     </niobject>
 
@@ -3684,8 +3684,8 @@
         <add name="Diffuse Color" type="Color3" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21))">How much the material reflects diffuse light.</add>
         <add name="Specular Color" type="Color3">How much light the material reflects in a specular manner.</add>
         <add name="Emissive Color" type="Color3">How much light the material emits.</add>
-        <add name="Glossiness" type="float">The material&#039;s glossiness.</add>
-        <add name="Alpha" type="float">The material transparency (1=non-transparant). Refer to a NiAlphaProperty object in this material&#039;s parent NiTriShape object, when alpha is not 1.</add>
+        <add name="Glossiness" type="float">The material glossiness.</add>
+        <add name="Alpha" type="float">The material transparency (1=non-transparant). Refer to a NiAlphaProperty object in this material's parent NiTriShape object, when alpha is not 1.</add>
         <add name="Emit Multi" type="float" default="1.0" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21)">Unknown</add>
     </niobject>
 
@@ -3778,12 +3778,10 @@
 
     <niobject name="NiLODNode" abstract="0" inherit="NiSwitchNode">
         Level of detail selector. Links to different levels of detail of the same model, used to switch a geometry at a specified distance.
-        <!--<add name="Unknown 4 Bytes" type="byte" arr1="4">Unknown.  0,0,0,0 or 1,0,0,0.</add>-->
-        <add name="LOD Center" type="Vector3" ver1="4.0.0.2" ver2="10.0.1.0">Point to calculate distance from for switching?</add>
-        <add name="Num LOD Levels" type="uint" ver2="10.0.1.0">Number of levels of detail.</add>
-        <add name="LOD Levels" type="LODRange" arr1="Num LOD Levels" ver2="10.0.1.0">The ranges of distance that each level of detail applies in.</add>
-        <!--<add name="Unknown Short" type="ushort" ver1="10.1.0.0">Zero?</add>-->
-        <add name="LOD Level Data" type="Ref" template="NiLODData"  ver1="10.1.0.0">Refers to LOD level information, either distance or screen size based.</add>
+        <add name="LOD Center" type="Vector3" ver1="4.0.0.2" ver2="10.0.1.0" />
+        <add name="Num LOD Levels" type="uint" ver2="10.0.1.0" />
+        <add name="LOD Levels" type="LODRange" arr1="Num LOD Levels" ver2="10.0.1.0" />
+        <add name="LOD Level Data" type="Ref" template="NiLODData" ver1="10.1.0.0" />
     </niobject>
 
     <niobject name="NiPalette" abstract="0" inherit="NiObject">
@@ -3796,19 +3794,19 @@
 
     <niobject name="NiParticleBomb" abstract="0" inherit="NiParticleModifier">
         LEGACY (pre-10.1) particle modifier.
-        <add name="Decay?" type="float">Unknown.</add>
-        <add name="Duration?" type="float">Unknown.</add>
-        <add name="DeltaV?" type="float">Unknown.</add>
-        <add name="Start?" type="float">Unknown.</add>
-        <add name="Decay Type?" type="DecayType">Unknown.</add>
-        <add name="Symmetry Type?" type="SymmetryType" ver1="4.1.0.12">Unknown.</add>
-        <add name="Position?" type="Vector3">The position of the mass point relative to the particle system?</add>
-        <add name="Direction?" type="Vector3">The direction of the applied acceleration?</add>
+        <add name="Decay" type="float" />
+        <add name="Duration" type="float" />
+        <add name="DeltaV" type="float" />
+        <add name="Start" type="float" />
+        <add name="Decay Type" type="DecayType" />
+        <add name="Symmetry Type" type="SymmetryType" ver1="4.1.0.12" />
+        <add name="Position" type="Vector3">The position of the mass point relative to the particle system?</add>
+        <add name="Direction" type="Vector3">The direction of the applied acceleration?</add>
     </niobject>
 
     <niobject name="NiParticleColorModifier" abstract="0" inherit="NiParticleModifier">
         LEGACY (pre-10.1) particle modifier.
-        <add name="Color Data" type="Ref" template="NiColorData">Color data index.</add>
+        <add name="Color Data" type="Ref" template="NiColorData" />
     </niobject>
 
     <niobject name="NiParticleGrowFade" abstract="0" inherit="NiParticleModifier">
@@ -3819,15 +3817,15 @@
 
     <niobject name="NiParticleMeshModifier" abstract="0" inherit="NiParticleModifier">
         LEGACY (pre-10.1) particle modifier.
-        <add name="Num Particle Meshes" type="uint">The number of particle mesh references that follow.</add>
-        <add name="Particle Meshes" arr1="Num Particle Meshes" type="Ref" template="NiAVObject">Links to nodes of particle meshes?</add>
+        <add name="Num Particle Meshes" type="uint" />
+        <add name="Particle Meshes" arr1="Num Particle Meshes" type="Ref" template="NiAVObject" />
     </niobject>
 
     <niobject name="NiParticleRotation" abstract="0" inherit="NiParticleModifier">
         LEGACY (pre-10.1) particle modifier.
-        <add name="Random Initial Axis?" type="byte">Unknown.</add>
-        <add name="Initial Axis?" type="Vector3">Unknown.</add>
-        <add name="Rotation Speed?" type="float">Unknown.</add>
+        <add name="Random Initial Axis" type="byte" />
+        <add name="Initial Axis" type="Vector3" />
+        <add name="Rotation Speed" type="float" />
     </niobject>
 
     <niobject name="NiParticles" abstract="0" inherit="NiGeometry">
@@ -3875,9 +3873,9 @@
             1.6 : horizontal
             3.1416 : down
         </add>
-        <add name="Vertical Angle" type="float">emitter&#039;s vertical opening angle [radians]</add>
+        <add name="Vertical Angle" type="float">emitter's vertical opening angle [radians]</add>
         <add name="Horizontal Direction" type="float">horizontal emit direction</add>
-        <add name="Horizontal Angle" type="float">emitter&#039;s horizontal opening angle</add>
+        <add name="Horizontal Angle" type="float">emitter's horizontal opening angle</add>
         <add name="Unknown Normal?" type="Vector3">Unknown.</add>
         <add name="Unknown Color?" type="Color4">Unknown.</add>
         <add name="Size" type="float">Particle size</add>
@@ -3899,7 +3897,7 @@
         <!-- <add name="Particle" type="Particle" ver2="3.1">The particle (older NIF versions only have a single particle per controller?)</add> -->
         <add name="Particle Velocity" type="Vector3" ver2="3.1">Particle velocity</add>
         <add name="Particle Unknown Vector" type="Vector3" ver2="3.1">Unknown</add>
-        <add name="Particle Lifetime" type="float" ver2="3.1">The particle&#039;s age.</add>
+        <add name="Particle Lifetime" type="float" ver2="3.1">The particle's age.</add>
         <add name="Particle Link" type="Ref" template="NiObject" ver2="3.1" />
         <add name="Particle Timestamp" type="uint" ver2="3.1">Timestamp of the last update.</add>
         <add name="Particle Unknown Short" type="ushort" ver2="3.1">Unknown short</add>
@@ -3962,7 +3960,7 @@
         <add name="Bits Per Pixel" type="byte" ver1="10.3.0.3">Bits per pixel, 0 (Compressed), 8, 24 or 32.</add>
         <add name="Renderer Hint" type="uint" ver1="10.3.0.3" />
         <add name="Extra Data" type="uint" ver1="10.3.0.3" />
-        <add name="Flags" type="byte" ver1="10.3.0.3">Flags</add>
+        <add name="Flags" type="byte" ver1="10.3.0.3" />
         <add name="Tiling" type="PixelTiling" ver1="10.3.0.3" />
         <add name="sRGB Space" type="bool" ver1="20.3.0.4" />
         <add name="Channels" type="PixelFormatComponent" arr1="4" ver1="10.3.0.3">Channel Data</add>
@@ -4017,111 +4015,110 @@
 
     <niobject name="NiPointLight" abstract="0" inherit="NiLight">
         A point light.
-        <add name="Constant Attenuation" type="float">Constant Attenuation</add>
-        <add name="Linear Attenuation" type="float">Linear Attenuation</add>
-        <add name="Quadratic Attenuation" type="float">Quadratic Attenuation (see glLight)</add>
+        <add name="Constant Attenuation" type="float" />
+        <add name="Linear Attenuation" type="float" />
+        <add name="Quadratic Attenuation" type="float" />
     </niobject>
 
     <niobject name="NiPosData" abstract="0" inherit="NiObject">
         Wrapper for position animation keys.
-        <add name="Data" type="KeyGroup" template="Vector3">The position keys.</add>
+        <add name="Data" type="KeyGroup" template="Vector3" />
     </niobject>
 
     <niobject name="NiPSysAgeDeathModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that controls and updates the age of particles in the system.
-        <add name="Spawn on Death" type="bool">Unknown.</add>
-        <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">Link to NiPSysSpawnModifier object?</add>
+        <add name="Spawn on Death" type="bool">Should the particles spawn on death?</add>
+        <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">The spawner to use on death.</add>
     </niobject>
 
     <niobject name="NiPSysBombModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies an explosive force to particles.
-        <add name="Bomb Object" type="Ptr" template="NiNode">Link to a NiNode for bomb to function.</add>
-        <add name="Bomb Axis" type="Vector3">Orientation of bomb object.</add>
-        <add name="Decay" type="float">Falloff rate of the bomb object.</add>
-        <add name="Delta V" type="float">DeltaV /  Strength?</add>
-        <add name="Decay Type" type="DecayType">Decay type</add>
-        <add name="Symmetry Type" type="SymmetryType">Shape/symmetry of the bomb object.</add>
+        <add name="Bomb Object" type="Ptr" template="NiNode">The object whose position and orientation are the basis of the force.</add>
+        <add name="Bomb Axis" type="Vector3">The local direction of the force.</add>
+        <add name="Decay" type="float">How the bomb force will decrease with distance.</add>
+        <add name="Delta V" type="float">The acceleration the bomb will apply to particles.</add>
+        <add name="Decay Type" type="DecayType" />
+        <add name="Symmetry Type" type="SymmetryType" />
     </niobject>
 
     <niobject name="NiPSysBoundUpdateModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that creates and updates bound volumes.
-        <add name="Update Skip" type="ushort">Unknown.</add>
+        <add name="Update Skip" type="ushort">Optimize by only computing the bound of (1 / Update Skip) of the total particles each frame.</add>
     </niobject>
 
     <niobject name="NiPSysBoxEmitter" abstract="0" inherit="NiPSysVolumeEmitter">
         Particle emitter that uses points within a defined Box shape to emit from.
-        <add name="Width" type="float">Defines the Width of the box area.</add>
-        <add name="Height" type="float">Defines the Height of the box area.</add>
-        <add name="Depth" type="float">Defines the Depth of the box area.</add>
+        <add name="Width" type="float" />
+        <add name="Height" type="float" />
+        <add name="Depth" type="float" />
     </niobject>
 
     <niobject name="NiPSysColliderManager" abstract="0" inherit="NiPSysModifier">
         Particle modifier that adds a defined shape to act as a collision object for particles to interact with.
-        <add name="Collider" type="Ref" template="NiPSysCollider">Link to a NiPSysPlanarCollider or NiPSysSphericalCollider.</add>
+        <add name="Collider" type="Ref" template="NiPSysCollider" />
     </niobject>
 
     <niobject name="NiPSysColorModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that adds keyframe data to modify color/alpha values of particles over time.
-        <add name="Data" type="Ref" template="NiColorData">Refers to NiColorData object.</add>
+        <add name="Data" type="Ref" template="NiColorData" />
     </niobject>
 
     <niobject name="NiPSysCylinderEmitter" abstract="0" inherit="NiPSysVolumeEmitter">
         Particle emitter that uses points within a defined Cylinder shape to emit from.
-        <add name="Radius" type="float">Radius of the cylinder shape.</add>
-        <add name="Height" type="float">Height of the cylinders shape.</add>
+        <add name="Radius" type="float" />
+        <add name="Height" type="float" />
     </niobject>
 
     <niobject name="NiPSysDragModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies a linear drag force to particles.
-        <add name="Parent" type="Ptr" template="NiObject">Parent reference.</add>
-        <add name="Drag Axis" type="Vector3">The drag axis.</add>
-        <add name="Percentage" type="float">Drag percentage.</add>
-        <add name="Range" type="float">The range.</add>
-        <add name="Range Falloff" type="float">The range falloff.</add>
+        <add name="Parent" type="Ptr" template="NiObject">The object whose position and orientation are the basis of the force.</add>
+        <add name="Drag Axis" type="Vector3">The local direction of the force.</add>
+        <add name="Percentage" type="float">The amount of drag to apply to particles.</add>
+        <add name="Range" type="float">The distance up to which particles are fully affected.</add>
+        <add name="Range Falloff" type="float">The distance at which particles cease to be affected.</add>
     </niobject>
 
     <niobject name="NiPSysEmitterCtlrData" abstract="0" inherit="NiObject">
         DEPRECATED (10.2). Particle system emitter controller data.
-        <add name="Float Keys?" type="KeyGroup" template="float">Unknown.</add>
-        <add name="Num Visibility Keys?" type="uint">Number of keys.</add>
-        <add name="Visibility Keys?" type="Key" arg="1" template="byte" arr1="Num Visibility Keys?">Unknown.</add>
+        <add name="Birth Rate Keys" type="KeyGroup" template="float" />
+        <add name="Num Active Keys" type="uint" />
+        <add name="Active Keys" type="Key" arg="1" template="byte" arr1="Num Active Keys" />
     </niobject>
 
     <niobject name="NiPSysGravityModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies a gravitational force to particles.
-        <add name="Gravity Object" type="Ptr" template="NiNode">Refers to a NiNode for gravity location.</add>
-        <add name="Gravity Axis" type="Vector3">Orientation of gravity.</add>
-        <add name="Decay" type="float">Falloff range.</add>
-        <add name="Strength" type="float">The strength of gravity.</add>
-        <add name="Force Type" type="ForceType">Planar or Spherical type</add>
+        <add name="Gravity Object" type="Ptr" template="NiNode">The object whose position and orientation are the basis of the force.</add>
+        <add name="Gravity Axis" type="Vector3">The local direction of the force.</add>
+        <add name="Decay" type="float">How the force diminishes by distance.</add>
+        <add name="Strength" type="float">The acceleration of the force.</add>
+        <add name="Force Type" type="ForceType">The type of gravitational force.</add>
         <add name="Turbulence" type="float">Adds a degree of randomness.</add>
-        <add name="Turbulence Scale" type="float" default="1.0">Range for turbulence.</add>
+        <add name="Turbulence Scale" type="float" default="1.0">Scale for turbulence.</add>
         <add name="World Aligned" type="bool" ver1="20.2.0.7" vercond="User Version >= 11" />
     </niobject>
 
     <niobject name="NiPSysGrowFadeModifier" abstract="0" inherit="NiPSysModifier">
-        Particle modifier that controls the time it takes to grow a particle from Size=0 to the specified Size in the emitter, and then back to 0.  This modifer has no control over alpha settings.
-        <add name="Grow Time" type="float">Time in seconds to fade in.</add>
-        <add name="Grow Generation" type="ushort">Unknown.</add>
-        <add name="Fade Time" type="float">Time in seconds to fade out.</add>
-        <add name="Fade Generation" type="ushort">Unknown.</add>
-        <add name="Base Scale" type="float" ver1="20.2.0.7" userver="11">Unknown</add>
+        Particle modifier that controls the time it takes to grow and shrink a particle.
+        <add name="Grow Time" type="float">The time taken to grow from 0 to their specified size.</add>
+        <add name="Grow Generation" type="ushort">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</add>
+        <add name="Fade Time" type="float">The time taken to shrink from their specified size to 0.</add>
+        <add name="Fade Generation" type="ushort">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system.</add>
+        <add name="Base Scale" type="float" ver1="20.2.0.7" userver="11">A multiplier on the base particle scale.</add>
     </niobject>
 
     <niobject name="NiPSysMeshEmitter" abstract="0" inherit="NiPSysEmitter">
         Particle emitter that uses points on a specified mesh to emit from.
-        <add name="Num Emitter Meshes" type="uint">The number of references to emitter meshes that follow.</add>
-        <!-- Note: Reduced strictness of validation -->
-        <add name="Emitter Meshes" type="Ref" template="NiAVObject" arr1="Num Emitter Meshes">Links to meshes used for emitting.</add>
-        <add name="Initial Velocity Type" type="VelocityType">The way the particles get their initial direction and speed.</add>
-        <add name="Emission Type" type="EmitFrom">The parts of the mesh that the particles emit from.</add>
-        <add name="Emission Axis" type="Vector3">The emission axis.</add>
+        <add name="Num Emitter Meshes" type="uint" />
+        <add name="Emitter Meshes" type="Ptr" template="NiAVObject" arr1="Num Emitter Meshes">The meshes which are emitted from.</add>
+        <add name="Initial Velocity Type" type="VelocityType">The method by which the initial particle velocity will be computed.</add>
+        <add name="Emission Type" type="EmitFrom">The manner in which particles are emitted from the Emitter Meshes.</add>
+        <add name="Emission Axis" type="Vector3">The emission axis if VELOCITY_USE_DIRECTION.</add>
     </niobject>
 
     <niobject name="NiPSysMeshUpdateModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that updates mesh particles using the age of each particle.
-        <add name="Num Meshes" type="uint">The number of object references that follow.</add>
-        <add name="Meshes" type="Ref" template="NiAVObject" arr1="Num Meshes">Group of target NiNodes or NiTriShapes?</add>
+        <add name="Num Meshes" type="uint" />
+        <add name="Meshes" type="Ref" template="NiAVObject" arr1="Num Meshes" />
     </niobject>
     
     <niobject name="BSPSysInheritVelocityModifier"  abstract="0" inherit="NiPSysModifier">
@@ -4132,9 +4129,9 @@
     </niobject>
     
     <niobject name="BSPSysHavokUpdateModifier"  abstract="0" inherit="NiPSysModifier">
-        <add name="Num Nodes" type="uint">Unknown</add>
-        <add name="Nodes" type="Ref" template="NiNode" arr1="Num Nodes">Group of target NiNodes?</add>
-        <add name="Modifier" type="Ref" template="NiPSysModifier">Unknown</add>
+        <add name="Num Nodes" type="uint" />
+        <add name="Nodes" type="Ref" template="NiNode" arr1="Num Nodes" />
+        <add name="Modifier" type="Ref" template="NiPSysModifier" />
     </niobject>   
 
     <niobject name="BSPSysRecycleBoundModifier"  abstract="0" inherit="NiPSysModifier">
@@ -4149,22 +4146,22 @@
         <add name="Start Frame Fudge" type="float">Random chance to start on a different frame?</add>
         <add name="End Frame" type="float">Ending frame/position on atlas</add>
         <add name="Loop Start Frame" type="float">Frame to start looping</add>
-        <add name="Loop Start Frame Fudge" type="float"></add>
-        <add name="Frame Count" type="float">Unknown</add>
-        <add name="Frame Count Fudge" type="float">Unknown</add>
+        <add name="Loop Start Frame Fudge" type="float" />
+        <add name="Frame Count" type="float" />
+        <add name="Frame Count Fudge" type="float" />
     </niobject>
     
     <niobject name="NiPSysPlanarCollider" abstract="0" inherit="NiPSysCollider">
         Particle Collider object which particles will interact with.
-        <add name="Width" type="float">Defines the width of the plane.</add>
-        <add name="Height" type="float">Defines the height of the plane.</add>
-        <add name="X Axis" type="Vector3">Defines Orientation.</add>
-        <add name="Y Axis" type="Vector3">Defines Orientation.</add>
+        <add name="Width" type="float">Width of the plane along the X Axis.</add>
+        <add name="Height" type="float">Height of the plane along the Y Axis.</add>
+        <add name="X Axis" type="Vector3">Axis defining a plane, relative to Collider Object.</add>
+        <add name="Y Axis" type="Vector3">Axis defining a plane, relative to Collider Object.</add>
     </niobject>
 
     <niobject name="NiPSysSphericalCollider" abstract="0" inherit="NiPSysCollider">
         Particle Collider object which particles will interact with.
-        <add name="Radius" type="float">Defines the radius of the sphere object.</add>
+        <add name="Radius" type="float" />
     </niobject>
 
     <niobject name="NiPSysPositionModifier" abstract="0" inherit="NiPSysModifier">
@@ -4177,31 +4174,31 @@
 
     <niobject name="NiPSysRotationModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that adds rotations to particles.
-        <add name="Initial Rotation Speed" type="float">The initial speed of rotation.</add>
-        <add name="Initial Rotation Speed Variation" type="float" ver1="20.0.0.4">Adds a ranged randomness to rotation speed.</add>
-        <add name="Initial Rotation Angle" type="float" ver1="20.0.0.4">Sets the intial angle for particles to be birthed in.</add>
-        <add name="Initial Rotation Angle Variation" type="float" ver1="20.0.0.4">Adds a random range to Initial angle.</add>
-        <add name="Random Rot Speed Sign" type="bool" ver1="20.0.0.4">Unknown</add>
-        <add name="Random Initial Axis" type="bool">Unknown.</add>
-        <add name="Initial Axis" type="Vector3">Unknown.</add>
+        <add name="Rotation Speed" type="float">Initial Rotation Speed in radians per second.</add>
+        <add name="Rotation Speed Variation" type="float" ver1="20.0.0.2">Distributes rotation speed over the range [Speed - Variation, Speed + Variation].</add>
+        <add name="Rotation Angle" type="float" ver1="20.0.0.2">Initial Rotation Angle in radians.</add>
+        <add name="Rotation Angle Variation" type="float" ver1="20.0.0.2">Distributes rotation angle over the range [Angle - Variation, Angle + Variation].</add>
+        <add name="Random Rot Speed Sign" type="bool" ver1="20.0.0.2">Randomly negate the initial rotation speed?</add>
+        <add name="Random Axis" type="bool">Assign a random axis to new particles?</add>
+        <add name="Axis" type="Vector3">Initial rotation axis.</add>
     </niobject>
 
     <niobject name="NiPSysSpawnModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that spawns additional copies of a particle.
-        <add name="Num Spawn Generations" type="ushort">Unknown.</add>
-        <add name="Percentage Spawned" type="float">Unknown.</add>
-        <add name="Min Num to Spawn" type="ushort">Unknown.</add>
-        <add name="Max Num to Spawn" type="ushort">Unknown.</add>
-        <add name="Spawn Speed Chaos" type="float">Unknown.</add>
-        <add name="Spawn Dir Chaos" type="float">Unknown.</add>
-        <add name="Life Span" type="float">Unknown.</add>
-        <add name="Life Span Variation" type="float">Unknown.</add>
-        <add name="Unknown int" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown</add>
+        <add name="Num Spawn Generations" type="ushort">Number of allowed generations for spawning. Particles whose generations are >= will not be spawned.</add>
+        <add name="Percentage Spawned" type="float">The likelihood of a particular particle being spawned. Must be between 0.0 and 1.0.</add>
+        <add name="Min Num to Spawn" type="ushort">The minimum particles to spawn for any given original particle.</add>
+        <add name="Max Num to Spawn" type="ushort">The maximum particles to spawn for any given original particle.</add>
+        <add name="Unknown Int" type="int" ver1="10.4.0.1" ver2="10.4.0.1">WorldShift</add>
+        <add name="Spawn Speed Variation" type="float">How much the spawned particle speed can vary.</add>
+        <add name="Spawn Dir Variation" type="float">How much the spawned particle direction can vary.</add>
+        <add name="Life Span" type="float">Lifespan assigned to spawned particles.</add>
+        <add name="Life Span Variation" type="float">The amount the lifespan can vary.</add>
     </niobject>
 
     <niobject name="NiPSysSphereEmitter" abstract="0" inherit="NiPSysVolumeEmitter">
         Particle emitter that uses points within a sphere shape to emit from.
-        <add name="Radius" type="float">The radius of the sphere shape</add>
+        <add name="Radius" type="float" />
     </niobject>
 
     <niobject name="NiPSysUpdateCtlr" abstract="0" inherit="NiTimeController">
@@ -4210,32 +4207,32 @@
 
     <niobject name="NiPSysFieldModifier" abstract="1" inherit="NiPSysModifier">
         Base for all force field particle modifiers.
-        <add name="Field Object" type="Ref" template="NiAVObject">Force Field Object</add>
-        <add name="Magnitude" type="float">Magnitude of the force</add>
-        <add name="Attenuation" type="float">Controls how quick the field diminishes</add>
-        <add name="Use Max Distance" type="bool">Use maximum distance</add>
-        <add name="Max Distance" type="float">Maximum distance</add>
+        <add name="Field Object" type="Ref" template="NiAVObject">The object whose position and orientation are the basis of the field.</add>
+        <add name="Magnitude" type="float">Magnitude of the force.</add>
+        <add name="Attenuation" type="float">How the magnitude diminishes with distance from the Field Object.</add>
+        <add name="Use Max Distance" type="bool">Whether or not to use a distance from the Field Object after which there is no effect.</add>
+        <add name="Max Distance" type="float">Maximum distance after which there is no effect.</add>
     </niobject>
 
     <niobject name="NiPSysVortexFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, implements a vortex field force for particles.
-        <add name="Direction" type="Vector3">Direction of the particle velocity</add>
+        <add name="Direction" type="Vector3">Direction of the vortex field in Field Object's space.</add>
     </niobject>
 
     <niobject name="NiPSysGravityFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, implements a gravity field force for particles.
-        <add name="Direction" type="Vector3">Direction of the particle velocity</add>
+        <add name="Direction" type="Vector3">Direction of the gravity field in Field Object's space.</add>
     </niobject>
 
     <niobject name="NiPSysDragFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, implements a drag field force for particles.
-        <add name="Use Direction?" type="bool">Whether to use the direction field?</add>
-        <add name="Direction" type="Vector3">Direction of the particle velocity</add>
+        <add name="Use Direction" type="bool">Whether or not the drag force applies only in the direction specified.</add>
+        <add name="Direction" type="Vector3">Direction in which the force applies if Use Direction is true.</add>
     </niobject>
 
     <niobject name="NiPSysTurbulenceFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, implements a turbulence field force for particles.
-        <add name="Frequency" type="float">Frequency of the update.</add>
+        <add name="Frequency" type="float">How many turbulence updates per second.</add>
     </niobject>
 
     <niobject name="BSPSysLODModifier" inherit="NiPSysModifier">
@@ -4246,8 +4243,8 @@
     </niobject>
     
     <niobject name="BSPSysScaleModifier" inherit="NiPSysModifier">
-        <add name="Num Floats" type="uint"></add>
-        <add name="Floats" type="float" arr1="Num Floats">Unknown</add>
+        <add name="Num Scales" type="uint" />
+        <add name="Scales" type="float" arr1="Num Scales" />
     </niobject>
     
     
@@ -4331,18 +4328,18 @@
 
     <niobject name="NiPSysRadialFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, updates the particle velocity to simulate the effects of point gravity.
-        <add name="Radial Type" type="int">Unknown Enums?</add>
+        <add name="Radial Type" type="float">If zero, no attenuation.</add>
     </niobject>
 
-    <niobject name ="NiLODData" abstract="1" inherit="NiObject">
+    <niobject name="NiLODData" abstract="1" inherit="NiObject">
         Abstract class used for different types of LOD selections.
     </niobject>
 
     <niobject name="NiRangeLODData" abstract="0" inherit="NiLODData">
         NiRangeLODData controls switching LOD levels based on Z depth from the camera to the NiLODNode.
-        <add name="LOD Center" type="Vector3">?</add>
-        <add name="Num LOD Levels" type="uint">Number of levels of detail.</add>
-        <add name="LOD Levels" type="LODRange" arr1="Num LOD Levels">The ranges of distance that each level of detail applies in.</add>
+        <add name="LOD Center" type="Vector3" />
+        <add name="Num LOD Levels" type="uint" />
+        <add name="LOD Levels" type="LODRange" arr1="Num LOD Levels" />
     </niobject>
 
     <niobject name="NiScreenLODData" abstract="0" inherit="NiLODData">
@@ -4365,9 +4362,7 @@
     <niobject name="NiShadeProperty" abstract="0" inherit="NiProperty">
         Determines whether flat shading or smooth shading is used on a shape.
         <add name="Flags" type="Flags">
-            1&#039;s Bit:  Enable smooth phong shading on this shape.
-
-            If 1&#039;s bit is not set, hard-edged flat shading will be used on this shape.
+            Bit 0: Enable smooth phong shading on this shape. Otherwise, hard-edged flat shading will be used on this shape.
         </add>
     </niobject>
 
@@ -4403,7 +4398,7 @@
 
     <niobject name="NiSkinPartition" abstract="0" inherit="NiObject">
         Skinning data, optimized for hardware skinning. The mesh is partitioned in submeshes such that each vertex of a submesh is influenced only by a limited and fixed number of bones.
-        <add name="Num Skin Partition Blocks" type="uint">Unknown.</add>
+        <add name="Num Skin Partition Blocks" type="uint" />
 		<add name="Skin Partition Blocks" type="SkinPartition" arr1="Num Skin Partition Blocks" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 100))">Skin partition objects.</add>
 		<add name="Data Size" type="uint" ver="20.2.0.7" userver2="100" />
 		<add name="Vertex Size" type="uint" ver="20.2.0.7" userver2="100" />
@@ -4445,7 +4440,7 @@
 
     <niobject name="NiSpecularProperty" abstract="0" inherit="NiProperty">
         Gives specularity to a shape. Flags 0x0001.
-        <add name="Flags" type="Flags">1&#039;s Bit = Enable specular lighting on this shape.</add>
+        <add name="Flags" type="Flags">Bit 0 = Enable specular lighting on this shape.</add>
     </niobject>
 
     <niobject name="NiSphericalCollider" abstract="0" inherit="NiParticleModifier">
@@ -4471,7 +4466,7 @@
         <add name="Flags" type="Flags" ver2="10.0.1.2">Property flags.</add>
         <add name="Stencil Enabled" type="byte" ver2="20.0.0.5">Enables or disables the stencil test.</add>
         <add name="Stencil Function" type="StencilCompareMode" ver2="20.0.0.5">Selects the compare mode function (see: glStencilFunc).</add>
-        <add name="Stencil Ref" type="uint" ver2="20.0.0.5">Unknown.  Default is 0.</add>
+        <add name="Stencil Ref" type="uint" ver2="20.0.0.5" />
         <add name="Stencil Mask" type="uint" default="4294967295" ver2="20.0.0.5">A bit mask. The default is 0xffffffff.</add>
         <add name="Fail Action" type="StencilAction" ver2="20.0.0.5" />
         <add name="Z Fail Action" type="StencilAction" ver2="20.0.0.5" />
@@ -4486,7 +4481,7 @@
             Bits 10-11: Draw Mode
             Bits 12-14: Stencil Function
         </add>
-        <add name="Stencil Ref" type="uint" ver1="20.1.0.3">Unknown.  Default is 0.</add>
+        <add name="Stencil Ref" type="uint" ver1="20.1.0.3" />
         <add name="Stencil Mask" type="uint" default="4294967295" ver1="20.1.0.3">A bit mask. The default is 0xffffffff.</add>
     </niobject>
 
@@ -4576,9 +4571,9 @@
         <add name="Glow Texture" type="TexDesc" cond="Has Glow Texture">The glowing texture.</add>
         <add name="Has Bump Map Texture" type="bool" ver1="3.3.0.13" cond="Texture Count &gt; 5">Do we have a bump map texture?</add>
         <add name="Bump Map Texture" type="TexDesc" cond="Has Bump Map Texture">The bump map texture.</add>
-        <add name="Bump Map Luma Scale" type="float" cond="Has Bump Map Texture">Unknown.</add>
-        <add name="Bump Map Luma Offset" type="float" cond="Has Bump Map Texture">Unknown.</add>
-        <add name="Bump Map Matrix" type="Matrix22" cond="Has Bump Map Texture">Unknown.</add>
+        <add name="Bump Map Luma Scale" type="float" cond="Has Bump Map Texture" />
+        <add name="Bump Map Luma Offset" type="float" cond="Has Bump Map Texture" />
+        <add name="Bump Map Matrix" type="Matrix22" cond="Has Bump Map Texture" />
         <add name="Has Normal Texture" type="bool" cond="Texture Count &gt; 6" ver1="20.2.0.5">Do we have a normal texture?</add>
         <add name="Normal Texture" type="TexDesc" cond="Has Normal Texture">Normal texture.</add>
         <add name="Has Parallax Texture" type="bool" cond="Texture Count &gt; 7" ver1="20.2.0.5" />
@@ -4724,18 +4719,12 @@
     <niobject name="NiVertexColorProperty" abstract="0" inherit="NiProperty">
         Property of vertex colors. This object is referred to by the root object of the NIF file whenever some NiTriShapeData object has vertex colors with non-default settings; if not present, vertex colors have vertex_mode=2 and lighting_mode=1.
         <add name="Flags" type="Flags">
-            Property flags. Appears to be unused until 20.1.0.3.
-
             Bits 0-2: Unknown
-            Bit 3: Lighting Mode?
-            Bits 4-5: Vertex Mode?
+            Bit 3: Lighting Mode
+            Bits 4-5: Vertex Mode
         </add>
-        <add name="Vertex Mode" type="VertMode" ver2="20.0.0.5">
-            Determines how vertex and material colors are mixed.
-            related gl function: glColorMaterial
-            In Flags from version 20.1.0.3 onwards.
-        </add>
-        <add name="Lighting Mode" type="LightMode" ver2="20.0.0.5">The light mode. In Flags from 20.1.0.3 on.</add>
+        <add name="Vertex Mode" type="VertMode" ver2="20.0.0.5">In Flags from 20.1.0.3 on.</add>
+        <add name="Lighting Mode" type="LightMode" ver2="20.0.0.5">In Flags from 20.1.0.3 on.</add>
     </niobject>
 
     <niobject name="NiVertWeightsExtraData" abstract="0" inherit="NiExtraData">
@@ -4750,8 +4739,8 @@
     <niobject name="NiVisData" abstract="0" inherit="NiObject">
         DEPRECATED (10.2), REMOVED (?), Replaced by NiBoolData.
         Visibility data for a controller.
-        <add name="Num Keys" type="uint">The number of visibility keys that follow.</add>
-        <add name="Keys" type="Key" arg="1" template="byte" arr1="Num Keys">The visibility keys.</add>
+        <add name="Num Keys" type="uint" />
+        <add name="Keys" type="Key" arg="1" template="byte" arr1="Num Keys" />
     </niobject>
 
     <niobject name="NiWireframeProperty" abstract="0" inherit="NiProperty">
@@ -5167,10 +5156,10 @@
 
     <compound name="Polygon">
         Two dimensional screen elements.
-        <add name="Num Vertices" type="ushort">Number of vertices in this polygon</add>
-        <add name="Vertex Offset" type="ushort">Vertex Offset</add>
-        <add name="Num Triangles" type="ushort">Number of faces in this polygon</add>
-        <add name="Triangle Offset" type="ushort">Triangle offset in shape</add>
+        <add name="Num Vertices" type="ushort" />
+        <add name="Vertex Offset" type="ushort">Offset in vertex array.</add>
+        <add name="Num Triangles" type="ushort" />
+        <add name="Triangle Offset" type="ushort">Offset in indices array.</add>
     </compound>
 
     <niobject name="NiScreenElementsData" inherit="NiTriShapeData">
@@ -5194,9 +5183,9 @@
 
     <niobject name="NiRoomGroup" inherit="NiNode">
         NiRoomGroup represents a set of connected rooms i.e. a game level.
-        <add name="Shell Link" type="Ptr" template="NiNode" >Outer Shell Geometry Node?</add>
-        <add name="Num Rooms" type="int">Number of rooms in this group</add>
-        <add name="Rooms" type="Ptr" template="NiRoom" arr1="Num Rooms">Rooms associated with this group.</add>
+        <add name="Shell" type="Ptr" template="NiNode">Object that represents the room group as seen from the outside.</add>
+        <add name="Num Rooms" type="int" />
+        <add name="Rooms" type="Ptr" template="NiRoom" arr1="Num Rooms" />
     </niobject>
 
     <niobject name="NiRoom" inherit="NiNode">
@@ -5216,9 +5205,9 @@
         They represent flat polygonal regions through which a part of a scene graph can be viewed.
         <add name="Portal Flags" type="ushort" />
         <add name="Plane Count" type="ushort">Unused in 20.x, possibly also 10.x.</add>
-        <add name="Num Vertices" type="ushort">Number of vertices in this polygon</add>
-        <add name="Vertices" type="Vector3" arr1="Num Vertices">Vertices</add>
-        <add name="Target" type="Ptr" template="NiNode">Target portal or room</add>
+        <add name="Num Vertices" type="ushort" />
+        <add name="Vertices" type="Vector3" arr1="Num Vertices" />
+        <add name="Adjoiner" type="Ptr" template="NiNode">Root of the scenegraph which is to be seen through this portal.</add>
     </niobject>
 
     <!-- Red Ocean Custom Objects
@@ -5341,13 +5330,13 @@
     
     <niobject name="BSShaderProperty" abstract="0" inherit="NiProperty">
         Bethesda-specific property.
-        <add name="Smooth" type="Flags" default="1">Unknown.
+        <add name="Smooth" type="Flags" default="1">
             0: smooth no
             1: smooth yes
         </add>
-        <add name="Shader Type" type="BSShaderType" default="SHADER_DEFAULT">Unknown (Set to 0x21 for NoLighting, 0x11 for Water)</add>
-        <add name="Shader Flags" type="BSShaderFlags" default="0x82000000">Shader Property Flags</add>
-        <add name="Shader Flags 2" type="BSShaderFlags2" default="1">Shader Property Flags 2</add>
+        <add name="Shader Type" type="BSShaderType" default="SHADER_DEFAULT" />
+        <add name="Shader Flags" type="BSShaderFlags" default="0x82000000" />
+        <add name="Shader Flags 2" type="BSShaderFlags2" default="1" />
         <add name="Environment Map Scale" type="float" default="1.0" vercond="User Version == 11">Scales the intensity of the environment/cube map.</add>
     </niobject>
 
@@ -5410,23 +5399,23 @@
         <add name="Interpolator 7: Length Var" type="Ref" template="NiInterpolator">References length variation interpolator.</add>
         <add name="Interpolator 8: Width" type="Ref" template="NiInterpolator">References width interpolator.</add>
         <add name="Interpolator 9: Arc Offset" type="Ref" template="NiInterpolator">References interpolator for amplitude control. 0=straight, 50=wide</add>
-        <add name="Subdivisions" type="ushort">Unknown</add>
-        <add name="Num Branches" type="ushort">Unknown</add>
-        <add name="Num Branches Variation" type="ushort">Unknown</add>
+        <add name="Subdivisions" type="ushort" />
+        <add name="Num Branches" type="ushort" />
+        <add name="Num Branches Variation" type="ushort" />
         <add name="Length" type="float">How far lightning will stretch to.</add>
         <add name="Length Variation" type="float">How far lightning variation will stretch to.</add>
         <add name="Width" type="float">How wide the bolt will be.</add>
         <add name="Child Width Mult" type="float">Influences forking behavior with a multiplier.</add>
-        <add name="Arc Offset" type="float">Unknown</add>
-        <add name="Fade Main Bolt" type="bool">Unknown</add>
-        <add name="Fade Child Bolts" type="bool">Unknown</add>
-        <add name="Animate Arc Offset" type="bool">Unknown</add>
+        <add name="Arc Offset" type="float" />
+        <add name="Fade Main Bolt" type="bool" />
+        <add name="Fade Child Bolts" type="bool" />
+        <add name="Animate Arc Offset" type="bool" />
         <add name="Shader Property" type="Ref" template="NiProperty">Reference to a shader property.</add>
 	</niobject>
 
    <niobject name="BSShaderTextureSet" abstract="0" inherit="NiObject">
         Bethesda-specific Texture Set.
-        <add name="Num Textures" type="int" default="6">Number of Textures</add>
+        <add name="Num Textures" type="int" default="6" />
         <add name="Textures" type="SizedString" arr1="Num Textures">Textures.
             0: Diffuse
             1: Normal/Gloss
@@ -5492,7 +5481,7 @@
         Skyrim Shader Property Flags 1
         <option value="0" name="SLSF1_Specular">Enables Specularity</option>
         <option value="1" name="SLSF1_Skinned">Required For Skinned Meshes.</option>
-        <option value="2" name="SLSF1_Temp_Refraction">Unknown</option>
+        <option value="2" name="SLSF1_Temp_Refraction"></option>
         <option value="3" name="SLSF1_Vertex_Alpha">Enables using alpha component of vertex colors.</option>
         <option value="4" name="SLSF1_Greyscale_To_PaletteColor">in EffectShaderProperty</option>
         <option value="5" name="SLSF1_Greyscale_To_PaletteAlpha">in EffectShaderProperty</option>
@@ -5503,8 +5492,8 @@
         <option value="10" name="SLSF1_Facegen_Detail_Map">Use a face detail map in the 4th texture slot.</option>
         <option value="11" name="SLSF1_Parallax">Unused?</option>
         <option value="12" name="SLSF1_Model_Space_Normals">Use Model space normals and an external Specular Map.</option>
-        <option value="13" name="SLSF1_Non_Projective_Shadows">Unknown.</option>
-        <option value="14" name="SLSF1_Landscape">Unknown.</option>
+        <option value="13" name="SLSF1_Non_Projective_Shadows"></option>
+        <option value="14" name="SLSF1_Landscape"></option>
         <option value="15" name="SLSF1_Refraction">Use normal map for refraction effect.</option>
         <option value="16" name="SLSF1_Fire_Refraction"></option>
         <option value="17" name="SLSF1_Eye_Environment_Mapping">Eye Environment Mapping (Must use the Eye shader and the model must be skinned)</option>
@@ -5645,9 +5634,9 @@
         <add name="Emissive Multiple" type="float">Multiplied emissive colors</add>
         <add name="Wet Material" type="string" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
         <add name="Texture Clamp Mode" type="TexClampMode">How to handle texture borders.</add>
-        <add name="Alpha" type="float" default="1.0">The material&#039;s opacity (1=non-transparent).</add>
+        <add name="Alpha" type="float" default="1.0">The material opacity (1=non-transparent).</add>
         <add name="Refraction Strength" type="float">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
-        <add name="Glossiness" type="float">The material&#039;s specular power, or glossiness (0-999).</add>
+        <add name="Glossiness" type="float">The material specular power, or glossiness (0-999).</add>
         <add name="Specular Color" type="Color3">Adds a colored highlight.</add>
         <add name="Specular Strength" type="float" default="1.0">Brightness of specular highlight. (0=not visible) (0-999)</add>
         <add name="Lighting Effect 1" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
@@ -5674,7 +5663,7 @@
         <add name="Parallax Refraction Scale" type="float" cond="Skyrim Shader Type == 11">Depth of inner parallax layer effect.</add>
         <add name="Parallax Inner Layer Texture Scale" type="TexCoord" cond="Skyrim Shader Type == 11">Scales the inner parallax layer texture.</add>
         <add name="Parallax Envmap Strength" type="float" cond="Skyrim Shader Type == 11">How strong the environment/cube map is. (0-??)</add>
-        <add name="Sparkle Parameters" type="Vector4" cond="Skyrim Shader Type == 14">Unknown/unused?  CK lists "snow material" when used.</add>
+        <add name="Sparkle Parameters" type="Vector4" cond="Skyrim Shader Type == 14">CK lists "snow material" when used.</add>
         <add name="Eye Cubemap Scale" type="float" cond="Skyrim Shader Type == 16">Eye cubemap scale</add>
         <add name="Left Eye Reflection Center" type="Vector3" cond="Skyrim Shader Type == 16">Offset to set center for left eye cubemap</add>
         <add name="Right Eye Reflection Center" type="Vector3" cond="Skyrim Shader Type == 16">Offset to set center for right eye cubemap</add>
@@ -5737,44 +5726,43 @@
         <add name="UV Offset" type="TexCoord">Offset UVs. Seems to be unused, but it fits with the other Skyrim shader properties.</add>
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures, see above.</add>
         <add name="Source Texture" type="SizedString">points to an external texture.</add>
-        <add name="Sky Object Type" type="SkyObjectType">Sky Object Type</add>
+        <add name="Sky Object Type" type="SkyObjectType" />
     </niobject>
 
     <niobject name="BSDismemberSkinInstance" abstract="0" inherit="NiSkinInstance">
         Bethesda-specific skin instance.
-        <add name="Num Partitions" type="int">Unknown</add>
-
-        <add name="Partitions" type="BodyPartList" arr1="Num Partitions">Unknown</add>
+        <add name="Num Partitions" type="int" />
+        <add name="Partitions" type="BodyPartList" arr1="Num Partitions" />
     </niobject>
 
     <niobject name="BSDecalPlacementVectorExtraData" inherit="NiFloatExtraData">
-        Bethesda-specific extra data. (for dynamic decal projection?)
-        <add name="Num Vector Blocks" type="short">Number of groups</add>
-        <add name="Vector Blocks" type="DecalVectorArray" arr1="Num Vector Blocks">Number of Blocks</add>
+        Bethesda-specific extra data. Lists locations and normals on a mesh that are appropriate for decal placement.
+        <add name="Num Vector Blocks" type="short" />
+        <add name="Vector Blocks" type="DecalVectorArray" arr1="Num Vector Blocks" />
     </niobject>
 
     <niobject name="BSPSysSimpleColorModifier" inherit="NiPSysModifier">
         Bethesda-specific particle modifier.
-        <add name="Fade In Percent" type="float">Unknown</add>
-        <add name="Fade out Percent" type="float">Unknown</add>
-        <add name="Color 1 End Percent" type="float">Unknown</add>
-        <add name="Color 1 Start Percent" type="float">Unknown</add>
-        <add name="Color 2 End Percent" type="float">Unknown</add>
-        <add name="Color 2 Start Percent" type="float">Unknown</add>
-        <add name="Colors" type="Color4" arr1="3">Colors</add>
+        <add name="Fade In Percent" type="float" />
+        <add name="Fade out Percent" type="float" />
+        <add name="Color 1 End Percent" type="float" />
+        <add name="Color 1 Start Percent" type="float" />
+        <add name="Color 2 End Percent" type="float" />
+        <add name="Color 2 Start Percent" type="float" />
+        <add name="Colors" type="Color4" arr1="3" />
     </niobject>
 
 
     <bitflags name="BSValueNodeFlags" storage="byte">
         Flags for BSValueNode.
-        <option value="0" name="BillboardWorldZ">Billboard World Z</option>
-        <option value="1" name="UsePlayerAdjust">Use Player Adjust</option>
+        <option value="0" name="BillboardWorldZ" />
+        <option value="1" name="UsePlayerAdjust" />
     </bitflags>
 
     <niobject name="BSValueNode" inherit="NiNode">
         Bethesda-specific node. Found on fxFire effects
-        <add name="Value" type="uint">Value</add>
-        <add name="Value Node Flags" type="BSValueNodeFlags">Value node flags.</add>
+        <add name="Value" type="uint" />
+        <add name="Value Node Flags" type="BSValueNodeFlags" />
     </niobject>
 
 
@@ -5794,7 +5782,7 @@
 
     <niobject name="BSPSysStripUpdateModifier" inherit="NiPSysModifier">
         Bethesda-Specific (mesh?) Particle System Modifier.
-        <add name="Update Delta Time" type="float">Unknown</add>
+        <add name="Update Delta Time" type="float" />
     </niobject>
 
 
@@ -5806,9 +5794,9 @@
 
     <niobject name="BSMasterParticleSystem" inherit="NiNode">
         Bethesda-Specific particle system.
-        <add name="Max Emitter Objects" type="ushort">Unknown</add>
-        <add name="Num Particle Systems" type="int">Unknown</add>
-        <add name="Particle Systems" type="Ref" template="NiAVObject" arr1="Num Particle Systems">Unknown</add>
+        <add name="Max Emitter Objects" type="ushort" />
+        <add name="Num Particle Systems" type="int" />
+        <add name="Particle Systems" type="Ref" template="NiAVObject" arr1="Num Particle Systems" />
 
     </niobject>
 
@@ -5827,16 +5815,16 @@
 
     <niobject name="BSOrderedNode" inherit="NiNode">
         Bethesda-Specific node.
-        <add name="Alpha Sort Bound" type="Vector4">Unknown</add>
-        <add name="Static Bound" type="bool">Unknown</add>
+        <add name="Alpha Sort Bound" type="Vector4" />
+        <add name="Static Bound" type="bool" />
     </niobject>
 
 
     <niobject name="BSRangeNode" inherit="NiNode">
         Bethesda-Specific node.
-        <add name="Min" type="byte">Min</add>
-        <add name="Max" type="byte">Max</add>
-        <add name="Current" type="byte">Current</add>
+        <add name="Min" type="byte" />
+        <add name="Max" type="byte" />
+        <add name="Current" type="byte" />
     </niobject>
 
     <niobject name="BSBlastNode" inherit="BSRangeNode">
@@ -5850,7 +5838,7 @@
 
     <niobject name="BSRefractionFirePeriodController" abstract="0" inherit="NiTimeController">
         Bethesda-specific time controller.
-        <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="20.2.0.7">Link to Interpolator.</add>
+        <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="20.2.0.7" />
     </niobject>
 
     <niobject name="bhkConvexListShape" abstract="0" inherit="bhkShape">
@@ -5862,7 +5850,7 @@
 
         Also, shapes collected in a bhkListShape may not have the correct
         walking noise, so only use it for non-walkable objects.
-        <add name="Num Sub Shapes" type="uint">The number of sub shapes referenced.</add>
+        <add name="Num Sub Shapes" type="uint" />
         <add name="Sub Shapes" type="Ref" template="bhkConvexShape" arr1="Num Sub Shapes">List of shapes.</add>
         <add name="Material" type="HavokMaterial">The material of the shape.</add>
         <add name="Radius" type="float" />
@@ -5882,9 +5870,9 @@
 
     <niobject name="BSTreadTransfInterpolator" abstract="0" inherit="NiInterpolator">
         Bethesda-specific interpolator.
-        <add name="Num Tread Transforms" type="int">Unknown.</add>
-        <add name="Tread Transforms" type="BSTreadTransform" arr1="Num Tread Transforms">Unknown.</add>
-        <add name="Data" type="Ref" template="NiFloatData">Unknown float data.</add>
+        <add name="Num Tread Transforms" type="int" />
+        <add name="Tread Transforms" type="BSTreadTransform" arr1="Num Tread Transforms" />
+        <add name="Data" type="Ref" template="NiFloatData" />
     </niobject>
 
     <enum name="AnimNoteType" storage="uint">
@@ -5912,8 +5900,8 @@
     <niobject name="bhkLiquidAction" inherit="bhkSerializable">
         Bethesda-specific Havok serializable.
         <add name="User Data" type="uint" />
-        <add name="Unknown Int 2" type="int">Unknown Flag</add>
-        <add name="Unknown Int 3" type="int">Unknown Flag</add>
+        <add name="Unknown Int 2" type="int">Unknown</add>
+        <add name="Unknown Int 3" type="int">Unknown</add>
         <add name="Initial Stick Force" type="float" />
         <add name="Stick Strength" type="float" />
         <add name="Neighbor Distance" type="float" />
@@ -5953,8 +5941,8 @@
     
     <niobject name="BSMultiBoundSphere" inherit="BSMultiBoundData">
         Bethesda-specific object.
-        <add name="Center" type="Vector3">Center</add>
-        <add name="Radius" type="float">Radius</add>
+        <add name="Center" type="Vector3" />
+        <add name="Radius" type="float" />
     </niobject>
 
     <niobject name="BSSegmentedTriShape" inherit="NiTriShape">
@@ -5983,12 +5971,12 @@
         <!-- todo: check if this is essentially the same as BSPackedAdditionalData, i.e. if this is identical to BSPackedAdditionalData minus its last two fields -->
         <add name="Has Data" type="bool">Has data</add>
         <add name="Block Size" type="int" cond="Has Data">Size of Block</add>
-        <add name="Num Blocks" type="int" cond="Has Data">Unknown</add>
-        <add name="Block Offsets" type="int" arr1="Num Blocks" cond="Has Data">Unknown</add>
+        <add name="Num Blocks" type="int" cond="Has Data" />
+        <add name="Block Offsets" type="int" arr1="Num Blocks" cond="Has Data" />
 
-        <add name="Num Data" type="int" cond="Has Data">Unknown</add>
-        <add name="Data Sizes" type="int" arr1="Num Data" cond="Has Data">Unknown</add>
-        <add name="Data" type="byte" arr1="Num Data" arr2="Block Size" cond="Has Data">Unknown</add>
+        <add name="Num Data" type="int" cond="Has Data" />
+        <add name="Data Sizes" type="int" arr1="Num Data" cond="Has Data" />
+        <add name="Data" type="byte" arr1="Num Data" arr2="Block Size" cond="Has Data" />
     </compound>
 
     <compound name="BSPackedAdditionalDataBlock">
@@ -6000,7 +5988,7 @@
 
         <add name="Num Atoms" type="int" cond="Has Data">Number of atoms?</add>
         <add name="Atom Sizes" type="int" arr1="Num Atoms" cond="Has Data">The sum of all of these equal num total bytes per element, so this probably describes how each data element breaks down into smaller chunks (i.e. atoms).</add>
-        <add name="Data" type="byte" arr1="Num Total Bytes" cond="Has Data">Unknown</add>
+        <add name="Data" type="byte" arr1="Num Total Bytes" cond="Has Data" />
         <add name="Unknown Int 1" type="int" />
         <add name="Num Total Bytes Per Element" type="int">Unsure, but this seems to correspond again to the number of total bytes per element.</add>
     </compound>
@@ -6024,8 +6012,8 @@
 
     <niobject name="BSWArray" inherit="NiExtraData">
         Bethesda-specific extra data.
-        <add name="Num Items" type="int">Unknown</add>
-        <add name="Items" type="int" arr1="Num Items">Unknown</add>
+        <add name="Num Items" type="int" />
+        <add name="Items" type="int" arr1="Num Items" />
     </niobject>
 
     <niobject name="bhkAabbPhantom" inherit="bhkShapePhantom">
@@ -6068,16 +6056,16 @@
         Found in Fallout 3 .psa files, extra ragdoll info for NPCs/creatures. (usually idleanims\deathposes.psa)
         Defines different kill poses. The game selects the pose randomly and applies it to a skeleton immediately upon ragdolling.
         Poses can be previewed in GECK Object Window-Actor Data-Ragdoll and selecting Pose Matching tab.
-        <add name="Num Bones" type="int">Number of target bones.</add>
-        <add name="Bones" type="string" arr1="Num Bones">Array of bone names.</add>
-        <add name="Num Poses" type="int">Number of poses.</add>
-        <add name="Poses" type="BonePose" arr1="Num Poses">Array of poses.</add>
+        <add name="Num Bones" type="int" />
+        <add name="Bones" type="string" arr1="Num Bones" />
+        <add name="Num Poses" type="int" />
+        <add name="Poses" type="BonePose" arr1="Num Poses" />
     </niobject>
 
     <niobject name="bhkRagdollTemplate" inherit="NiExtraData">
         Found in Fallout 3, more ragdoll info?  (meshes\ragdollconstraint\*.rdt)
-        <add name="Num Bones" type="int">Number of target bones</add>
-        <add name="Bones" type="Ref" template="NiObject" arr1="Num Bones">Bones in index</add>
+        <add name="Num Bones" type="int" />
+        <add name="Bones" type="Ref" template="NiObject" arr1="Num Bones" />
     </niobject>
 
     <niobject name="bhkRagdollTemplateData" inherit="NiObject">
@@ -6201,7 +6189,6 @@
         <add name="Regions" type="Region" arr1="Num Regions">The regions in the mesh. Regions can be used to mark off submeshes which are independent draw calls.</add>
         <add name="Num Components" type="uint">Number of components of the data (matches corresponding field in MeshData).</add>
         <add name="Component Formats" type="ComponentFormat" arr1="Num Components">The format of each component in this data stream.</add>
-        <!-- temporarily defined as blob until we have a way to handle this -->
         <add name="Data" type="byte" binary="1" arr1="Num Bytes" />
         <add name="Streamable" type="bool" default="1" />
     </niobject>
@@ -6243,15 +6230,15 @@
     <compound name="MaterialData" ver1="20.5.0.0">
         Data stored per-material by NiRenderObject
         <add name="Material Name" type="string">The name of the material.</add>
-        <add name="Material Extra Data" type ="uint">Extra data associated with the material?</add>
+        <add name="Material Extra Data" type="uint">Extra data associated with the material?</add>
     </compound>
 
     <niobject name="NiRenderObject" inherit="NiAVObject">
         An object that can be rendered.
-        <add name="Num Materials" type="uint">The number of materials affecting this renderable object.</add>
+        <add name="Num Materials" type="uint" />
         <add name="Material Data" type="MaterialData" arr1="Num Materials">Per-material data.</add>
         <add name="Active Material" type="int" default="-1">The index of the currently active material.</add>
-        <add name="Material Needs Update Default" type="bool">The initial value for the flag that determines if the internal cached shader is valid.</add>
+        <add name="Material Needs Update Default" type="bool">Whether the materials for this render object always needs to be updated before rendering with them.</add>
     </niobject>
 
     <enum name="MeshPrimitiveType" storage="uint">
@@ -6264,23 +6251,23 @@
     </enum>
 
     <enum name="SyncPoint" storage="ushort">
-        Specifies the time when an application must syncronize for some reason.
-        <option value="0x8000" name="SYNC_ANY">Value used when no specific sync point is desired.</option>
+        A sync point corresponds to a particular stage in per-frame processing.
+        <option value="0x8000" name="SYNC_ANY">Synchronize for any sync points that the modifier supports.</option>
         <option value="0x8010" name="SYNC_UPDATE">Synchronize when an object is updated.</option>
         <option value="0x8020" name="SYNC_POST_UPDATE">Synchronize when an entire scene graph has been updated.</option>
         <option value="0x8030" name="SYNC_VISIBLE">Synchronize when an object is determined to be potentially visible.</option>
         <option value="0x8040" name="SYNC_RENDER">Synchronize when an object is rendered.</option>
         <option value="0x8050" name="SYNC_PHYSICS_SIMULATE">Synchronize when a physics simulation step is about to begin.</option>
         <option value="0x8060" name="SYNC_PHYSICS_COMPLETED">Synchronize when a physics simulation step has produced results.</option>
-        <option value="0x8070" name="SYNC_REFLECTIONS">Syncronize after all data necessary to calculate reflections is ready.</option>
+        <option value="0x8070" name="SYNC_REFLECTIONS">Synchronize after all data necessary to calculate reflections is ready.</option>
     </enum>
 
     <niobject name="NiMeshModifier" inherit="NiObject">
         Base class for mesh modifiers.
-        <add name="Num Submit Points" type="uint">The number of submit points used by this mesh modifier.</add>
-        <add name="Submit Points" type="SyncPoint" arr1="Num Submit Points">The submit points used by this mesh modifier</add>
-        <add name="Num Complete Points" type="uint">The number of complete points used by this mesh modifier.</add>
-        <add name="Complete Points" type="SyncPoint" arr1="Num Complete Points">The complete points used by this mesh modifier</add>
+        <add name="Num Submit Points" type="uint" />
+        <add name="Submit Points" type="SyncPoint" arr1="Num Submit Points">The sync points supported by this mesh modifier for SubmitTasks.</add>
+        <add name="Num Complete Points" type="uint" />
+        <add name="Complete Points" type="SyncPoint" arr1="Num Complete Points">The sync points supported by this mesh modifier for CompleteTasks.</add>
     </niobject>
 
     <compound name="ExtraMeshDataEpicMickey">
@@ -6316,7 +6303,7 @@
         <add name="Num Datas" type="uint" />
         <add name="Datas" type="MeshData" arr1="Num Datas" />
         <add name="Num Modifiers" type="uint" />
-        <add name="Modifiers" type="Ref" template="NiMeshModifier" arr1="Num Modifiers" /><!-- see Zorsis Zombie_Boy.nif -->
+        <add name="Modifiers" type="Ref" template="NiMeshModifier" arr1="Num Modifiers" />
 
         <!-- start: epic mickey (user version 15) unknowns -->
         <add name="Unknown 100" type="byte" userver="15">Unknown.</add>
@@ -6338,11 +6325,11 @@
     </niobject>
 
     <niobject name="NiMorphWeightsController" inherit="NiInterpController">
-        <add name="Unknown 2" type="int"></add>
-        <add name="Num Interpolators" type="uint"></add>
-        <add name="Interpolators" type="Ref" template="NiObject" arr1="Num Interpolators"></add>
-        <add name="Num Targets" type="uint">The number of morph targets.</add>
-        <add name="Target Names" type="string" arr1="Num Targets">Name of each morph target.</add>
+        <add name="Count" type="uint" />
+        <add name="Num Interpolators" type="uint" />
+        <add name="Interpolators" type="Ref" template="NiObject" arr1="Num Interpolators" />
+        <add name="Num Targets" type="uint" />
+        <add name="Target Names" type="string" arr1="Num Targets" />
     </niobject>
 
     <compound name="ElementReference" ver1="20.5.0.0">
@@ -6371,20 +6358,22 @@
             USE_SOFTWARE_SKINNING = 0x0001
             RECOMPUTE_BOUNDS = 0x0002
         </add>
-        <add name="Skeleton Root" type="Ptr" template="NiAVObject">The root bone of the skeleton.</add><!-- Root Bone Parent -->
-        <add name="Skeleton Transform" type="NiTransform">The transform that takes the root bone parent coordinate system into the skin coordinate system.</add><!-- Root Bone Parent To Skin Transform -->
+        <add name="Skeleton Root" type="Ptr" template="NiAVObject">The root bone of the skeleton.</add>
+        <add name="Skeleton Transform" type="NiTransform">The transform that takes the root bone parent coordinate system into the skin coordinate system.</add>
         <add name="Num Bones" type="uint">The number of bones referenced by this mesh modifier.</add>
         <add name="Bones" type="Ptr" template="NiAVObject" arr1="Num Bones">Pointers to the bone nodes that affect this skin.</add>
-        <add name="Bone Transforms" type="NiTransform" arr1="Num Bones">The transforms that go from bind-pose space to bone space.</add><!-- Skin To Bone Transforms -->
+        <add name="Bone Transforms" type="NiTransform" arr1="Num Bones">The transforms that go from bind-pose space to bone space.</add>
         <add name="Bone Bounds" type="NiBound" cond="(Flags &amp; 2)!=0" arr1="Num Bones">The bounds of the bones.  Only stored if the RECOMPUTE_BOUNDS bit is set.</add>
     </niobject>
 
     <niobject name="NiMeshHWInstance" inherit="NiAVObject">
-        <add name="Master Mesh" type="Ref" template="NiMesh" />
+        An instance of a hardware-instanced mesh in a scene graph.
+        <add name="Master Mesh" type="Ref" template="NiMesh">The instanced mesh this object represents.</add>
         <add name="Mesh Modifier" type="Ref" template="NiInstancingMeshModifier" />
     </niobject>
 
     <niobject name="NiInstancingMeshModifier" inherit="NiMeshModifier">
+        Mesh modifier that provides per-frame instancing capabilities in Gamebryo.
         <add name="Has Instance Nodes" type="bool" />
         <add name="Per Instance Culling" type="bool" />
         <add name="Has Static Bounds" type="bool" />
@@ -6400,6 +6389,7 @@
     </compound>
 
     <niobject name="NiSkinningLODController" inherit="NiTimeController">
+        Defines the levels of detail for a given character and dictates the character's current LOD.
         <add name="Current LOD" type="uint" />
         <add name="Num Bones" type="uint" />
         <add name="Bones" type="Ref" template="NiNode" arr1="Num Bones" />
@@ -6418,6 +6408,7 @@
     </compound>
 
     <enum name="AlignMethod" storage="uint">
+        Describes the various methods that may be used to specify the orientation of the particles.
         <option value="0" name="ALIGN_INVALID" />
         <option value="1" name="ALIGN_PER_PARTICLE" />
         <option value="2" name="ALIGN_LOCAL_FIXED" />
@@ -6491,8 +6482,8 @@
 
     <niobject name="NiPSSimulator" inherit="NiMeshModifier">
         The mesh modifier that performs all particle system simulation.
-        <add name="Num Simulation Steps" type="uint">The number of simulation steps in this modifier.</add>
-        <add name="Simulation Steps" type="Ref" template="NiPSSimulatorStep" arr1="Num Simulation Steps">Links to the simulation steps.</add>
+        <add name="Num Simulation Steps" type="uint" />
+        <add name="Simulation Steps" type="Ref" template="NiPSSimulatorStep" arr1="Num Simulation Steps" />
     </niobject>
 
     <niobject name="NiPSSimulatorStep" inherit="NiObject" abstract="1">
@@ -6509,13 +6500,13 @@
 
     <niobject name="NiPSSimulatorGeneralStep" inherit="NiPSSimulatorStep">
         Encapsulates a floodgate kernel that updates particle size, colors, and rotations.
-        <add name="Num Size Keys" type="byte" ver1="20.6.1.0">The number of size animation keys.</add>
+        <add name="Num Size Keys" type="byte" ver1="20.6.1.0" />
         <add name="Size Keys" type="Key" template="float" arg="1" arr1="Num Size Keys" ver1="20.6.1.0">The particle size keys.</add>
         <add name="Size Loop Behavior" type="PSLoopBehavior" ver1="20.6.1.0">The loop behavior for the size keys.</add>
-        <add name="Num Color Keys" type="byte">The number of color animation keys.</add>
+        <add name="Num Color Keys" type="byte" />
         <add name="Color Keys" type="Key" template="ByteColor4" arg="1" arr1="Num Color Keys">The particle color keys.</add>
         <add name="Color Loop Behavior" type="PSLoopBehavior" ver1="20.6.1.0">The loop behavior for the color keys.</add>
-        <add name="Num Rotation Keys" type="byte" ver1="20.6.1.0">The number of rotation animation keys.</add>
+        <add name="Num Rotation Keys" type="byte" ver1="20.6.1.0" />
         <add name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys" ver1="20.6.1.0">The particle rotation keys.</add>
         <add name="Rotation Loop Behavior" type="PSLoopBehavior" ver1="20.6.1.0">The loop behavior for the rotation keys.</add>
         <add name="Grow Time" type="float"> The the amount of time over which a particle's size is ramped from 0.0 to 1.0 in seconds</add>
@@ -6526,19 +6517,19 @@
 
     <niobject name="NiPSSimulatorForcesStep" inherit="NiPSSimulatorStep">
         Encapsulates a floodgate kernel that simulates particle forces.
-        <add name="Num Forces" type="uint">The number of forces affecting the particle system.</add>
-        <add name="Forces" type="Ref" template="NiObject" arr1="Num Forces">The forces affecting the particle system.</add><!--Should be NiPSForce-->
+        <add name="Num Forces" type="uint" />
+        <add name="Forces" type="Ref" template="NiPSForce" arr1="Num Forces">The forces affecting the particle system.</add>
     </niobject>
 
     <niobject name="NiPSSimulatorCollidersStep" inherit="NiPSSimulatorStep">
         Encapsulates a floodgate kernel that simulates particle colliders.
-        <add name="Num Colliders" type="uint">The number of colliders affecting the particle system.</add>
-        <add name="Colliders" type="Ref" template="NiObject" arr1="Num Colliders">The colliders affecting the particle system.</add><!--Should be NiPSCollider-->
+        <add name="Num Colliders" type="uint" />
+        <add name="Colliders" type="Ref" template="NiPSCollider" arr1="Num Colliders">The colliders affecting the particle system.</add>
     </niobject>
 
     <niobject name="NiPSSimulatorMeshAlignStep" inherit="NiPSSimulatorStep">
         Encapsulates a floodgate kernel that updates mesh particle alignment and transforms.
-        <add name="Num Rotation Keys" type="byte">The number of rotation keys.</add>
+        <add name="Num Rotation Keys" type="byte" />
         <add name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys">The particle rotation keys.</add>
         <add name="Rotation Loop Behavior" type="PSLoopBehavior">The loop behavior for the rotation keys.</add>
     </niobject>
@@ -6555,6 +6546,7 @@
     <!-- NiPS Forces -->
 
     <enum name="PSForceType" storage="uint">
+        This is used by the Floodgate kernel to determine which NiPSForceHelpers functions to call.
         <option value="0" name="FORCE_BOMB" />
         <option value="1" name="FORCE_DRAG" />
         <option value="2" name="FORCE_AIR_FIELD" />
@@ -6751,6 +6743,7 @@
     <!-- NiPS Colliders -->
 
     <enum name="ColliderType" storage="uint">
+        This is used by the Floodgate kernel to determine which NiPSColliderHelpers functions to call.
         <option value="0" name="COLLIDER_PLANAR" />
         <option value="1" name="COLLIDER_SPHERICAL" />
     </enum>
@@ -6808,6 +6801,7 @@
     </niobject>
 
     <niobject name="NiShadowGenerator" inherit="NiObject">
+        An NiShadowGenerator object is attached to an NiDynamicEffect object to inform the shadowing system that the effect produces shadows.
         <add name="Name" type="string" />
         <add name="Flags" type="ushort" />
         <add name="Num Shadow Casters" type="uint" />
@@ -6869,15 +6863,15 @@
 		<add name="Materials 8" type="uint" arr1="Num Materials 8">Does not appear to be used.</add>
 		<add name="Num Materials" type="uint">Number of chunk materials</add>
 		<add name="Chunk Materials" type="bhkCMSDMaterial" arr1="Num Materials">Table (array) with sets of materials. Chunks refers to this table by index.</add>
-		<add name="Unknown Int 6" type="uint">Unknown</add>
+		<add name="Num Named Materials" type="uint" />
 		<add name="Num Transforms" type="uint">Number of chunk transformations</add>
         <add name="Chunk Transforms" type="bhkCMSDTransform" arr1="Num Transforms">Table (array) with sets of transformations. Chunks refers to this table by index.</add>
-		<add name="Num Big Verts" type="uint">Unknown</add>
+		<add name="Num Big Verts" type="uint" />
 		<add name="Big Verts" type="Vector4" arr1="Num Big Verts">Compressed Vertices?</add>
-        <add name="Num Big Tris" type="uint">Unknown</add>
-        <add name="Big Tris" type="bhkCMSDBigTris" arr1="Num Big Tris">Unknown</add>
-        <add name="Num Chunks" type="uint">Unknown</add>
-        <add name="Chunks" type="bhkCMSDChunk" arr1="Num Chunks"></add>
+        <add name="Num Big Tris" type="uint" />
+        <add name="Big Tris" type="bhkCMSDBigTris" arr1="Num Big Tris" />
+        <add name="Num Chunks" type="uint" />
+        <add name="Chunks" type="bhkCMSDChunk" arr1="Num Chunks" />
         <add name="Num Convex Piece A" type="uint">Does not appear to be used. Needs array.</add>
 	</niobject>
 	
@@ -6917,9 +6911,9 @@
 
 	<niobject name="BSLODTriShape" inherit="NiTriBasedGeom">
 		A variation on NiTriShape, for visibility control over vertex groups.
-		<add name="Level 0 Size" type="uint">Unknown</add>
-		<add name="Level 1 Size" type="uint">Unknown</add>
-		<add name="Level 2 Size" type="uint">Unknown</add>
+		<add name="Level 0 Size" type="uint" />
+		<add name="Level 1 Size" type="uint" />
+		<add name="Level 2 Size" type="uint" />
 	</niobject>
 
 	<niobject name="BSFurnitureMarkerNode" inherit="BSFurnitureMarker">
@@ -6932,9 +6926,9 @@
     
     <niobject name="BSTreeNode" inherit="NiNode">
         Node for handling Trees, Switches branch configurations for variation?
-        <add name="Num Bones 1" type="uint">Unknown</add>
+        <add name="Num Bones 1" type="uint" />
         <add name="Bones 1" type="Ref" arr1="Num Bones 1" template="NiNode">Unknown</add>
-        <add name="Num Bones 2" type="uint">Unknown</add>
+        <add name="Num Bones 2" type="uint" />
         <add name="Bones" type="Ref" arr1="Num Bones 2" template="NiNode">Unknown</add>
     </niobject>
     
@@ -7083,11 +7077,11 @@
     </niobject>
 
     <compound name="BSConnectPoint">
-        <add name="Parent" type="SizedString" />
+        <add name="Parent" type="SizedString" default="WorkshopConnectPoints" />
         <add name="Name" type="SizedString" />
         <add name="Rotation" type="Quaternion" />
         <add name="Translation" type="Vector3" />
-        <add name="Scale" type="float" />
+        <add name="Scale" type="float" default="1.0" />
     </compound>
 
     <niobject name="BSConnectPoint::Parents" inherit="NiExtraData">

--- a/nif.xml
+++ b/nif.xml
@@ -1479,8 +1479,8 @@
         <add name="User Version" type="ulittle32" ver1="10.0.1.8">An extra version number, for companies that decide to modify the file format.</add>
         <add name="Num Blocks" type="ulittle32" ver1="3.1.0.1">Number of file objects.</add>
         <!-- BSStreamHeader -->
-        <add name="User Version 2" type="ulittle32" default="0" cond="(Version == 20.2.0.7) || (Version == 20.0.0.5) || ((Version == 20.0.0.4) &amp;&amp; (User Version == 11)) || ((Version &gt;= 10.0.1.2) &amp;&amp; (Version &lt; 20.0.0.4) &amp;&amp; (User Version &gt;= 3))" />
-        <add name="Export Info" type="ExportInfo" cond="(Version == 20.2.0.7) || (Version == 20.0.0.5) || ((Version == 20.0.0.4) &amp;&amp; (User Version == 11)) || ((Version &gt;= 10.0.1.2) &amp;&amp; (Version &lt; 20.0.0.4) &amp;&amp; (User Version &gt;= 3))" />
+        <add name="User Version 2" type="ulittle32" default="0" cond="((Version == 20.2.0.7) || (Version == 20.0.0.5) || ((Version &gt;= 10.0.1.2) &amp;&amp; (Version &lt;= 20.0.0.4) &amp;&amp; (User Version &lt;= 11))) &amp;&amp; (User Version &gt;= 3)" />
+        <add name="Export Info" type="ExportInfo" cond="((Version == 20.2.0.7) || (Version == 20.0.0.5) || ((Version &gt;= 10.0.1.2) &amp;&amp; (Version &lt;= 20.0.0.4) &amp;&amp; (User Version &lt;= 11))) &amp;&amp; (User Version &gt;= 3)" />
         <add name="Max Filepath" type="ShortString" cond="(User Version 2 == 130)" />
         <!-- / BSStreamHeader -->
         <add name="Metadata" type="ByteArray" ver1="30.0.0.0" />
@@ -3304,7 +3304,7 @@
         <!-- Bethesda -->
         <add name="Has Texture Indices" type="bool" vercond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
         <add name="Num Subtexture Offsets" type="uint" vercond="(User Version 2 &gt; 34)">How many quads to use in BSPSysSubTexModifier for texture atlasing</add>
-        <add name="Num Subtexture Offsets" type="byte" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt;= 34)">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</add>
+        <add name="Num Subtexture Offsets" type="byte" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt;= 34) &amp;&amp; (User Version 2 &gt; 0)">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</add>
         <add name="Subtexture Offsets" type="Vector4" arr1="Num Subtexture Offsets" vercond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">Defines UV offsets</add>
         <add name="Aspect Ratio" type="float" vercond="(User Version 2 &gt; 34)">Sets aspect ratio for Subtexture Offset UV quads</add>
         <add name="Aspect Flags" type="ushort" vercond="(User Version 2 &gt; 34)" />

--- a/nif.xml
+++ b/nif.xml
@@ -143,16 +143,9 @@
         These are like C enums and consist of a list of options.  They can appear
         as parts of compounds or niobjects.-->
 
-    <enum name="AlphaFormat" storage="uint">
-        An unsigned 32-bit integer, describing how transparency is handled in a texture.
-        <option value="0" name="ALPHA_NONE">No alpha blending; the texture is fully opaque.</option>
-        <option value="1" name="ALPHA_BINARY">Texture is either fully transparent or fully opaque.  There are no partially transparent areas.</option>
-        <option value="2" name="ALPHA_SMOOTH">Full range of alpha values can be used from fully transparent to fully opaque including all partially transparent values in between.</option>
-        <option value="3" name="ALPHA_DEFAULT">Use default setting.</option>
-    </enum>
 
     <enum name="ApplyMode" storage="uint">
-        An unsigned 32-bit integer, describing the apply mode of a texture.
+        Describes how the vertex colors are blended with the filtered texture color.
         <option value="0" name="APPLY_REPLACE">Replaces existing color</option>
         <option value="1" name="APPLY_DECAL">For placing images on the object like stickers.</option>
         <option value="2" name="APPLY_MODULATE">Modulates existing color. (Default)</option>
@@ -185,14 +178,8 @@
         <option value="5" name="CONST_KEY">Step function. Used for visibility keys in NiBoolData.</option>
     </enum>
 
-    <enum name="LightMode" storage="uint">
-        An unsigned 32-bit integer, describing how vertex colors influence lighting.
-        <option value="0" name="LIGHT_MODE_EMISSIVE">Emissive.</option>
-        <option value="1" name="LIGHT_MODE_EMI_AMB_DIF">Emissive + Ambient + Diffuse. (Default)</option>
-    </enum>
-
     <enum name="OblivionHavokMaterial" storage="uint">
-        A material, used by havok shape objects in Oblivion.
+        Bethesda Havok. Material descriptor for a Havok shape in Oblivion.
         <option value="0" name="OB_HAV_MAT_STONE">Stone</option>
         <option value="1" name="OB_HAV_MAT_CLOTH">Cloth</option>
         <option value="2" name="OB_HAV_MAT_DIRT">Dirt</option>
@@ -228,10 +215,7 @@
     </enum>
 
     <enum name="Fallout3HavokMaterial" storage="uint">
-        A material, used by havok shape objects in Fallout 3.
-        Bit 5: flag for PLATFORM (for values 32-63 substract 32 to know material number)
-        Bit 6: flag for STAIRS  (for values 64-95 substract 64 to know material number)
-        Bit 5+6: flag for STAIRS+PLATFORM  (for values 96-127 substract 96 to know material number)
+        Bethesda Havok. Material descriptor for a Havok shape in Fallout 3 and Fallout NV.
         <option value="0" name="FO_HAV_MAT_STONE">Stone</option>
         <option value="1" name="FO_HAV_MAT_CLOTH">Cloth</option>
         <option value="2" name="FO_HAV_MAT_DIRT">Dirt</option>
@@ -363,7 +347,7 @@
     </enum>
 
     <enum name="SkyrimHavokMaterial" storage="uint">
-        A material, used by havok shape objects in Skyrim.
+        Bethesda Havok. Material descriptor for a Havok shape in Skyrim.
         <option value="131151687" name="SKY_HAV_MAT_BROKEN_STONE">Broken Stone</option>
         <option value="365420259" name="SKY_HAV_MAT_LIGHT_WOOD">Light Wood</option>
         <option value="398949039" name="SKY_HAV_MAT_SNOW">Snow</option>
@@ -428,7 +412,7 @@
     </enum>
 
     <enum name="OblivionLayer" storage="byte">
-        Sets mesh color in Oblivion Construction Set.  Anything higher than 57 is also null.
+        Bethesda Havok. Describes the collision layer a body belongs to in Oblivion.
         <option value="0" name="OL_UNIDENTIFIED">Unidentified (white)</option>
         <option value="1" name="OL_STATIC">Static (red)</option>
         <option value="2" name="OL_ANIM_STATIC">AnimStatic (magenta)</option>
@@ -490,7 +474,7 @@
     </enum>
 
     <enum name="Fallout3Layer" storage="byte">
-        Sets mesh color in Fallout 3 GECK. Anything higher than 72 is also null.
+        Bethesda Havok. Describes the collision layer a body belongs to in Fallout 3 and Fallout NV.
         <option value="0" name="FOL_UNIDENTIFIED">Unidentified (white)</option>
         <option value="1" name="FOL_STATIC">Static (red)</option>
         <option value="2" name="FOL_ANIM_STATIC">AnimStatic (magenta)</option>
@@ -538,7 +522,7 @@
     </enum>
 
     <enum name="SkyrimLayer" storage="byte">
-        Physical purpose of collision object? The setting affects object's havok behavior in game. Anything higher than 47 is also null.
+        Bethesda Havok. Describes the collision layer a body belongs to in Skyrim.
         <option value="0" name="SKYL_UNIDENTIFIED">Unidentified</option>
         <option value="1" name="SKYL_STATIC">Static</option>
         <option value="2" name="SKYL_ANIMSTATIC">Anim Static</option>
@@ -590,20 +574,15 @@
     </enum>
 
     <enum name="MoppDataBuildType" storage="byte">
+        Bethesda Havok.
         A byte describing if MOPP Data is organized into chunks (PS3) or not (PC)
         <option value="0" name="BUILT_WITH_CHUNK_SUBDIVISION">Organized in chunks for PS3.</option>
         <option value="1" name="BUILT_WITHOUT_CHUNK_SUBDIVISION">Not organized in chunks for PC. (Default)</option>
         <option value="2" name="BUILD_NOT_SET">Build type not set yet.</option>
     </enum>
 
-    <enum name="MipMapFormat" storage="uint">
-        An unsigned 32-bit integer, describing how mipmaps are handled in a texture.
-        <option value="0" name="MIP_FMT_NO">Texture does not use mip maps.</option>
-        <option value="1" name="MIP_FMT_YES">Texture uses mip maps.</option>
-        <option value="2" name="MIP_FMT_DEFAULT">Use default setting.</option>
-    </enum>
-
     <enum name="PlatformID" storage="uint" prefix="PLATFORM">
+        Target platform for NiPersistentSrcTextureRendererData (later than 30.1).
         <option value="0" name="ANY" />
         <option value="1" name="XENON" />
         <option value="2" name="PS3" />
@@ -613,6 +592,7 @@
     </enum>
 
     <enum name="RendererID" storage="uint" prefix="RENDERER">
+        Target renderer for NiPersistentSrcTextureRendererData (until 30.1).
         <option value="0" name="XBOX360" />
         <option value="1" name="PS3" />
         <option value="2" name="DX9" />
@@ -623,27 +603,28 @@
     </enum>
 
     <enum name="PixelFormat" storage="uint" prefix="PX">
-        Specifies the pixel format used by the NiPixelData object to store a texture.
-        <option value="0" name="FMT_RGB8">24-bit color: uses 8 bit to store each red, blue, and green component.</option>
-        <option value="1" name="FMT_RGBA8">32-bit color with alpha: uses 8 bits to store each red, blue, green, and alpha component.</option>
-        <option value="2" name="FMT_PAL8">8-bit palette index: uses 8 bits to store an index into the palette stored in a NiPalette object.</option>
-        <option value="3" name="FMT_PALA" />
+        Describes the pixel format used by the NiPixelData object to store a texture.
+        <option value="0" name="FMT_RGB">24-bit RGB. 8 bits per red, blue, and green component.</option>
+        <option value="1" name="FMT_RGBA">32-bit RGB with alpha. 8 bits per red, blue, green, and alpha component.</option>
+        <option value="2" name="FMT_PAL">8-bit palette index.</option>
+        <option value="3" name="FMT_PALA">8-bit palette index with alpha.</option>
         <option value="4" name="FMT_DXT1">DXT1 compressed texture.</option>
         <option value="5" name="FMT_DXT3">DXT3 compressed texture.</option>
         <option value="6" name="FMT_DXT5">DXT5 compressed texture.</option>
-        <option value="7" name="FMT_RGB24NONINT">24-bit noninterleaved texture.</option>
-        <option value="8" name="FMT_BUMP" />
-        <option value="9" name="FMT_BUMPLUMA" />
-        <option value="10" name="FMT_RENDERSPEC" />
-        <option value="11" name="FMT_1CH" />
-        <option value="12" name="FMT_2CH" />
-        <option value="13" name="FMT_3CH" />
-        <option value="14" name="FMT_4CH" />
-        <option value="15" name="FMT_DEPTH_STENCIL" />
+        <option value="7" name="FMT_RGB24NONINT">(Deprecated) 24-bit noninterleaved texture, an old PS2 format.</option>
+        <option value="8" name="FMT_BUMP">Uncompressed dU/dV gradient bump map.</option>
+        <option value="9" name="FMT_BUMPLUMA">Uncompressed dU/dV gradient bump map with luma channel representing shininess.</option>
+        <option value="10" name="FMT_RENDERSPEC">Generic descriptor for any renderer-specific format not described by other formats.</option>
+        <option value="11" name="FMT_1CH">Generic descriptor for formats with 1 component.</option>
+        <option value="12" name="FMT_2CH">Generic descriptor for formats with 2 components.</option>
+        <option value="13" name="FMT_3CH">Generic descriptor for formats with 3 components.</option>
+        <option value="14" name="FMT_4CH">Generic descriptor for formats with 4 components.</option>
+        <option value="15" name="FMT_DEPTH_STENCIL">Indicates the NiPixelFormat is meant to be used on a depth/stencil surface.</option>
         <option value="16" name="FMT_UNKNOWN" />
     </enum>
 
     <enum name="PixelTiling" storage="uint" prefix="PX">
+        Describes whether pixels have been tiled from their standard row-major format to a format optimized for a particular platform.
         <option value="0" name="TILE_NONE" />
         <option value="1" name="TILE_XENON" />
         <option value="2" name="TILE_WII" />
@@ -651,7 +632,7 @@
     </enum>
 
     <enum name="PixelComponent" storage="uint" prefix="PX">
-        Specifies the pixel format used by the NiPixelData object to store a texture.
+        Describes the pixel format used by the NiPixelData object to store a texture.
         <option value="0" name="COMP_RED" />
         <option value="1" name="COMP_GREEN" />
         <option value="2" name="COMP_BLUE" />
@@ -675,6 +656,7 @@
     </enum>
 
     <enum name="PixelRepresentation" storage="uint" prefix="PX">
+        Describes how each pixel should be accessed on NiPixelFormat.
         <option value="0" name="REP_NORM_INT" />
         <option value="1" name="REP_HALF" />
         <option value="2" name="REP_FLOAT" />
@@ -685,7 +667,7 @@
     </enum>
 
     <enum name="PixelLayout" storage="uint" prefix="PX">
-        An unsigned 32-bit integer, describing the color depth of a texture.
+        Describes the color depth in an NiTexture.
         <option value="0" name="LAY_PALETTIZED_8">Texture is in 8-bit palettized format.</option>
         <option value="1" name="LAY_HIGH_COLOR_16">Texture is in 16-bit high color format.</option>
         <option value="2" name="LAY_TRUE_COLOR_32">Texture is in 32-bit true color format.</option>
@@ -705,8 +687,23 @@
         <option value="16" name="LAY_DEPTH_24_X8" />
     </enum>
 
+    <enum name="MipMapFormat" storage="uint">
+        Describes how mipmaps are handled in an NiTexture.
+        <option value="0" name="MIP_FMT_NO">Texture does not use mip maps.</option>
+        <option value="1" name="MIP_FMT_YES">Texture uses mip maps.</option>
+        <option value="2" name="MIP_FMT_DEFAULT">Use default setting.</option>
+    </enum>
+
+    <enum name="AlphaFormat" storage="uint">
+        Describes how transparency is handled in an NiTexture.
+        <option value="0" name="ALPHA_NONE">No alpha.</option>
+        <option value="1" name="ALPHA_BINARY">1-bit alpha.</option>
+        <option value="2" name="ALPHA_SMOOTH">Interpolated 4- or 8-bit alpha.</option>
+        <option value="3" name="ALPHA_DEFAULT">Use default setting.</option>
+    </enum>
+
     <enum name="TexClampMode" storage="uint">
-        Specifies the availiable texture clamp modes.  That is, the behavior of pixels outside the range of the texture.
+        Describes the availiable texture clamp modes, i.e. the behavior of UV mapping outside the [0,1] range.
         <option value="0" name="CLAMP_S_CLAMP_T">Clamp in both directions.</option>
         <option value="1" name="CLAMP_S_WRAP_T">Clamp in the S(U) direction but wrap in the T(V) direction.</option>
         <option value="2" name="WRAP_S_CLAMP_T">Wrap in the S(U) direction but clamp in the T(V) direction.</option>
@@ -714,20 +711,27 @@
     </enum>
 
     <enum name="TexFilterMode" storage="uint">
-        Specifies the availiable texture filter modes.  That is, the way pixels within a texture are blended together when textures are displayed on the screen at a size other than their original dimentions.
-        <option value="0" name="FILTER_NEAREST">Simply uses the nearest pixel.  Very grainy.</option>
-        <option value="1" name="FILTER_BILERP">Uses bilinear filtering.</option>
-        <option value="2" name="FILTER_TRILERP">Uses trilinear filtering.</option>
-        <option value="3" name="FILTER_NEAREST_MIPNEAREST">Uses the nearest pixel from the mipmap that is closest to the display size.</option>
-        <option value="4" name="FILTER_NEAREST_MIPLERP">Blends the two mipmaps closest to the display size linearly, and then uses the nearest pixel from the result.</option>
-        <option value="5" name="FILTER_BILERP_MIPNEAREST">Uses the closest mipmap to the display size and then uses bilinear filtering on the pixels.</option>
+        Describes the availiable texture filter modes, i.e. the way the pixels in a texture are displayed on screen.
+        <option value="0" name="FILTER_NEAREST">Nearest neighbor. Uses nearest texel with no mipmapping.</option>
+        <option value="1" name="FILTER_BILERP">Bilinear. Linear interpolation with no mipmapping.</option>
+        <option value="2" name="FILTER_TRILERP">Trilinear. Linear intepolation between 8 texels (4 nearest texels between 2 nearest mip levels).</option>
+        <option value="3" name="FILTER_NEAREST_MIPNEAREST">Nearest texel on nearest mip level.</option>
+        <option value="4" name="FILTER_NEAREST_MIPLERP">Linear interpolates nearest texel between two nearest mip levels.</option>
+        <option value="5" name="FILTER_BILERP_MIPNEAREST">Linear interpolates on nearest mip level.</option>
+        <option value="6" name="FILTER_ANISOTROPIC">Anisotropic filtering. One or many trilinear samples depending on anisotropy.</option>
     </enum>
 
     <enum name="VertMode" storage="uint">
-        An unsigned 32-bit integer, which describes how to apply vertex colors.
-        <option value="0" name="VERT_MODE_SRC_IGNORE">Source Ignore.</option>
-        <option value="1" name="VERT_MODE_SRC_EMISSIVE">Source Emissive.</option>
-        <option value="2" name="VERT_MODE_SRC_AMB_DIF">Source Ambient/Diffuse. (Default)</option>
+        Describes how to apply vertex colors for NiVertexColorProperty.
+        <option value="0" name="VERT_MODE_SRC_IGNORE">Emissive, ambient, and diffuse colors are all specified by the NiMaterialProperty.</option>
+        <option value="1" name="VERT_MODE_SRC_EMISSIVE">Emissive colors are specified by the source vertex colors. Ambient+Diffuse are specified by the NiMaterialProperty.</option>
+        <option value="2" name="VERT_MODE_SRC_AMB_DIF">Ambient+Diffuse colors are specified by the source vertex colors. Emissive is specified by the NiMaterialProperty. (Default)</option>
+    </enum>
+
+    <enum name="LightMode" storage="uint">
+        Describes which lighting equation components influence the final vertex color for NiVertexColorProperty.
+        <option value="0" name="LIGHT_MODE_EMISSIVE">Emissive.</option>
+        <option value="1" name="LIGHT_MODE_EMI_AMB_DIF">Emissive + Ambient + Diffuse. (Default)</option>
     </enum>
 
     <enum name="CycleType" storage="uint">
@@ -746,61 +750,62 @@
     <enum name="BillboardMode" storage="ushort">
         Determines the way the billboard will react to the camera.
         Billboard mode is stored in lowest 3 bits although Oblivion vanilla nifs uses values higher than 7.
-        <option value="0" name="ALWAYS_FACE_CAMERA">The billboard will always face the camera.</option>
-        <option value="1" name="ROTATE_ABOUT_UP">The billboard will only rotate around the up axis.</option>
-        <option value="2" name="RIGID_FACE_CAMERA">Rigid Face Camera.</option>
-        <option value="3" name="ALWAYS_FACE_CENTER">Always Face Center.</option>
-        <option value="4" name="RIGID_FACE_CENTER">Rigid Face Center.</option>
+        <option value="0" name="ALWAYS_FACE_CAMERA">Align billboard and camera forward vector. Minimized rotation.</option>
+        <option value="1" name="ROTATE_ABOUT_UP">Align billboard and camera forward vector while allowing rotation around the up axis.</option>
+        <option value="2" name="RIGID_FACE_CAMERA">Align billboard and camera forward vector. Non-minimized rotation.</option>
+        <option value="3" name="ALWAYS_FACE_CENTER">Billboard forward vector always faces camera ceneter. Minimized rotation.</option>
+        <option value="4" name="RIGID_FACE_CENTER">Billboard forward vector always faces camera ceneter. Non-minimized rotation.</option>
+        <!-- TODO: Unverified -->
         <option value="5" name="BSROTATE_ABOUT_UP">The billboard will only rotate around its local Z axis (it always stays in its local X-Y plane).</option>
         <option value="9" name="ROTATE_ABOUT_UP2">The billboard will only rotate around the up axis (same as ROTATE_ABOUT_UP?).</option>
     </enum>
 
     <enum name="StencilCompareMode" storage="uint">
-        This enum contains the options for doing stencil buffer tests.
-        <option value="0" name="TEST_NEVER">Test will allways return false. Nothing is drawn at all.</option>
-        <option value="1" name="TEST_LESS">The test will only succeed if the pixel is nearer than the previous pixel.</option>
-        <option value="2" name="TEST_EQUAL">Test will only succeed if the z value of the pixel to be drawn is equal to the value of the previous drawn pixel.</option>
-        <option value="3" name="TEST_LESS_EQUAL">Test will succeed if the z value of the pixel to be drawn is smaller than or equal to the value in the Stencil Buffer.</option>
-        <option value="4" name="TEST_GREATER">Opposite of TEST_LESS.</option>
-        <option value="5" name="TEST_NOT_EQUAL">Test will succeed if the z value of the pixel to be drawn is NOT equal to the value of the previously drawn pixel.</option>
-        <option value="6" name="TEST_GREATER_EQUAL">Opposite of TEST_LESS_EQUAL.</option>
-        <option value="7" name="TEST_ALWAYS">Test will allways succeed. The Stencil Buffer value is ignored.</option>
-    </enum>
-
-    <enum name="ZCompareMode" storage="uint">
-        This enum contains the options for doing z buffer tests.
-        <option value="0" name="ZCOMP_ALWAYS">Test will allways succeed. The Z Buffer value is ignored.</option>
-        <option value="1" name="ZCOMP_LESS">The test will only succeed if the pixel is nearer than the previous pixel.</option>
-        <option value="2" name="ZCOMP_EQUAL">Test will only succeed if the z value of the pixel to be drawn is equal to the value of the previous drawn pixel.</option>
-        <option value="3" name="ZCOMP_LESS_EQUAL">Test will succeed if the z value of the pixel to be drawn is smaller than or equal to the value in the Z Buffer.</option>
-        <option value="4" name="ZCOMP_GREATER">Opposite of TEST_LESS.</option>
-        <option value="5" name="ZCOMP_NOT_EQUAL">Test will succeed if the z value of the pixel to be drawn is NOT equal to the value of the previously drawn pixel.</option>
-        <option value="6" name="ZCOMP_GREATER_EQUAL">Opposite of TEST_LESS_EQUAL.</option>
-        <option value="7" name="ZCOMP_NEVER">Test will allways return false. Nothing is drawn at all.</option>
+        Describes stencil buffer test modes for NiStencilProperty.
+        <option value="0" name="TEST_NEVER">Always false. Ref value is ignored.</option>
+        <option value="1" name="TEST_LESS">VRef ‹ VBuf</option>
+        <option value="2" name="TEST_EQUAL">VRef = VBuf</option>
+        <option value="3" name="TEST_LESS_EQUAL">VRef ≤ VBuf</option>
+        <option value="4" name="TEST_GREATER">VRef › VBuf</option>
+        <option value="5" name="TEST_NOT_EQUAL">VRef ≠ VBuf</option>
+        <option value="6" name="TEST_GREATER_EQUAL">VRef ≥ VBuf</option>
+        <option value="7" name="TEST_ALWAYS">Always true. Buffer is ignored.</option>
     </enum>
 
     <enum name="StencilAction" storage="uint">
-        This enum defines the various actions used in conjunction with the stencil buffer.
-        For a detailed description of the individual options please refer to the OpenGL docs.
-        <option value="0" name="ACTION_KEEP" />
-        <option value="1" name="ACTION_ZERO" />
-        <option value="2" name="ACTION_REPLACE" />
-        <option value="3" name="ACTION_INCREMENT" />
-        <option value="4" name="ACTION_DECREMENT" />
-        <option value="5" name="ACTION_INVERT" />
+        Describes the actions which can occur as a result of tests for NiStencilProperty.
+        <option value="0" name="ACTION_KEEP">Keep the current value in the stencil buffer.</option>
+        <option value="1" name="ACTION_ZERO">Write zero to the stencil buffer.</option>
+        <option value="2" name="ACTION_REPLACE">Write the reference value to the stencil buffer.</option>
+        <option value="3" name="ACTION_INCREMENT">Increment the value in the stencil buffer.</option>
+        <option value="4" name="ACTION_DECREMENT">Decrement the value in the stencil buffer.</option>
+        <option value="5" name="ACTION_INVERT">Bitwise invert the value in the stencil buffer.</option>
     </enum>
 
-    <enum name="FaceDrawMode" storage="uint">
-        This enum lists the different face culling options.
-        <option value="0" name="DRAW_CCW_OR_BOTH">use application defaults?</option>
-        <option value="1" name="DRAW_CCW">Draw counter clock wise faces, cull clock wise faces. This is the default for most (all?) Nif Games so far.</option>
-        <option value="2" name="DRAW_CW">Draw clock wise faces, cull counter clock wise faces. This will flip all the faces.</option>
-        <option value="3" name="DRAW_BOTH">Draw double sided faces.</option>
+    <enum name="StencilDrawMode" storage="uint">
+        Describes the face culling options for NiStencilProperty.
+        <option value="0" name="DRAW_CCW_OR_BOTH">Application default, chooses between DRAW_CCW or DRAW_BOTH.</option>
+        <option value="1" name="DRAW_CCW">Draw only the triangles whose vertices are ordered CCW with respect to the viewer. (Standard behavior)</option>
+        <option value="2" name="DRAW_CW">Draw only the triangles whose vertices are ordered CW with respect to the viewer. (Effectively flips faces)</option>
+        <option value="3" name="DRAW_BOTH">Draw all triangles, regardless of orientation. (Effectively force double-sided)</option>
+    </enum>
+
+    <enum name="ZCompareMode" storage="uint">
+        Describes Z-buffer test modes for NiZBufferProperty.
+        "Less than" = closer to camera, "Greater than" = further from camera.
+        <option value="0" name="ZCOMP_ALWAYS">Always true. Buffer is ignored.</option>
+        <option value="1" name="ZCOMP_LESS">VRef ‹ VBuf</option>
+        <option value="2" name="ZCOMP_EQUAL">VRef = VBuf</option>
+        <option value="3" name="ZCOMP_LESS_EQUAL">VRef ≤ VBuf</option>
+        <option value="4" name="ZCOMP_GREATER">VRef › VBuf</option>
+        <option value="5" name="ZCOMP_NOT_EQUAL">VRef ≠ VBuf</option>
+        <option value="6" name="ZCOMP_GREATER_EQUAL">VRef ≥ VBuf</option>
+        <option value="7" name="ZCOMP_NEVER">Always false. Ref value is ignored.</option>
     </enum>
 
     <enum name="MotionSystem" storage="byte">
+        Bethesda Havok.
         The motion system. 4 (Box) is used for everything movable. 7 (Keyframed) is used on statics and animated stuff.
-
         <option value="0" name="MO_SYS_INVALID">Invalid</option>
         <option value="1" name="MO_SYS_DYNAMIC">A fully-simulated, movable rigid body. At construction time the engine checks the input inertia and selects MO_SYS_SPHERE_INERTIA or MO_SYS_BOX_INERTIA as appropriate.</option>
         <option value="2" name="MO_SYS_SPHERE">Simulation is performed using a sphere inertia tensor.</option>
@@ -814,12 +819,14 @@
     </enum>
 
     <enum name="DeactivatorType" storage="byte">
+        Bethesda Havok.
         <option value="0" name="DEACTIVATOR_INVALID">Invalid</option>
         <option value="1" name="DEACTIVATOR_NEVER">This will force the rigid body to never deactivate.</option>
         <option value="2" name="DEACTIVATOR_SPATIAL">Tells Havok to use a spatial deactivation scheme. This makes use of high and low frequencies of positional motion to determine when deactivation should occur.</option>
     </enum>
 
     <enum name="SolverDeactivation" storage="byte">
+        Bethesda Havok.
         A list of possible solver deactivation settings. This value defines how the
         solver deactivates objects. The solver works on a per object basis.
         Note: Solver deactivation does not save CPU, but reduces creeping of
@@ -833,6 +840,7 @@
     </enum>
 
     <enum name="MotionQuality" storage="byte">
+        Bethesda Havok.
         The motion type. Determines quality of motion?
         <option value="0" name="MO_QUAL_INVALID">Automatically assigned to MO_QUAL_FIXED, MO_QUAL_KEYFRAMED or MO_QUAL_DEBRIS</option>
         <option value="1" name="MO_QUAL_FIXED">Use this for fixed bodies. </option>
@@ -849,30 +857,30 @@
     </enum>
 
     <enum name="ForceType" storage="uint">
-        The type of force?  May be more valid values.
+        Describes the type of gravitational force.
         <option value="0" name="FORCE_PLANAR"></option>
         <option value="1" name="FORCE_SPHERICAL"></option>
         <option value="2" name="FORCE_UNKNOWN"></option>
     </enum>
 
-    <enum name="TexTransform" storage="uint">
-        Determines how a NiTextureTransformController animates the UV coordinates.
-        <option value="0" name="TT_TRANSLATE_U">Means this controller moves the U texture cooridnates.</option>
-        <option value="1" name="TT_TRANSLATE_V">Means this controller moves the V texture cooridnates.</option>
-        <option value="2" name="TT_ROTATE">Means this controller roates the UV texture cooridnates.</option>
-        <option value="3" name="TT_SCALE_U">Means this controller scales the U texture cooridnates.</option>
-        <option value="4" name="TT_SCALE_V">Means this controller scales the V texture cooridnates.</option>
+    <enum name="TransformMember" storage="uint">
+        Describes which aspect of the NiTextureTransform the NiTextureTransformController will modify.
+        <option value="0" name="TT_TRANSLATE_U">Control the translation of the U coordinates.</option>
+        <option value="1" name="TT_TRANSLATE_V">Control the translation of the V coordinates.</option>
+        <option value="2" name="TT_ROTATE">Control the rotation of the coordinates.</option>
+        <option value="3" name="TT_SCALE_U">Control the scale of the U coordinates.</option>
+        <option value="4" name="TT_SCALE_V">Control the scale of the V coordinates.</option>
     </enum>
 
     <enum name="DecayType" storage="uint">
-        Determines decay function.  Used by NiPSysBombModifier.
+        Describes the decay function of bomb forces.
         <option value="0" name="DECAY_NONE">No decay.</option>
         <option value="1" name="DECAY_LINEAR">Linear decay.</option>
         <option value="2" name="DECAY_EXPONENTIAL">Exponential decay.</option>
     </enum>
 
     <enum name="SymmetryType" storage="uint">
-        Determines symetry type used by NiPSysBombModifier.
+        Describes the symmetry type of bomb forces.
         <option value="0" name="SPHERICAL_SYMMETRY">Spherical Symmetry.</option>
         <option value="1" name="CYLINDRICAL_SYMMETRY">Cylindrical Symmetry.</option>
         <option value="2" name="PLANAR_SYMMETRY">Planar Symmetry.</option>
@@ -894,21 +902,21 @@
         <option value="4" name="EMIT_FROM_EDGE_SURFACE">Perhaps randomly emit particles from anywhere on the edges of the mesh?</option>
     </enum>
 
-    <enum name="EffectType" storage="uint">
-        The type of information that's store in a texture used by a NiTextureEffect.
-        <option value="0" name="EFFECT_PROJECTED_LIGHT">Apply a projected light texture.</option>
-        <option value="1" name="EFFECT_PROJECTED_SHADOW">Apply a projected shaddow texture.</option>
-        <option value="2" name="EFFECT_ENVIRONMENT_MAP">Apply an environment map texture.</option>
-        <option value="3" name="EFFECT_FOG_MAP">Apply a fog map texture.</option>
+    <enum name="TextureType" storage="uint">
+        The type of information that is stored in a texture used by an NiTextureEffect.
+        <option value="0" name="TEX_PROJECTED_LIGHT">Apply a projected light texture. Each light effect is summed before multiplying by the base texture.</option>
+        <option value="1" name="TEX_PROJECTED_SHADOW">Apply a projected shadow texture. Each shadow effect is multiplied by the base texture.</option>
+        <option value="2" name="TEX_ENVIRONMENT_MAP">Apply an environment map texture. Added to the base texture and light/shadow/decal maps.</option>
+        <option value="3" name="TEX_FOG_MAP">Apply a fog map texture. Alpha channel is used to blend the color channel with the base texture.</option>
     </enum>
 
     <enum name="CoordGenType" storage="uint">
         Determines the way that UV texture coordinates are generated.
-        <option value="0" name="CG_WORLD_PARALLEL">Use plannar mapping.</option>
+        <option value="0" name="CG_WORLD_PARALLEL">Use planar mapping.</option>
         <option value="1" name="CG_WORLD_PERSPECTIVE">Use perspective mapping.</option>
         <option value="2" name="CG_SPHERE_MAP">Use spherical mapping.</option>
-        <option value="3" name="CG_SPECULAR_CUBE_MAP">Use specular cube mapping.</option>
-        <option value="4" name="CG_DIFFUSE_CUBE_MAP">Use Diffuse cube mapping.</option>
+        <option value="3" name="CG_SPECULAR_CUBE_MAP">Use specular cube mapping. For NiSourceCubeMap only.</option>
+        <option value="4" name="CG_DIFFUSE_CUBE_MAP">Use diffuse cube mapping. For NiSourceCubeMap only.</option>
     </enum>
 
     <enum name="EndianType" storage="byte">
@@ -917,7 +925,7 @@
     </enum>
 
     <enum name="TargetColor" storage="ushort">
-        Used by NiPoint3InterpControllers to select which type of color in the controlled object that will be animated.
+        Used by NiMaterialColorControllers to select which type of color in the controlled object that will be animated.
         <option value="0" name="TC_AMBIENT">Control the ambient color.</option>
         <option value="1" name="TC_DIFFUSE">Control the diffuse color.</option>
         <option value="2" name="TC_SPECULAR">Control the specular color.</option>
@@ -925,29 +933,33 @@
     </enum>
 
     <enum name="ConsistencyType" storage="ushort">
-        Used by NiGeometryData to control the volatility of the mesh.  While they appear to be flags they behave as an enum.
+        Used by NiGeometryData to control the volatility of the mesh.
+        Consistency Type is masked to only the upper 4 bits (0xF000). Dirty mask is the lower 12 (0x0FFF) but only used at runtime.
         <option value="0x0000" name="CT_MUTABLE">Mutable Mesh</option>
         <option value="0x4000" name="CT_STATIC">Static Mesh</option>
         <option value="0x8000" name="CT_VOLATILE">Volatile Mesh</option>
     </enum>
 
     <enum name="SortingMode" storage="uint">
-        <option value="0" name="SORTING_INHERIT">Inherit</option>
-        <option value="1" name="SORTING_OFF">Disable</option>
+        Describes the way that NiSortAdjustNode modifies the sorting behavior for the subtree below it.
+        <option value="0" name="SORTING_INHERIT">Inherit. Acts identical to NiNode.</option>
+        <option value="1" name="SORTING_OFF">Disables sort on all geometry under this node.</option>
     </enum>
 
     <enum name="PropagationMode" storage="uint">
-        <option value="0" name="PROPAGATE_ON_SUCCESS">On Success</option>
-        <option value="1" name="PROPAGATE_ON_FAILURE">On Failure</option>
-        <option value="2" name="PROPAGATE_ALWAYS">Always</option>
-        <option value="3" name="PROPAGATE_NEVER">Never</option>
+        The propagation mode controls scene graph traversal during collision detection operations for NiCollisionData.
+        <option value="0" name="PROPAGATE_ON_SUCCESS">Propagation only occurs as a result of a successful collision.</option>
+        <option value="1" name="PROPAGATE_ON_FAILURE">(Deprecated) Propagation only occurs as a result of a failed collision.</option>
+        <option value="2" name="PROPAGATE_ALWAYS">Propagation always occurs regardless of collision result.</option>
+        <option value="3" name="PROPAGATE_NEVER">Propagation never occurs regardless of collision result.</option>
     </enum>
 
     <enum name="CollisionMode" storage="uint">
+        The collision mode controls the type of collision operation that is to take place for NiCollisionData.
         <option value="0" name="CM_USE_OBB">Use Bounding Box</option>
         <option value="1" name="CM_USE_TRI">Use Triangles</option>
         <option value="2" name="CM_USE_ABV">Use Alternate Bounding Volumes</option>
-        <option value="3" name="CM_NOTEST">No Test</option>
+        <option value="3" name="CM_NOTEST">Indicates that no collision test should be made.</option>
         <option value="4" name="CM_USE_NIBOUND">Use NiBound</option>
     </enum>
 
@@ -961,6 +973,7 @@
     </enum>
 
     <enum name="hkResponseType" storage="byte">
+        Bethesda Havok.
         <option value="0" name="RESPONSE_INVALID">Invalid Response</option>
         <option value="1" name="RESPONSE_SIMPLE_CONTACT">Do normal collision resolution</option>
         <option value="2" name="RESPONSE_REPORTING">No collision resolution is performed but listeners are called</option>
@@ -1135,7 +1148,7 @@
     </enum>
 
     <enum name="hkConstraintType" storage="uint">
-        The type of constraint.
+        Bethesda Havok. Describes the type of bhkConstraint.
         <option value="0" name="BallAndSocket">A ball and socket constraint.</option>
         <option value="1" name="Hinge">A hinge constraint.</option>
         <option value="2" name="Limited Hinge">A limited hinge constraint.</option>
@@ -1297,7 +1310,7 @@
     </compound>
 
     <compound name="Matrix34" niflibtype="Matrix34">
-        A 4x4 transformation matrix.
+        A 3x4 transformation matrix.
         <add name="m11" type="float" default="1.0">The (1,1) element.</add>
         <add name="m21" type="float" default="0.0">The (2,1) element.</add>
         <add name="m31" type="float" default="0.0">The (3,1) element.</add>
@@ -1349,14 +1362,14 @@
     </compound>
 
     <compound name="MipMap">
-        Description of a MipMap within a NiPixelData object.
+        Description of a mipmap within an NiPixelData object.
         <add name="Width" type="uint">Width of the mipmap image.</add>
         <add name="Height" type="uint">Height of the mipmap image.</add>
         <add name="Offset" type="uint">Offset into the pixel data array where this mipmap starts.</add>
     </compound>
 
-    <compound name="NodeGroup">
-        A group of NiNodes references.
+    <compound name="NodeSet">
+        A set of NiNode references.
         <add name="Num Nodes" type="uint">Number of node references that follow.</add>
         <add name="Nodes" type="Ptr" template="NiNode" arr1="Num Nodes">The list of NiNode references.</add>
     </compound>
@@ -1367,23 +1380,20 @@
         <add name="Value" type="char" arr1="Length">The string itself, null terminated (the null terminator is taken into account in the length byte).</add>
     </compound>
 
-    <compound name="SkinShape">
-        Reference to shape and skin instance.
-        <add name="Shape" type="Ptr" template="NiTriBasedGeom">The shape.</add>
-        <add name="Skin Instance" type="Ref" template="NiSkinInstance">Skinning instance for the shape?</add>
+    <compound name="SkinInfo">
+        NiBoneLODController::SkinInfo. Reference to shape and skin instance.
+        <add name="Shape" type="Ptr" template="NiTriBasedGeom" />
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" />
     </compound>
 
-    <compound name="SkinShapeGroup" ver1="10.0.1.0">
-        Unknown.
-        <add name="Num Link Pairs" type="uint">Counts unknown.</add>
-        <add name="Link Pairs" type="SkinShape" arr1="Num Link Pairs">
-            First link is a NiTriShape object.
-            Second link is a NiSkinInstance object.
-        </add>
+    <compound name="SkinInfoSet" ver1="10.0.1.0">
+        A set of NiBoneLODController::SkinInfo.
+        <add name="Num Skin Info" type="uint" />
+        <add name="Skin Info" type="SkinInfo" arr1="Num Skin Info" />
     </compound>
 
-    <compound name="SkinWeight">
-        A weighted vertex.
+    <compound name="BoneVertData">
+        NiSkinData::BoneVertData. A vertex and its weight.
         <add name="Index" type="ushort">The vertex index, in the mesh.</add>
         <add name="Weight" type="float">The vertex weight - between 0.0 and 1.0</add>
     </compound>
@@ -1504,13 +1514,15 @@
     </compound>
     
     <enum name="TransformMethod" storage="uint" prefix="TM">
-        <option value="0" name="Maya Deprecated" />
-        <option value="1" name="Max" />
-        <option value="2" name="Maya" />
+        Describes the order of scaling and rotation matrices. Translate, Scale, Rotation, Center are from TexDesc.
+        Back = inverse of Center. FromMaya = inverse of the V axis with a positive translation along V of 1 unit.
+        <option value="0" name="Maya Deprecated">Center * Rotation * Back * Translate * Scale</option>
+        <option value="1" name="Max">Center * Scale * Rotation * Translate * Back</option>
+        <option value="2" name="Maya">Center * Rotation * Back * FromMaya * Translate * Scale</option>
     </enum>
 
     <compound name="TexDesc">
-        Texture description.
+        NiTexturingProperty::Map. Texture description.
         <add name="Image" type="Ref" template="NiImage" ver2="3.1">Link to the texture image.</add>
         <add name="Source" type="Ref" template="NiSourceTexture" ver1="3.3.0.13">NiSourceTexture object index.</add>
         <add name="Clamp Mode" type="TexClampMode" default="WRAP_S_WRAP_T" ver2="20.0.0.5">0=clamp S clamp T, 1=clamp S wrap T, 2=wrap S clamp T, 3=wrap S wrap T</add>
@@ -1529,11 +1541,11 @@
         <add name="Center Offset" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The offset from the origin?</add>
     </compound>
 
-    <compound name="ShaderTexDesc" ver1="10.0.1.0">
-        An extended texture description for shader textures.
-        <add name="Is Used" type="bool">Is it used?</add>
-        <add name="Texture Data" type="TexDesc" cond="Is Used">The texture data.</add>
-        <add name="Map Index" type="uint" cond="Is Used">Map Index</add>
+    <compound name="ShaderTexDesc">
+        NiTexturingProperty::ShaderMap. Shader texture description.
+        <add name="Has Map" type="bool" />
+        <add name="Map" type="TexDesc" cond="Has Map" />
+        <add name="Map ID" type="uint" cond="Has Map">Unique identifier for the Gamebryo shader system.</add>
     </compound>
 
     <compound name="Triangle" niflibtype="Triangle">
@@ -1681,7 +1693,7 @@
     </compound>
 
 	<bitflags name="FurnitureEntryPoints" storage="ushort">
-		Furniture entry points. It specifies the direction(s) from where the actor is able to enter (and leave) the position.
+		Bethesda Animation. Furniture entry points. It specifies the direction(s) from where the actor is able to enter (and leave) the position.
 		<option value="0" name="Front">front entry point</option>
 		<option value="1" name="Behind">behind entry point</option>
 		<option value="2" name="Right">right entry point</option>
@@ -1690,14 +1702,14 @@
 	</bitflags>
 
 	<enum name="AnimationType" storage="ushort">
-		Animation type used on this position. This specifies the function of this position.
+		Bethesda Animation. Animation type used on this position. This specifies the function of this position.
 		<option value="1" name="Sit">Actor use sit animation.</option>
 		<option value="2" name="Sleep">Actor use sleep animation.</option>
 		<option value="4" name="Lean">Used for lean animations?</option>
 	</enum>
 
     <compound name="FurniturePosition">
-        Describes a furniture position?
+        Bethesda Animation. Describes a furniture position?
         <add name="Offset" type="Vector3">Offset of furniture marker.</add>
         <add name="Orientation" type="ushort" vercond="User Version &lt;= 11">Furniture marker orientation.</add>
         <add name="Position Ref 1" type="byte" vercond="User Version &lt;= 11">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 2.</add>
@@ -1708,7 +1720,7 @@
     </compound>
 
     <compound name="hkTriangle">
-        A triangle with extra data used for physics.
+        Bethesda Havok. A triangle with extra data used for physics.
         <add name="Triangle" type="Triangle">The triangle.</add>
         <add name="Welding Info" type="ushort">Additional havok information on how triangles are welded.</add>
         <add name="Normal" type="Vector3" ver2="20.0.0.5">This is the triangle's normal.</add>
@@ -1736,19 +1748,19 @@
         <add name="Vertex ID" type="ushort">Particle/vertex index matches array index</add>
     </compound>
 
-    <compound name="SkinData">
-        Skinning data component.
+    <compound name="BoneData">
+        NiSkinData::BoneData. Skinning data component.
         <add name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</add>
         <add name="Bounding Sphere Offset" type="Vector3">Translation offset of a bounding sphere holding all vertices. (Note that its a Sphere Containing Axis Aligned Box not a minimum volume Sphere)</add>
         <add name="Bounding Sphere Radius" type="float">Radius for bounding sphere holding all vertices.</add>
         <add name="Unknown 13 Shorts" type="short" arr1="13" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Unknown, always 0?</add>
         <add name="Num Vertices" type="ushort">Number of weighted vertices.</add>
-        <add name="Vertex Weights" type="SkinWeight" arr1="Num Vertices" ver2="4.2.1.0">The vertex weights.</add>
-        <add name="Vertex Weights" type="SkinWeight" arr1="Num Vertices" ver1="4.2.2.0" cond="ARG != 0">The vertex weights.</add>
+        <add name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" ver2="4.2.1.0">The vertex weights.</add>
+        <add name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" ver1="4.2.2.0" cond="ARG != 0">The vertex weights.</add>
     </compound>
 
-    <compound name="HavokColFilter">
-        ColFilter property for Havok. It contains Layer, Flags and Part Number
+    <compound name="HavokFilter">
+        Bethesda Havok. Collision filter info representing Layer, Flags, Part Number, and Group all combined into one uint.
         <add name="Layer" suffix="OB" type="OblivionLayer" default="OL_STATIC" ver1="20.0.0.4" ver2="20.0.0.5">The layer the collision belongs to.</add>
         <add name="Layer" suffix="FO" type="Fallout3Layer" default="FOL_STATIC" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt;= 34)">The layer the collision belongs to.</add>
         <add name="Layer" suffix="SK" type="SkyrimLayer" default="SKYL_STATIC" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 34)">The layer the collision belongs to.</add>
@@ -1796,14 +1808,15 @@
     </compound>
 
     <compound name="HavokMaterial">
+        Bethesda Havok. Material wrapper for varying material enums by game.
         <add name="Material" suffix="OB" type="OblivionHavokMaterial" ver1="20.0.0.4" ver2="20.0.0.5">The material of the shape.</add>
         <add name="Material" suffix="FO" type="Fallout3HavokMaterial" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt;= 34)">The material of the shape.</add>
         <add name="Material" suffix="SK" type="SkyrimHavokMaterial" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 34)">The material of the shape.</add>
     </compound>
 
     <compound name="OblivionSubShape">
-        Havok Information for packed TriStrip shapes.
-        <add name="Havok Col Filter" type="HavokColFilter" />
+        Bethesda Havok. Havok Information for packed TriStrip shapes.
+        <add name="Havok Filter" type="HavokFilter" />
         <add name="Num Vertices" type="uint">The number of vertices that form this sub shape.</add>
         <add name="Material" type="HavokMaterial">The material of the subshape.</add>
     </compound>
@@ -2093,10 +2106,8 @@
 
     <compound name="bhkCMSDMaterial">
         Per-chunk material, used in bhkCompressedMeshShapeData
-        <add name="Material" type="SkyrimHavokMaterial">Material.</add>
-        <add name="Layer" type="SkyrimLayer">Copy of Layer from bhkRigidBody. The value is stored as 32-bit integer.</add>
-    <add name="Byte set to 0" type="byte" default="0">Always set to 0. It is only remainder of "Layer" 32-bit integer above.</add>
-    <add name="Short set to 0" type="ushort" default="0">Always set to 0. It is only remainder of "Layer" 32-bit integer above.</add>
+        <add name="Material" type="SkyrimHavokMaterial" />
+        <add name="Filter" type="HavokFilter" />
     </compound>
 
     <compound name="bhkCMSDBigTris">
@@ -2254,7 +2265,7 @@
     <niobject name="bhkWorldObject" abstract="1" inherit="bhkSerializable">
         Havok objects that have a position in the world?
         <add name="Shape" type="Ref" template="bhkShape"> Link to the body for this collision object.</add>
-        <add name="Havok Col Filter" type="HavokColFilter" />
+        <add name="Havok Filter" type="HavokFilter" />
         <add name="Unused" type="byte" arr1="4">Garbage data from memory.</add>
         <add name="Broad Phase Type" type="BroadPhaseType" default="1" />
         <add name="Unused Bytes" type="byte" arr1="3" />
@@ -2288,7 +2299,7 @@
         <add name="Unused Byte 1" type="byte">Skipped over when writing Collision Response and Callback Delay.</add>
         <add name="Process Contact Callback Delay" type="ushort" default="0xffff">Lowers the frequency for processContactCallbacks. A value of 5 means that a callback is raised every 5th frame.</add>
         <add name="Unknown Int 1" type="uint">Unknown.</add>
-        <add name="Havok Col Filter Copy" type="HavokColFilter">Copy of Havok Col Filter</add>
+        <add name="Havok Filter Copy" type="HavokFilter">Copy of Havok Filter</add>
         <add name="Unused 2" type="byte" arr1="4">Garbage data from memory. Matches previous Unused value.</add>
         <add name="Unknown Int 2" type="uint" vercond="User Version 2 &gt; 34" />
         <add name="Collision Response 2" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT" />
@@ -2549,7 +2560,7 @@
         <add name="Num Strips Data" type="uint">The number of strips data objects referenced.</add>
         <add name="Strips Data" type="Ref" template="NiTriStripsData" arr1="Num Strips Data">Refers to a bunch of NiTriStripsData objects that make up this shape.</add>
         <add name="Num Data Layers" type="uint">Number of Havok Layers, equal to Number of strips data objects.</add>
-        <add name="Data Layers" type="HavokColFilter" arr1="Num Data Layers">Havok Layers for each strip data.</add>
+        <add name="Data Layers" type="HavokFilter" arr1="Num Data Layers">Havok Layers for each strip data.</add>
     </niobject>
 
     <niobject name="NiExtraData" abstract="0" inherit="NiObject">
@@ -2940,11 +2951,11 @@
     </niobject>
 
     <niobject name="NiTextureTransformController" abstract="0" inherit="NiFloatInterpController">
-        Texture transformation controller. The target texture slot should have "Has Texture Transform" enabled.
+        Used to animate a single member of an NiTextureTransform.
         <add name="Shader Map" type="bool">Is the target map a shader map?</add>
-        <add name="Texture Slot" type="TexType"> The target texture slot.</add>
-        <add name="Operation" type="TexTransform">Determines how this controller animates the UV Coordinates.</add>
-        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0">Link to NiFloatData.</add>
+        <add name="Texture Slot" type="TexType">The target texture slot.</add>
+        <add name="Operation" type="TransformMember">Controls which aspect of the texture transform to modify.</add>
+        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0" />
     </niobject>
 
     <niobject name="NiLightDimmerController" abstract="0" inherit="NiFloatInterpController">
@@ -2961,18 +2972,17 @@
     </niobject>
 
     <niobject name="NiPoint3InterpController" abstract="1" inherit="NiSingleInterpController">
-        Abstract base class for all NiInterpControllers that use a NiInterpolator to animate their target NiPoint3 value.
-        <add name="Target Color" type="TargetColor" ver1="10.1.0.0">Selects which color to control.</add>
-        <add name="Data" type="Ref" template="NiPosData" ver2="10.1.0.0">Material color controller data object index. Points to NiPosData.</add>
+        Abstract base class for all NiInterpControllers that use an NiInterpolator to animate their target NiPoint3 value.
     </niobject>
 
     <niobject name="NiMaterialColorController" abstract="0" inherit="NiPoint3InterpController">
         Time controller for material color. Flags are used for color selection in versions below 10.1.0.0.
-        
         Bits 4-5: Target Color (00 = Ambient, 01 = Diffuse, 10 = Specular, 11 = Emissive)
+        <add name="Target Color" type="TargetColor" ver1="10.1.0.0">Selects which color to control.</add>
+        <add name="Data" type="Ref" template="NiPosData" ver2="10.1.0.0">Material color controller data object index. Points to NiPosData.</add>
     </niobject>
 
-    <niobject name="NiLightColorController" abstract="0" inherit="NiPoint3InterpController">
+    <niobject name="NiLightColorController" abstract="0" inherit="NiMaterialColorController">
         Animates the ambient, diffuse and specular colors of an NiLight.
     </niobject>
 
@@ -2995,11 +3005,11 @@
         <add name="LOD" type="uint">Unknown.</add>
         <add name="Num LODs" type="uint">Number of LODs.</add>
         <add name="Num Node Groups" type="uint">Number of node arrays.</add>
-        <add name="Node Groups" type="NodeGroup" arr1="Num LODs">A list of node groups (each group a sequence of bones).</add>
+        <add name="Node Groups" type="NodeSet" arr1="Num LODs">A list of node sets (each set a sequence of bones).</add>
         <add name="Num Shape Groups" type="uint" ver1="4.2.2.0" userver="0">Number of shape groups.</add>
         <add name="Num Shape Groups" type="uint" ver1="10.2.0.0" ver2="10.2.0.0" userver="1">Number of shape groups.</add>
-        <add name="Shape Groups 1" type="SkinShapeGroup" arr1="Num Shape Groups"  ver1="4.2.2.0" userver="0">List of shape groups.</add>
-        <add name="Shape Groups 1" type="SkinShapeGroup" arr1="Num Shape Groups"  ver1="10.2.0.0" ver2="10.2.0.0" userver="1">List of shape groups.</add>
+        <add name="Shape Groups 1" type="SkinInfoSet" arr1="Num Shape Groups"  ver1="4.2.2.0" userver="0">List of shape groups.</add>
+        <add name="Shape Groups 1" type="SkinInfoSet" arr1="Num Shape Groups"  ver1="10.2.0.0" ver2="10.2.0.0" userver="1">List of shape groups.</add>
         <add name="Num Shape Groups 2" type="uint"  ver1="4.2.2.0" userver="0">The size of the second list of shape groups.</add>
         <add name="Num Shape Groups 2" type="uint"  ver1="10.2.0.0" ver2="10.2.0.0" userver="1">The size of the second list of shape groups.</add>
         <add name="Shape Groups 2" type="Ref" template="NiTriBasedGeom" arr1="Num Shape Groups 2"  ver1="4.2.2.0" userver="0">Group of NiTriShape indices.</add>
@@ -4299,7 +4309,7 @@
         <add name="Num Bones" type="uint">Number of bones.</add>
         <add name="Skin Partition" type="Ref" template="NiSkinPartition" ver1="4.0.0.2" ver2="10.1.0.0">This optionally links a NiSkinPartition for hardware-acceleration information.</add>
         <add name="Has Vertex Weights" type="byte" ver1="4.2.1.0" default="1">Enables Vertex Weights for this NiSkinData.</add>
-        <add name="Bone List" type="SkinData" arr1="Num Bones" arg="Has Vertex Weights">Contains offset data for each node that this skin is influenced by.</add>
+        <add name="Bone List" type="BoneData" arr1="Num Bones" arg="Has Vertex Weights">Contains offset data for each node that this skin is influenced by.</add>
     </niobject>
 
     <niobject name="NiSkinInstance" abstract="0" inherit="NiObject">
@@ -4393,7 +4403,7 @@
         <add name="Fail Action" type="StencilAction" ver2="20.0.0.5" />
         <add name="Z Fail Action" type="StencilAction" ver2="20.0.0.5" />
         <add name="Pass Action" type="StencilAction" ver2="20.0.0.5" />
-        <add name="Draw Mode" default="DRAW_BOTH" type="FaceDrawMode" ver2="20.0.0.5">Used to enabled double sided faces. Default is 3 (DRAW_BOTH).</add>
+        <add name="Draw Mode" default="DRAW_BOTH" type="StencilDrawMode" ver2="20.0.0.5">Used to enabled double sided faces. Default is 3 (DRAW_BOTH).</add>
         <add name="Flags" type="Flags" default="19840" ver1="20.1.0.3">
             Property flags:
             Bit 0: Stencil Enable
@@ -4439,7 +4449,7 @@
         <add name="Texture Filtering" type="TexFilterMode" default="FILTER_TRILERP">Texture Filtering mode.</add>
         <add name="Max Anisotropy" type="ushort" ver1="20.5.0.4" />
         <add name="Texture Clamping" type="TexClampMode" default="WRAP_S_WRAP_T">Texture Clamp mode.</add>
-        <add name="Texture Type" default="EFFECT_ENVIRONMENT_MAP" type="EffectType">The type of effect that the texture is used for.</add>
+        <add name="Texture Type" default="TEX_ENVIRONMENT_MAP" type="TextureType">The type of effect that the texture is used for.</add>
         <add name="Coordinate Generation Type" default="CG_SPHERE_MAP" type="CoordGenType">The method that will be used to generate UV coordinates for the texture effect.</add>
         <add name="Image" type="Ref" template="NiImage" ver2="3.1">Image index.</add>
         <add name="Source Texture" type="Ref" template="NiSourceTexture" ver1="4.0.0.0">Source texture index.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -3347,45 +3347,45 @@
 
     <niobject name="NiBSplineFloatInterpolator" abstract="1" inherit="NiBSplineInterpolator">
         Uses B-Splines to animate a float value over time.
+        <add name="Value" type="float">Base value when curve not defined.</add>
+        <add name="Handle" type="uint">Handle into the data. (USHRT_MAX for invalid handle.)</add>
     </niobject>
 
     <niobject name="NiBSplineCompFloatInterpolator" abstract="0" inherit="NiBSplineFloatInterpolator">
         NiBSplineFloatInterpolator plus the information required for using compact control points.
-        <add name="Base" type="float">Base value when curve not defined.</add>
-        <add name="Offset" type="uint">Starting offset for the data. (USHRT_MAX for no data.)</add>
-        <add name="Bias" type="float">Bias</add>
-        <add name="Multiplier" type="float">Multiplier</add>
+        <add name="Float Offset" type="float" />
+        <add name="Float Half Range" type="float" />
     </niobject>
 
     <niobject name="NiBSplinePoint3Interpolator" abstract="1" inherit="NiBSplineInterpolator">
         Uses B-Splines to animate an NiPoint3 value over time.
-        <add name="Unknown Floats" type="float" arr1="6">Unknown.</add>
+        <add name="Value" type="Vector3">Base value when curve not defined.</add>
+        <add name="Handle" type="uint">Handle into the data. (USHRT_MAX for invalid handle.)</add>
     </niobject>
 
     <niobject name="NiBSplineCompPoint3Interpolator" abstract="0" inherit="NiBSplinePoint3Interpolator">
         NiBSplinePoint3Interpolator plus the information required for using compact control points.
+        <add name="Position Offset" type="float" />
+        <add name="Position Half Range" type="float" />
     </niobject>
 
     <niobject name="NiBSplineTransformInterpolator" abstract="0" inherit="NiBSplineInterpolator">
         Supports the animation of position, rotation, and scale using an NiQuatTransform.
         The NiQuatTransform can be an unchanging pose or interpolated from B-Spline control point channels.
-        <!-- TODO use QTransform -->
-        <add name="Translation" type="Vector3">Base translation when translate curve not defined.</add>
-        <add name="Rotation" type="Quaternion">Base rotation when rotation curve not defined.</add>
-        <add name="Scale" type="float">Base scale when scale curve not defined.</add>
-        <add name="Translation Offset" type="uint">Starting offset for the translation data. (USHRT_MAX for no data.)</add>
-        <add name="Rotation Offset" type="uint">Starting offset for the rotation data. (USHRT_MAX for no data.)</add>
-        <add name="Scale Offset" type="uint">Starting offset for the scale data. (USHRT_MAX for no data.)</add>
+        <add name="Transform" type="NiQuatTransform" />
+        <add name="Translation Handle" type="uint">Handle into the translation data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Rotation Handle" type="uint">Handle into the rotation data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Scale Handle" type="uint">Handle into the scale data. (USHRT_MAX for invalid handle.)</add>
     </niobject>
 
     <niobject name="NiBSplineCompTransformInterpolator" abstract="0" inherit="NiBSplineTransformInterpolator">
         NiBSplineTransformInterpolator plus the information required for using compact control points.
-        <add name="Translation Bias" type="float">Translation Bias</add>
-        <add name="Translation Multiplier" type="float">Translation Multiplier</add>
-        <add name="Rotation Bias" type="float">Rotation Bias</add>
-        <add name="Rotation Multiplier" type="float">Rotation Multiplier</add>
-        <add name="Scale Bias" type="float">Scale Bias</add>
-        <add name="Scale Multiplier" type="float">Scale Multiplier</add>
+        <add name="Translation Offset" type="float" />
+        <add name="Translation Half Range" type="float" />
+        <add name="Rotation Offset" type="float" />
+        <add name="Rotation Half Range" type="float" />
+        <add name="Scale Offset" type="float" />
+        <add name="Scale Half Range" type="float" />
     </niobject>
 	
 	<niobject name="BSRotAccumTransfInterpolator" inherit="NiTransformInterpolator">
@@ -3393,10 +3393,10 @@
 
     <niobject name="NiBSplineData" abstract="0" inherit="NiObject">
         Contains one or more sets of control points for use in interpolation of open, uniform B-Splines, stored as either float or compact.
-        <add name="Num Float Control Points" type="uint">Number of Float Data Points</add>
+        <add name="Num Float Control Points" type="uint" />
         <add name="Float Control Points" type="float" arr1="Num Float Control Points">Float values representing the control data.</add>
-        <add name="Num Short Control Points" type="uint">Number of Short Data Points</add>
-        <add name="Short Control Points" type="short" arr1="Num Short Control Points">Signed shorts representing the data from 0 to 1 (scaled by SHRT_MAX).</add>
+        <add name="Num Compact Control Points" type="uint" />
+        <add name="Compact Control Points" type="short" arr1="Num Compact Control Points">Signed shorts representing the data from 0 to 1 (scaled by SHRT_MAX).</add>
     </niobject>
 
     <niobject name="NiCamera" abstract="0" inherit="NiAVObject">

--- a/nif.xml
+++ b/nif.xml
@@ -1435,7 +1435,7 @@
         <add name="Target Name" type="string" ver2="10.1.0.103">Name of a controllable object in another NIF file.</add>
         <!-- NiControllerSequence::InterpArrayItem -->
         <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.106" />
-        <add name="Controller" type="Ref" template="NiTimeController" />
+        <add name="Controller" type="Ref" template="NiTimeController" ver2="20.5.0.0" />
         <add name="Blend Interpolator" type="Ref" template="NiBlendInterpolator" ver1="10.1.0.104" ver2="10.1.0.110" />
         <add name="Blend Index" type="ushort" ver1="10.1.0.104" ver2="10.1.0.110" />
         <!-- Bethesda-only -->
@@ -2586,7 +2586,7 @@
 
     <niobject name="NiFloatInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiFloatKeys to animate a float value over time.
-        <add name="Pose Value" type="float" default="-3.402823466e+38">Value if lacking NiFloatData.</add>
+        <add name="Value" type="float" default="-3.402823466e+38">Pose value if lacking NiFloatData.</add>
         <add name="Data" type="Ref" template="NiFloatData" />
     </niobject>
 
@@ -2598,7 +2598,7 @@
 
     <niobject name="NiPoint3Interpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiPosKeys to animate an NiPoint3 value over time.
-        <add name="Pose Value" type="Vector3" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38">Value if lacking NiPosData.</add>
+        <add name="Value" type="Vector3" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38">Pose value if lacking NiPosData.</add>
         <add name="Data" type="Ref" template="NiPosData" />
     </niobject>
 
@@ -2625,7 +2625,7 @@
 
     <niobject name="NiBoolInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiBoolKeys to animate a bool value over time.
-        <add name="Pose Value" type="bool" default="2">Value if lacking NiBoolData.</add>
+        <add name="Value" type="bool" default="2">Pose value if lacking NiBoolData.</add>
         <add name="Data" type="Ref" template="NiBoolData" />
     </niobject>
 
@@ -3378,17 +3378,17 @@
 
     <niobject name="NiBlendBoolInterpolator" abstract="0" inherit="NiBlendInterpolator">
         Blends bool values together.
-        <add name="Bool Value" type="byte">The interpolated bool?</add>
+        <add name="Value" type="byte" default="2">The pose value. Invalid if using data.</add>
     </niobject>
 
     <niobject name="NiBlendFloatInterpolator" abstract="0" inherit="NiBlendInterpolator">
         Blends float values together.
-        <add name="Float Value" type="float">The interpolated float?</add>
+        <add name="Value" type="float" default="-3.402823466e+38">The pose value. Invalid if using data.</add>
     </niobject>
 
     <niobject name="NiBlendPoint3Interpolator" abstract="0" inherit="NiBlendInterpolator">
         Blends NiPoint3 values together.
-        <add name="Point Value" type="Vector3">The interpolated point?</add>
+        <add name="Value" type="Vector3" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38">The pose value. Invalid if using data.</add>
     </niobject>
 
     <niobject name="NiBlendTransformInterpolator" abstract="0" inherit="NiBlendInterpolator">
@@ -3412,45 +3412,45 @@
 
     <niobject name="NiBSplineFloatInterpolator" abstract="1" inherit="NiBSplineInterpolator">
         Uses B-Splines to animate a float value over time.
-        <add name="Value" type="float">Base value when curve not defined.</add>
-        <add name="Handle" type="uint">Handle into the data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Value" type="float" default="-3.402823466e+38">Base value when curve not defined.</add>
+        <add name="Handle" type="uint" default="0xFFFF">Handle into the data. (USHRT_MAX for invalid handle.)</add>
     </niobject>
 
     <niobject name="NiBSplineCompFloatInterpolator" abstract="0" inherit="NiBSplineFloatInterpolator">
         NiBSplineFloatInterpolator plus the information required for using compact control points.
-        <add name="Float Offset" type="float" />
-        <add name="Float Half Range" type="float" />
+        <add name="Float Offset" type="float" default="3.402823466e+38" />
+        <add name="Float Half Range" type="float" default="3.402823466e+38" />
     </niobject>
 
     <niobject name="NiBSplinePoint3Interpolator" abstract="1" inherit="NiBSplineInterpolator">
         Uses B-Splines to animate an NiPoint3 value over time.
-        <add name="Value" type="Vector3">Base value when curve not defined.</add>
-        <add name="Handle" type="uint">Handle into the data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Value" type="Vector3" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38">Base value when curve not defined.</add>
+        <add name="Handle" type="uint" default="0xFFFF">Handle into the data. (USHRT_MAX for invalid handle.)</add>
     </niobject>
 
     <niobject name="NiBSplineCompPoint3Interpolator" abstract="0" inherit="NiBSplinePoint3Interpolator">
         NiBSplinePoint3Interpolator plus the information required for using compact control points.
-        <add name="Position Offset" type="float" />
-        <add name="Position Half Range" type="float" />
+        <add name="Position Offset" type="float" default="3.402823466e+38" />
+        <add name="Position Half Range" type="float" default="3.402823466e+38" />
     </niobject>
 
     <niobject name="NiBSplineTransformInterpolator" abstract="0" inherit="NiBSplineInterpolator">
         Supports the animation of position, rotation, and scale using an NiQuatTransform.
         The NiQuatTransform can be an unchanging pose or interpolated from B-Spline control point channels.
         <add name="Transform" type="NiQuatTransform" />
-        <add name="Translation Handle" type="uint">Handle into the translation data. (USHRT_MAX for invalid handle.)</add>
-        <add name="Rotation Handle" type="uint">Handle into the rotation data. (USHRT_MAX for invalid handle.)</add>
-        <add name="Scale Handle" type="uint">Handle into the scale data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Translation Handle" type="uint" default="0xFFFF">Handle into the translation data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Rotation Handle" type="uint" default="0xFFFF">Handle into the rotation data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Scale Handle" type="uint" default="0xFFFF">Handle into the scale data. (USHRT_MAX for invalid handle.)</add>
     </niobject>
 
     <niobject name="NiBSplineCompTransformInterpolator" abstract="0" inherit="NiBSplineTransformInterpolator">
         NiBSplineTransformInterpolator plus the information required for using compact control points.
-        <add name="Translation Offset" type="float" />
-        <add name="Translation Half Range" type="float" />
-        <add name="Rotation Offset" type="float" />
-        <add name="Rotation Half Range" type="float" />
-        <add name="Scale Offset" type="float" />
-        <add name="Scale Half Range" type="float" />
+        <add name="Translation Offset" type="float" default="3.402823466e+38" />
+        <add name="Translation Half Range" type="float" default="3.402823466e+38" />
+        <add name="Rotation Offset" type="float" default="3.402823466e+38" />
+        <add name="Rotation Half Range" type="float" default="3.402823466e+38" />
+        <add name="Scale Offset" type="float" default="3.402823466e+38" />
+        <add name="Scale Half Range" type="float" default="3.402823466e+38" />
     </niobject>
 	
 	<niobject name="BSRotAccumTransfInterpolator" inherit="NiTransformInterpolator">
@@ -3662,7 +3662,7 @@
         <add name="Flags" type="LookAtFlags" />
         <add name="Look At" type="Ptr" template="NiNode" />
         <add name="Look At Name" type="string" />
-        <add name="Transform" type="NiQuatTransform" ver2="20.5.0.0" />
+        <add name="Transform" type="NiQuatTransform" ver2="20.4.0.12" />
         <add name="Interpolator: Translation" type="Ref" template="NiPoint3Interpolator" />
         <add name="Interpolator: Roll" type="Ref" template="NiFloatInterpolator" />
         <add name="Interpolator: Scale" type="Ref" template="NiFloatInterpolator" />
@@ -4016,6 +4016,14 @@
     <niobject name="NiPosData" abstract="0" inherit="NiObject">
         Wrapper for position animation keys.
         <add name="Data" type="KeyGroup" template="Vector3" />
+    </niobject>
+
+    <niobject name="NiRotData" abstract="0" inherit="NiObject">
+        Wrapper for rotation animation keys.
+        <add name="Num Rotation Keys" type="uint" />
+        <add name="Rotation Type" type="KeyType" cond="Num Rotation Keys != 0" />
+        <add name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" arr1="Num Rotation Keys" cond="Rotation Type != 4" />
+        <add name="XYZ Rotations" type="KeyGroup" template="float" arr1="3" cond="Rotation Type == 4" />
     </niobject>
 
     <niobject name="NiPSysAgeDeathModifier" abstract="0" inherit="NiPSysModifier">
@@ -6787,17 +6795,162 @@
         <add name="Max to Spawn" type="uint" />
     </niobject>
 
+    <niobject name="NiEvaluator" abstract="1" inherit="NiObject">
+        <add name="Node Name" type="string">The name of the animated NiAVObject.</add>
+        <add name="Property Type" type="string">The RTTI type of the NiProperty the controller is attached to, if applicable.</add>
+        <add name="Controller Type" type="string">The RTTI type of the NiTimeController.</add>
+        <add name="Controller ID" type="string">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</add>
+        <add name="Interpolator ID" type="string">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</add>
+        <add name="Channel Types" type="byte" arr1="4">
+            Channel Indices are BASE/POS = 0, ROT = 1, SCALE = 2, FLAG = 3
+            Channel Types are:
+             INVALID = 0, COLOR, BOOL, FLOAT, POINT3, ROT = 5
+            Any channel may be | 0x40 which means POSED
+            The FLAG (3) channel flags affects the whole evaluator:
+             REFERENCED = 0x1, TRANSFORM = 0x2, ALWAYSUPDATE = 0x4, SHUTDOWN = 0x8
+        </add>
+    </niobject>
+
+    <niobject name="NiKeyBasedEvaluator" abstract="1" inherit="NiEvaluator" />
+
+    <niobject name="NiBoolEvaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Data" type="Ref" template="NiBoolData" />
+    </niobject>
+
+    <niobject name="NiBoolTimelineEvaluator" inherit="NiBoolEvaluator" />
+
+    <niobject name="NiColorEvaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Data" type="Ref" template="NiColorData" />
+    </niobject>
+
+    <niobject name="NiFloatEvaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Data" type="Ref" template="NiFloatData" />
+    </niobject>
+
+    <niobject name="NiPoint3Evaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Data" type="Ref" template="NiPosData" />
+    </niobject>
+
+    <niobject name="NiQuaternionEvaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Data" type="Ref" template="NiRotData" />
+    </niobject>
+
+    <niobject name="NiTransformEvaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Value" type="NiQuatTransform" />
+        <add name="Data" type="Ref" template="NiTransformData" />
+    </niobject>
+
+    <niobject name="NiConstBoolEvaluator" inherit="NiEvaluator">
+        <add name="Value" type="float" default="-3.402823466e+38" /> <!-- Yes, this is actually a float. -->
+    </niobject>
+
+    <niobject name="NiConstColorEvaluator" inherit="NiEvaluator">
+        <add name="Value" type="Color4" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38, -3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiConstFloatEvaluator" inherit="NiEvaluator">
+        <add name="Value" type="float" default="-3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiConstPoint3Evaluator" inherit="NiEvaluator">
+        <add name="Value" type="Vector3" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38," />
+    </niobject>
+
+    <niobject name="NiConstQuaternionEvaluator" inherit="NiEvaluator">
+        <add name="Value" type="Quaternion" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38, -3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiConstTransformEvaluator" inherit="NiEvaluator">
+        <add name="Value" type="NiQuatTransform" />
+    </niobject>
+
+    <niobject name="NiBSplineEvaluator" inherit="NiEvaluator">
+        <add name="Start Time" type="float" default="3.402823466e+38" />
+        <add name="End Time" type="float" default="-3.402823466e+38" />
+        <add name="Data" type="Ref" template="NiBSplineData" />
+        <add name="Basis Data" type="Ref" template="NiBSplineBasisData" />
+    </niobject>
+
+    <niobject name="NiBSplineColorEvaluator" inherit="NiBSplineEvaluator">
+        <add name="Handle" type="uint" default="0xFFFF">Handle into the data. (USHRT_MAX for invalid handle.)</add>
+    </niobject>
+
+    <niobject name="NiBSplineCompColorEvaluator" inherit="NiBSplineColorEvaluator">
+        <add name="Offset" type="float" default="3.402823466e+38" />
+        <add name="Half Range" type="float" default="3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiBSplineFloatEvaluator" inherit="NiBSplineEvaluator">
+        <add name="Handle" type="uint" default="0xFFFF">Handle into the data. (USHRT_MAX for invalid handle.)</add>
+    </niobject>
+
+    <niobject name="NiBSplineCompFloatEvaluator" inherit="NiBSplineFloatEvaluator">
+        <add name="Offset" type="float" default="3.402823466e+38" />
+        <add name="Half Range" type="float" default="3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiBSplinePoint3Evaluator" inherit="NiBSplineEvaluator">
+        <add name="Handle" type="uint" default="0xFFFF">Handle into the data. (USHRT_MAX for invalid handle.)</add>
+    </niobject>
+
+    <niobject name="NiBSplineCompPoint3Evaluator" inherit="NiBSplinePoint3Evaluator">
+        <add name="Offset" type="float" default="3.402823466e+38" />
+        <add name="Half Range" type="float" default="3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiBSplineTransformEvaluator" inherit="NiBSplineEvaluator">
+        <add name="Transform" type="NiQuatTransform" />
+        <add name="Translation Handle" type="uint" default="0xFFFF">Handle into the translation data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Rotation Handle" type="uint" default="0xFFFF">Handle into the rotation data. (USHRT_MAX for invalid handle.)</add>
+        <add name="Scale Handle" type="uint" default="0xFFFF">Handle into the scale data. (USHRT_MAX for invalid handle.)</add>
+    </niobject>
+
+    <niobject name="NiBSplineCompTransformEvaluator" inherit="NiBSplineTransformEvaluator">
+        <add name="Translation Offset" type="float" default="3.402823466e+38" />
+        <add name="Translation Half Range" type="float" default="3.402823466e+38" />
+        <add name="Rotation Offset" type="float" default="3.402823466e+38" />
+        <add name="Rotation Half Range" type="float" default="3.402823466e+38" />
+        <add name="Scale Offset" type="float" default="3.402823466e+38" />
+        <add name="Scale Half Range" type="float" default="3.402823466e+38" />
+    </niobject>
+
+    <niobject name="NiLookAtEvaluator" inherit="NiEvaluator">
+        <add name="Flags" type="LookAtFlags" />
+        <add name="Look At Name" type="string" />
+        <add name="Driven Name" type="string" />
+        <add name="Interpolator: Translation" type="Ref" template="NiPoint3Interpolator" />
+        <add name="Interpolator: Roll" type="Ref" template="NiFloatInterpolator" />
+        <add name="Interpolator: Scale" type="Ref" template="NiFloatInterpolator" />
+    </niobject>
+
+    <niobject name="NiPathEvaluator" inherit="NiKeyBasedEvaluator">
+        <add name="Flags" type="PathFlags" default="3" />
+        <add name="Bank Dir" type="int" default="1">-1 = Negative, 1 = Positive</add>
+        <add name="Max Bank Angle" type="float">Max angle in radians.</add>
+        <add name="Smoothing" type="float" />
+        <add name="Follow Axis" type="short">0, 1, or 2 representing X, Y, or Z.</add>
+        <add name="Path Data" type="Ref" template="NiPosData" />
+        <add name="Percent Data" type="Ref" template="NiFloatData" />
+    </niobject>
 
     <niobject name="NiSequenceData" inherit="NiObject">
-        <!-- not yet decoded -->
-    </niobject>
-
-    <niobject name="NiTransformEvaluator" inherit="NiObject">
-        <!-- not yet decoded -->
-    </niobject>
-
-    <niobject name="NiBSplineCompTransformEvaluator" inherit="NiObject">
-        <!-- not yet decoded -->
+        Root node in Gamebryo .kf files (20.5.0.1 and up).
+        For 20.5.0.0, "NiSequenceData" is an alias for "NiControllerSequence" and this is not handled in nifxml.
+        This was not found in any 20.5.0.0 KFs available and they instead use NiControllerSequence directly.
+        <add name="Name" type="string" />
+        <!-- Pre-Evaluator -->
+        <add name="Num Controlled Blocks" type="uint" ver2="20.5.0.1" />
+        <add name="Array Grow By" type="uint" ver2="20.5.0.1" />
+        <add name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" ver2="20.5.0.1" />
+        <!-- Evaluator -->
+        <add name="Num Evaluators" type="uint" ver1="20.5.0.2" />
+        <add name="Evaluators" type="Ref" template="NiEvaluator" arr1="Num Evaluators" ver1="20.5.0.2" />
+        <add name="Text Keys" type="Ref" template="NiTextKeyExtraData" />
+        <add name="Duration" type="float" />
+        <add name="Cycle Type" type="CycleType" />
+        <add name="Frequency" type="float" default="1.0" />
+        <add name="Accum Root Name" type="string">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</add>
+        <add name="Accum Flags" type="AccumFlags" default="ACCUM_X_FRONT" />
     </niobject>
 
     <niobject name="NiShadowGenerator" inherit="NiObject">

--- a/nif.xml
+++ b/nif.xml
@@ -1660,7 +1660,7 @@
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="(Has Faces) &amp;&amp; (Num Strips == 0)" ver1="10.1.0.0">The triangles.</add>
         <add name="Has Bone Indices" type="bool">Do we have bone indices?</add>
         <add name="Bone Indices" type="byte" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into 'Bones'.</add>
-		<add name="Unknown Short" type="ushort" vercond="User Version >= 12">Unknown</add>
+		<add name="Unknown Short" type="ushort" vercond="User Version 2 &gt; 34">Unknown</add>
 		<add name="Vertex Size" type="byte" ver="20.2.0.7" userver2="100" />
 		<add name="Float Size" type="byte" ver="20.2.0.7" userver2="100" />
 		<add name="VF3" type="byte" ver="20.2.0.7" userver2="100" />
@@ -1743,12 +1743,12 @@
     <compound name="FurniturePosition">
         Bethesda Animation. Describes a furniture position?
         <add name="Offset" type="Vector3">Offset of furniture marker.</add>
-        <add name="Orientation" type="ushort" vercond="User Version &lt;= 11">Furniture marker orientation.</add>
-        <add name="Position Ref 1" type="byte" vercond="User Version &lt;= 11">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 2.</add>
-        <add name="Position Ref 2" type="byte" vercond="User Version &lt;= 11">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 1.</add>
-        <add name="Heading" type="float" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Similar to Orientation, in float form.</add>
-        <add name="Animation Type" type="AnimationType" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
-        <add name="Entry Properties" type="FurnitureEntryPoints" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown/unused in nif?</add>
+        <add name="Orientation" type="ushort" vercond="User Version 2 &lt;= 34">Furniture marker orientation.</add>
+        <add name="Position Ref 1" type="byte" vercond="User Version 2 &lt;= 34">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 2.</add>
+        <add name="Position Ref 2" type="byte" vercond="User Version 2 &lt;= 34">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 1.</add>
+        <add name="Heading" type="float" vercond="User Version 2 &gt; 34">Similar to Orientation, in float form.</add>
+        <add name="Animation Type" type="AnimationType" vercond="User Version 2 &gt; 34">Unknown</add>
+        <add name="Entry Properties" type="FurnitureEntryPoints" vercond="User Version 2 &gt; 34">Unknown/unused in nif?</add>
     </compound>
 
     <compound name="TriangleData">
@@ -2121,6 +2121,16 @@
         Body part list for DismemberSkinInstance
         <add name="Part Flag" type="BSPartFlag" default="257">Flags related to the Body Partition</add>
         <add name="Body Part" type="BSDismemberBodyPartType">Body Part Index</add>
+    </compound>
+    
+    <compound name="BSVertexDesc">
+        <add name="VF1" type="byte" />
+        <add name="VF2" type="byte" />
+        <add name="VF3" type="byte" />
+        <add name="VF4" type="byte" />
+        <add name="VF5" type="byte" />
+        <add name="VF" type="VertexFlags" />
+        <add name="VF8" type="byte" />
     </compound>
     
     <compound name="BSGeometrySegmentData">
@@ -2523,7 +2533,7 @@
         <add name="Origin" type="Vector3">Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus 0.1.</add>
         <add name="Scale" type="float">The scaling factor to quantize the MOPP: the quantization factor is equal to 256*256 divided by this number. In Oblivion files, scale is taken equal to 256*256*254 / (size + 0.2) where size is the largest dimension of the bounding box of the packed shape.</add>
         <add name="Old MOPP Data" ver2="10.0.1.0" type="byte" binary="1" arr1="MOPP Data Size - 1">The tree of bounding volume data (old style, contains more than just the mopp script).</add>
-        <add name="Build Type" type="MoppDataBuildType" ver1="20.2.0.7" vercond="User Version >= 12">Tells if MOPP Data was organized into smaller chunks (PS3) or not (PC)</add>
+        <add name="Build Type" type="MoppDataBuildType" vercond="User Version 2 &gt; 34">Tells if MOPP Data was organized into smaller chunks (PS3) or not (PC)</add>
         <add name="MOPP Data" ver1="10.0.1.2" type="byte" binary="1" arr1="MOPP Data Size">The tree of bounding volume data.</add>
     </niobject>
 
@@ -2696,7 +2706,7 @@
 
     <niobject name="NiObjectNET" abstract="1" inherit="NiObject">
         Abstract base class for NiObjects that support names, extra data, and time controllers.
-        <add name="Skyrim Shader Type" type="BSLightingShaderPropertyShaderType" vercond="User Version >= 12" cond="BSLightingShaderProperty">Configures the main shader path</add>
+        <add name="Skyrim Shader Type" type="BSLightingShaderPropertyShaderType" vercond="User Version 2 &gt;= 83" cond="BSLightingShaderProperty">Configures the main shader path</add>
         <add name="Name" type="string">Name of this controllable object, used to refer to the object in .kf files.</add>
         <add name="Has Old Extra Data" type="bool" ver2="2.3">Extra data for pre-3.0 versions.</add>
         <add name="Old Extra Prop Name" cond="Has Old Extra Data" ver2="2.3" type="string">(=NiStringExtraData)</add>
@@ -2769,14 +2779,14 @@
 
     <niobject name="NiAVObject" abstract="1" inherit="NiObjectNET">
         Abstract audio-visual base class from which all of Gamebryo's scene graph objects inherit.
-        <add name="Flags" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects. For Bethesda streams above 26 only.</add>
-        <add name="Flags" type="Flags" ver1="3.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26))">Basic flags for AV objects; commonly 0x000C or 0x000A.</add>
+        <add name="Flags" type="uint" default="14" vercond="(User Version 2 &gt; 26)">Basic flags for AV objects. For Bethesda streams above 26 only.</add>
+        <add name="Flags" type="Flags" ver1="3.0" vercond="(User Version 2 &lt;= 26)">Basic flags for AV objects; commonly 0x000C or 0x000A.</add>
         <add name="Translation" type="Vector3">The translation vector.</add>
         <add name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</add>
         <add name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</add>
         <add name="Velocity" type="Vector3" ver2="4.2.2.0">Unknown function. Always seems to be (0, 0, 0)</add>
-        <add name="Num Properties" type="uint" vercond="((Version &lt; 20.2.0.7) || (User Version &lt;= 11))" />
-        <add name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="((Version &lt; 20.2.0.7) || (User Version &lt;= 11))">All rendering properties attached to this object.</add>
+        <add name="Num Properties" type="uint" vercond="(User Version 2 &lt;= 34)" />
+        <add name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="(User Version 2 &lt;= 34)">All rendering properties attached to this object.</add>
         <add name="Unknown 1" type="uint" arr1="4" ver2="2.3">Always 2,0,2,0.</add>
         <add name="Unknown 2" type="byte" ver2="2.3">0 or 1.</add>
         <add name="Has Bounding Box" type="bool" ver1="3.0" ver2="4.2.2.0" />
@@ -2881,8 +2891,8 @@
         <add name="Num Interpolators" type="uint" ver1="10.1.0.106" />
         <add name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" ver1="10.1.0.106" ver2="20.0.0.5" />
         <add name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" ver1="20.1.0.3" />
-        <add name="Num Unknown Ints" type="uint" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version >= 10)" />
-        <add name="Unknown Ints" type="uint" arr1="Num Unknown Ints" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version >= 10)">Unknown.</add>
+        <add name="Num Unknown Ints" type="uint" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version 2 &gt; 0)" />
+        <add name="Unknown Ints" type="uint" arr1="Num Unknown Ints" ver1="20.0.0.4" ver2="20.0.0.5" vercond="(User Version 2 &gt; 0)">Unknown.</add>
     </niobject>
 
     <niobject name="NiMorphController" abstract="0" inherit="NiInterpController">
@@ -3089,27 +3099,40 @@
     <niobject name="NiBSBoneLODController" abstract="0" inherit="NiBoneLODController">
         A simple LOD controller for bones.
     </niobject>
-
-    <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
-        Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
-        <add name="Data" type="Ref" template="NiGeometryData" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100))">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Data" type="Ref" template="NiGeometryData" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Data" suffix="BSPS" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
-        <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version &gt;= 3.3.0.13) &amp;&amp; !((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100))">Skin instance index.</add>
-        <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="!NiParticleSystem">Skin instance index.</add>
-        <add name="Skin Instance" suffix="BSPS" type="uint" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)" cond="NiParticleSystem">Skin instance index.</add>
+    
+    <compound name="GeomMaterialData">
+        <add name="Has Shader" type="bool" ver1="10.0.1.0" ver2="20.1.0.3">Shader.</add>
+        <add name="Shader Name" type="string" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">The shader name.</add>
+        <add name="Unknown Integer" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Unknown value, usually -1. (Not a link)</add>
         <add name="Num Materials" type="uint" ver1="20.2.0.7">Num Materials</add>
         <add name="Material Name" type="string" arr1="Num Materials" ver1="20.2.0.7">Unknown string.  Shader?</add>
         <add name="Material Extra Data" type="int" arr1="Num Materials" ver1="20.2.0.7">Unknown integer; often -1. (Is this a link, array index?)</add>
         <add name="Active Material" type="int" ver1="20.2.0.7" default="0">Active Material; often -1. (Is this a link, array index?)</add>
-        <add name="Has Shader" type="bool" ver1="10.0.1.0" ver2="20.1.0.3">Shader.</add>
-        <add name="Shader Name" type="string" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">The shader name.</add>
-        <add name="Unknown Integer" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Unknown value, usually -1. (Not a link)</add>
+    </compound>
+
+    <niobject name="NiGeometry" abstract="1" inherit="NiAVObject">
+        Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
+        <!-- Bethesda 20.2.0.7 NIFs: NiGeometry was changed to BSGeometry. 
+             Most new blocks (e.g. BSTriShape) do not refer to NiGeometry except NiParticleSystem was changed to use BSGeometry.
+             This causes massive inheritance problems so the rows below are doubled up to exclude NiParticleSystem for Bethesda Stream 100+.
+        -->
+        <!-- BSGeometry: Used by Bethesda Stream 100+ NiParticleSystem -->
+        <add name="Bound" type="NiBound" vercond="(User Version 2 &gt;= 100)" cond="NiParticleSystem" />
+        <add name="Skin" type="Ref" template="NiObject" vercond="(User Version 2 &gt;= 100)" cond="NiParticleSystem" />
+        <!-- NiGeometry: Each row is doubled in order to exclude NiParticleSystem for Bethesda Stream 100+ -->
+        <add name="Data" type="Ref" template="NiGeometryData" vercond="(User Version 2 &lt; 100)">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Data" type="Ref" template="NiGeometryData" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</add>
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="3.3.0.13" vercond="(User Version 2 &lt; 100)" />
+        <add name="Skin Instance" type="Ref" template="NiSkinInstance" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
+        <add name="Material Data" type="GeomMaterialData" ver1="10.0.1.0" vercond="(User Version 2 &lt; 100)" />
+        <add name="Material Data" type="GeomMaterialData" ver1="10.0.1.0" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
+        <!-- Custom Versions -->
         <add name="Unknown Byte" type="byte" default="255" userver="1">Cyanide extension (only in version 10.2.0.0?).</add>
         <add name="Unknown Integer 2" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown.</add>
-        <add name="Dirty Flag" type="bool" vercond="(Version &gt;= 20.2.0.7) &amp;&amp; (User Version 2 &lt; 100)">Dirty Flag?</add>
-        <add name="Dirty Flag" type="bool" cond="NiTriBasedGeom" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 100)">Dirty Flag?</add>
-        <add name="Unknown Integer 3" type="int" cond="NiParticleSystem" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)">Dirty Flag?</add>
+        <!-- / Custom -->
+        <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &lt; 100)" />
+        <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
+        <!-- Bethesda -->
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" ver1="20.2.0.7" userver="12">Two property links, used by Bethesda.</add>
     </niobject>
 
@@ -3157,25 +3180,30 @@
 
     <niobject name="NiGeometryData" abstract="1" inherit="NiObject">
         Mesh data: vertices, vertex normals, etc.
+        <!-- Bethesda 20.2.0.7 NIFs: NiParticlesData no longer inherits from NiGeometryData and inherits NiObject directly. 
+           "Num Vertices" is renamed to "BS Max Vertices" for Bethesda 20.2 because Vertices, Normals, Tangents, Colors, and UV arrays
+           do not have length for NiPSysData regardless of "Num" or booleans.
+        -->
         <add name="Unknown Int" type="int" ver1="10.2.0.0">Unknown identifier. Always 0.</add>
-        <!-- special case for Bethesda PSysData (or NiParticlesData?) in Fallout 3 and higher -->
         <add name="Num Vertices" type="ushort" cond="!NiPSysData">Number of vertices.</add>
-        <add name="Num Vertices" type="ushort" cond="NiPSysData" vercond="(Version &lt; 20.2.0.7) || (User Version &lt; 11)">Number of vertices.</add>
-        <add name="BS Max Vertices" type="ushort" cond="NiPSysData" vercond="(Version >= 20.2.0.7) &amp;&amp; (User Version >= 11)">Bethesda uses this for max number of particles in NiPSysData.</add>
+        <add name="Num Vertices" type="ushort" cond="NiPSysData" vercond="(User Version 2 &lt; 34)">Number of vertices.</add>
+        <add name="BS Max Vertices" type="ushort" cond="NiPSysData" vercond="(User Version 2 &gt;= 34)">Bethesda uses this for max number of particles in NiPSysData.</add>
         <add name="Keep Flags" type="byte" ver1="10.1.0.0">Used with NiCollision objects when OBB or TRI is set.</add>
         <add name="Compress Flags" type="byte" ver1="10.1.0.0">Unknown.</add>
         <add name="Has Vertices" type="bool" default="1">Is the vertex array present? (Always non-zero.)</add>
         <add name="Vertices" type="Vector3" arr1="Num Vertices" cond="Has Vertices">The mesh vertices.</add>
-        <add name="Vector Flags" type="VectorFlags" vercond="((Version &gt;= 10.0.1.0) &amp;&amp; (Version != 20.2.0.7))" />
-        <add name="BS Vector Flags" type="BSVectorFlags" vercond="(Version == 20.2.0.7)" />
-        <add name="Unknown Int 2" type="uint" ver1="20.2.0.7" userver="12" cond="!NiPSysData">Unknown, seen in Skyrim.</add>
+        <add name="Vector Flags" type="VectorFlags" ver1="10.0.1.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
+        <add name="BS Vector Flags" type="BSVectorFlags" vercond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
+        <add name="Material CRC" type="uint" ver1="20.2.0.7" ver2="20.2.0.7" userver="12" />
         <add name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</add>
         <add name="Normals" type="Vector3" arr1="Num Vertices" cond="Has Normals">The lighting normals.</add>
         <add name="Tangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) &amp;&amp; ((Vector Flags | BS Vector Flags) &amp; 4096)" ver1="10.1.0.0">Tangent vectors.</add>
         <add name="Bitangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) &amp;&amp; ((Vector Flags | BS Vector Flags) &amp; 4096)" ver1="10.1.0.0">Bitangent vectors.</add>
+        <!-- TODO: NiBound -->
         <add name="Center" type="Vector3">Center of the bounding box (smallest box that contains all vertices) of the mesh.</add>
         <add name="Radius" type="float">Radius of the mesh: maximal Euclidean distance between the center and all vertices.</add>
         <add name="Unknown 13 shorts" type="short" arr1="13" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Unknown, always 0?</add>
+        <!-- / NiBound -->
         <add name="Has Vertex Colors" type="bool">
             Do we have vertex colors? These are usually used to fine-tune the lighting of the model.
 
@@ -3191,10 +3219,8 @@
             Note: for compatibility with NifTexture, set this value to either 0x00000000 or 0xFFFFFFFF.
         </add>
         <add name="UV Sets" type="TexCoord" arr1="((Num UV Sets &amp; 63) | (Vector Flags &amp; 63) | (BS Vector Flags &amp; 1))" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</add>
-        <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE" vercond="User Version &lt; 12">Consistency Flags</add>
-        <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE" vercond="User Version >= 12" cond="!NiPSysData">Consistency Flags</add>
-        <add name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" ver1="20.0.0.4" vercond="User Version &lt; 12">Unknown.</add>
-        <add name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" ver1="20.0.0.4" vercond="User Version >= 12" cond="!NiPSysData">Unknown.</add>
+        <add name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE">Consistency Flags</add>
+        <add name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" ver1="20.0.0.4">Unknown.</add>
     </niobject>
 
     <niobject name="AbstractAdditionalGeometryData" abstract="1" inherit="NiObject">
@@ -3291,25 +3317,32 @@
 
     <niobject name="NiParticlesData" abstract="0" inherit="NiGeometryData">
         Generic rotating particles data object.
+        <!-- Bethesda 20.2.0.7 NIFs: NiParticlesData no longer inherits from NiGeometryData and inherits NiObject directly. 
+            `!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))` means "Not Bethesda 20.2"
+        -->
         <add name="Num Particles" type="ushort" ver2="4.0.0.2">The maximum number of particles (matches the number of vertices).</add>
         <add name="Particle Radius" type="float" ver2="10.0.1.0">The particles' size.</add>
         <add name="Has Radii" type="bool" ver1="10.1.0.0">Is the particle size array present?</add>
-        <add name="Radii" type="float" arr1="Num Vertices" cond="Has Radii" ver1="10.1.0.0" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">The individual particel sizes.</add>
+        <add name="Radii" type="float" arr1="Num Vertices" cond="Has Radii" ver1="10.1.0.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">The individual particle sizes.</add>
         <add name="Num Active" type="ushort">The number of active particles at the time the system was saved. This is also the number of valid entries in the following arrays.</add>
         <add name="Has Sizes" type="bool">Is the particle size array present?</add>
-        <add name="Sizes" type="float" arr1="Num Vertices" cond="Has Sizes" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">The individual particel sizes.</add>
+        <add name="Sizes" type="float" arr1="Num Vertices" cond="Has Sizes" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">The individual particle sizes.</add>
         <add name="Has Rotations" type="bool" ver1="10.0.1.0">Is the particle rotation array present?</add>
-        <add name="Rotations" type="Quaternion" arr1="Num Vertices" cond="Has Rotations" ver1="10.0.1.0" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">The individual particle rotations.</add>
-        <add name="Unknown Byte 1" type="byte" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown, probably a boolean.</add>
-        <add name="Unknown Link" type="Ref" template="NiObject" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
+        <add name="Rotations" type="Quaternion" arr1="Num Vertices" cond="Has Rotations" ver1="10.0.1.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">The individual particle rotations.</add>
         <add name="Has Rotation Angles" type="bool" ver1="20.0.0.4">Are the angles of rotation present?</add>
-        <add name="Rotation Angles" type="float" arr1="Num Vertices" cond="Has Rotation Angles" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Angles of rotation</add>
+        <add name="Rotation Angles" type="float" arr1="Num Vertices" cond="Has Rotation Angles" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">Angles of rotation</add>
         <add name="Has Rotation Axes" type="bool" ver1="20.0.0.4">Are axes of rotation present?</add>
-        <add name="Rotation Axes" type="Vector3" arr1="Num Vertices" cond="Has Rotation Axes" ver1="20.0.0.4" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Unknown</add>
-        <add name="Has UV Quadrants" type="bool" vercond="(Version >= 20.2.0.7) &amp;&amp; (User Version == 11)">if value is no, a single image rendered</add>
-        <add name="Num UV Quadrants" type="byte" vercond="(Version >= 20.2.0.7) &amp;&amp; (User Version == 11)">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</add>
-        <add name="UV Quadrants" type="Vector4" arr1="Num UV Quadrants" cond="Has UV Quadrants" vercond="(Version >= 20.2.0.7) &amp;&amp; (User Version == 11)"></add>
-        <add name="Unknown Byte 2" type="byte" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version >= 11)">Unknown</add>
+        <add name="Rotation Axes" type="Vector3" arr1="Num Vertices" cond="Has Rotation Axes" ver1="20.0.0.4" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">Axes of rotation.</add>
+        <!-- Bethesda -->
+        <add name="Has Texture Indices" type="bool" vercond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
+        <add name="Num Subtexture Offsets" type="uint" vercond="(User Version 2 &gt; 34)">How many quads to use in BSPSysSubTexModifier for texture atlasing</add>
+        <add name="Num Subtexture Offsets" type="byte" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt;= 34)">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</add>
+        <add name="Subtexture Offsets" type="Vector4" arr1="Num Subtexture Offsets" vercond="((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))">Defines UV offsets</add>
+        <add name="Aspect Ratio" type="float" vercond="(User Version 2 &gt; 34)">Sets aspect ratio for Subtexture Offset UV quads</add>
+        <add name="Aspect Flags" type="ushort" vercond="(User Version 2 &gt; 34)" />
+        <add name="Speed to Aspect Aspect 2" type="float" vercond="(User Version 2 &gt; 34)" />
+        <add name="Speed to Aspect Speed 1" type="float" vercond="(User Version 2 &gt; 34)" />
+        <add name="Speed to Aspect Speed 2" type="float" vercond="(User Version 2 &gt; 34)" />
     </niobject>
 
     <niobject name="NiRotatingParticlesData" abstract="0" inherit="NiParticlesData">
@@ -3334,21 +3367,12 @@
 
     <niobject name="NiPSysData" abstract="0" inherit="NiParticlesData">
         Particle system data.
-        <add name="Particle Descriptions" type="ParticleDesc" arr1="Num Vertices" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Unknown.</add>
-        <add name="Has Unknown Floats 3" type="bool" ver1="20.0.0.4" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Unknown.</add>
-        <add name="Unknown Floats 3" type="float" arr1="Num Vertices" cond="Has Unknown Floats 3" ver1="20.0.0.4" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Unknown.</add>
-        <add name="Unknown Short 1" type="ushort" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version == 11))">Unknown.</add>
-        <add name="Unknown Short 2" type="ushort" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version == 11))">Unknown.</add>
-
-        <add name="Has Subtexture Offset UVs" type="bool" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Boolean for Num Subtexture Offset UVs</add>
-        <add name="Num Subtexture Offset UVs" type="uint" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">How many quads to use in BSPSysSubTexModifier for texture atlasing</add>
-        <add name="Aspect Ratio" type="float" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Sets aspect ratio for Subtexture Offset UV quads</add>
-        <add name="Subtexture Offset UVs" type="Vector4" arr1="Num Subtexture Offset UVs" cond="Has Subtexture Offset UVs" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Defines UV offsets</add>
-        <add name="Unknown Int 4" type="uint" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
-        <add name="Unknown Int 5" type="uint" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
-        <add name="Unknown Int 6" type="uint" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
-        <add name="Unknown Short 3" type="ushort" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
-        <add name="Unknown Byte 4" type="byte" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown</add>
+        <!-- `!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))` means "Not Bethesda 20.2" -->
+        <add name="Particle Descriptions" type="ParticleDesc" arr1="Num Vertices" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
+        <add name="Has Rotation Speeds" type="bool" ver1="20.0.0.2" />
+        <add name="Rotation Speeds" type="float" arr1="Num Vertices" cond="Has Rotation Speeds" ver1="20.0.0.2" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
+        <add name="Num Added Particles" type="ushort" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
+        <add name="Added Particles Base" type="ushort" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 0))" />
     </niobject>
     
     <niobject name="NiMeshPSysData" abstract="0" inherit="NiPSysData">
@@ -3539,9 +3563,9 @@
         <add name="Accum Flags" type="AccumFlags" ver1="20.3.0.8" default="ACCUM_X_FRONT" />
         <add name="String Palette" type="Ref" template="NiStringPalette" ver1="10.1.0.113" ver2="20.1.0.0" />
         <!-- Bethesda -->
-        <add name="Anim Notes" type="Ref" template="BSAnimNotes" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt;= 24) &amp;&amp; (User Version 2 &lt;= 28)" />
-        <add name="Num Anim Note Arrays" type="ushort" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 28)" />
-        <add name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 28)" />
+        <add name="Anim Notes" type="Ref" template="BSAnimNotes" ver1="20.2.0.7" vercond="(User Version 2 &gt;= 24) &amp;&amp; (User Version 2 &lt;= 28)" />
+        <add name="Num Anim Note Arrays" type="ushort" ver1="20.2.0.7" vercond="(User Version 2 &gt; 28)" />
+        <add name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" ver1="20.2.0.7" vercond="(User Version 2 &gt; 28)" />
     </niobject>
 
     <niobject name="NiAVObjectPalette" abstract="1" inherit="NiObject">
@@ -3680,13 +3704,13 @@
     <niobject name="NiMaterialProperty" abstract="0" inherit="NiProperty">
         Describes the surface properties of an object e.g. translucency, ambient color, diffuse color, emissive color, and specular color.
         <add name="Flags" type="Flags" ver1="3.0" ver2="10.0.1.2">Property flags.</add>
-        <add name="Ambient Color" type="Color3" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21))">How much the material reflects ambient light.</add>
-        <add name="Diffuse Color" type="Color3" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21))">How much the material reflects diffuse light.</add>
+        <add name="Ambient Color" type="Color3" vercond="(User Version 2 &lt; 26)">How much the material reflects ambient light.</add>
+        <add name="Diffuse Color" type="Color3" vercond="(User Version 2 &lt; 26)">How much the material reflects diffuse light.</add>
         <add name="Specular Color" type="Color3">How much light the material reflects in a specular manner.</add>
         <add name="Emissive Color" type="Color3">How much light the material emits.</add>
         <add name="Glossiness" type="float">The material glossiness.</add>
         <add name="Alpha" type="float">The material transparency (1=non-transparant). Refer to a NiAlphaProperty object in this material's parent NiTriShape object, when alpha is not 1.</add>
-        <add name="Emit Multi" type="float" default="1.0" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version >= 11) &amp;&amp; (User Version 2 > 21)">Unknown</add>
+        <add name="Emissive Mult" type="float" default="1.0" vercond="(User Version 2 &gt; 21)" />
     </niobject>
 
     <niobject name="NiMorphData" abstract="0" inherit="NiObject">
@@ -3830,6 +3854,7 @@
 
     <niobject name="NiParticles" abstract="0" inherit="NiGeometry">
         Generic particle system node.
+        <add name="Vertex Desc" type="BSVertexDesc" vercond="(User Version 2 &gt;= 100)" />
     </niobject>
 
     <niobject name="NiAutoNormalParticles" abstract="0" inherit="NiParticles">
@@ -3847,13 +3872,14 @@
 
     <niobject name="NiParticleSystem" abstract="0" inherit="NiParticles">
         A particle system.
-		<add name="Unknown Short 2" type="ushort" vercond="User Version >= 12">Unknown</add>
-		<add name="Unknown Short 3" type="ushort" vercond="User Version >= 12">Unknown</add>
-		<add name="Unknown Int 1" type="uint" vercond="User Version >= 12">Unknown</add>
-		<add name="Unknown Int 2" type="int" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)">Unknown</add>
-		<add name="Unknown Int 3" type="int" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)">Unknown</add>
-		<add name="Data" type="Ref" template="NiPSysData" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)">Unknown</add>
-		<add name="World Space" type="bool" ver1="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</add>
+        <!-- Bethesda -->
+        <add name="Far Begin" type="ushort" vercond="(User Version 2 &gt;= 83)" />
+        <add name="Far End" type="ushort" vercond="(User Version 2 &gt;= 83)" />
+        <add name="Near Begin" type="ushort" vercond="(User Version 2 &gt;= 83)" />
+        <add name="Near End" type="ushort" vercond="(User Version 2 &gt;= 83)" />
+        <add name="Data" type="Ref" template="NiPSysData" vercond="(User Version 2 &gt;= 100)" />
+        <!-- / Bethesda -->
+        <add name="World Space" type="bool" ver1="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</add>
         <add name="Num Modifiers" type="uint" ver1="10.1.0.0">The number of modifier references.</add>
         <add name="Modifiers" type="Ref" template="NiPSysModifier" arr1="Num Modifiers" ver1="10.1.0.0">The list of particle modifiers.</add>
     </niobject>
@@ -4094,7 +4120,7 @@
         <add name="Force Type" type="ForceType">The type of gravitational force.</add>
         <add name="Turbulence" type="float">Adds a degree of randomness.</add>
         <add name="Turbulence Scale" type="float" default="1.0">Scale for turbulence.</add>
-        <add name="World Aligned" type="bool" ver1="20.2.0.7" vercond="User Version >= 11" />
+        <add name="World Aligned" type="bool" vercond="User Version 2 &gt; 16" />
     </niobject>
 
     <niobject name="NiPSysGrowFadeModifier" abstract="0" inherit="NiPSysModifier">
@@ -4103,7 +4129,7 @@
         <add name="Grow Generation" type="ushort">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</add>
         <add name="Fade Time" type="float">The time taken to shrink from their specified size to 0.</add>
         <add name="Fade Generation" type="ushort">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system.</add>
-        <add name="Base Scale" type="float" ver1="20.2.0.7" userver="11">A multiplier on the base particle scale.</add>
+        <add name="Base Scale" type="float" vercond="User Version 2 &gt;= 34">A multiplier on the base particle scale.</add>
     </niobject>
 
     <niobject name="NiPSysMeshEmitter" abstract="0" inherit="NiPSysEmitter">
@@ -5337,31 +5363,32 @@
         <add name="Shader Type" type="BSShaderType" default="SHADER_DEFAULT" />
         <add name="Shader Flags" type="BSShaderFlags" default="0x82000000" />
         <add name="Shader Flags 2" type="BSShaderFlags2" default="1" />
-        <add name="Environment Map Scale" type="float" default="1.0" vercond="User Version == 11">Scales the intensity of the environment/cube map.</add>
+        <add name="Environment Map Scale" type="float" default="1.0" vercond="(User Version 2 &lt;= 34)">Scales the intensity of the environment/cube map.</add>
     </niobject>
 
     <niobject name="BSShaderLightingProperty" abstract="1" inherit="BSShaderProperty">
         Bethesda-specific property.
-        <add name="Texture Clamp Mode" type="TexClampMode" default="3" vercond="User Version &lt;= 11">How to handle texture borders.</add>
+        <add name="Texture Clamp Mode" type="TexClampMode" default="3" vercond="(User Version 2 &lt;= 34)">How to handle texture borders.</add>
     </niobject>
 
     <niobject name="BSShaderNoLightingProperty" abstract="0" inherit="BSShaderLightingProperty">
         Bethesda-specific property.
         <add name="File Name" type="SizedString">The texture glow map.</add>
-        <add name="Falloff Start Angle" type="float" default="1.0" vercond="(User Version >= 11) &amp;&amp; (User Version 2 &gt; 26)">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
-        <add name="Falloff Stop Angle" type="float" default="0.0" vercond="(User Version >= 11) &amp;&amp; (User Version 2 &gt; 26)">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
-        <add name="Falloff Start Opacity" type="float" default="1.0" vercond="(User Version >= 11) &amp;&amp; (User Version 2 &gt; 26)">Alpha falloff multiplier at start angle</add>
-        <add name="Falloff Stop Opacity" type="float" default="0.0" vercond="(User Version >= 11) &amp;&amp; (User Version 2 &gt; 26)">Alpha falloff multiplier at end angle</add>
+        <add name="Falloff Start Angle" type="float" default="1.0" vercond="(User Version 2 &gt; 26)">At this cosine of angle falloff will be equal to Falloff Start Opacity</add>
+        <add name="Falloff Stop Angle" type="float" default="0.0" vercond="(User Version 2 &gt; 26)">At this cosine of angle falloff will be equal to Falloff Stop Opacity</add>
+        <add name="Falloff Start Opacity" type="float" default="1.0" vercond="(User Version 2 &gt; 26)">Alpha falloff multiplier at start angle</add>
+        <add name="Falloff Stop Opacity" type="float" default="0.0" vercond="(User Version 2 &gt; 26)">Alpha falloff multiplier at end angle</add>
     </niobject>
 
     <niobject name="BSShaderPPLightingProperty" abstract="0" inherit="BSShaderLightingProperty">
         Bethesda-specific property.
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set</add>
-        <add name="Refraction Strength" type="float" default="0.0" vercond="(User Version == 11) &amp;&amp; (User Version 2 &gt; 14)">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
-        <add name="Refraction Fire Period" type="int" default="0" vercond="(User Version == 11) &amp;&amp; (User Version 2 &gt; 14)">Rate of texture movement for refraction shader.</add>
-        <add name="Parallax Max Passes" type="float" default="4.0" vercond="(User Version == 11) &amp;&amp; (User Version 2 &gt; 24)">The number of passes the parallax shader can apply.</add>
-        <add name="Parallax Scale" type="float" default="1.0" vercond="(User Version == 11) &amp;&amp; (User Version 2 &gt; 24)">The strength of the parallax.</add>
-        <add name="Emissive Color" type="Color4" vercond="User Version >= 12">Glow color and alpha</add>
+        <add name="Refraction Strength" type="float" default="0.0" vercond="(User Version 2 &gt; 14)">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
+        <add name="Refraction Fire Period" type="int" default="0" vercond="(User Version 2 &gt; 14)">Rate of texture movement for refraction shader.</add>
+        <add name="Parallax Max Passes" type="float" default="4.0" vercond="(User Version 2 &gt; 24)">The number of passes the parallax shader can apply.</add>
+        <add name="Parallax Scale" type="float" default="1.0" vercond="(User Version 2 &gt; 24)">The strength of the parallax.</add>
+        <!-- TODO: Find where this could have even come from as > 34 doesn't exist for this block. -->
+        <add name="Emissive Color" type="Color4" vercond="(User Version 2 &gt; 34)">Glow color and alpha</add>
     </niobject>
 
     <!-- Skyrim specific Node -->
@@ -5632,7 +5659,7 @@
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</add>
         <add name="Emissive Color" type="Color3">Glow color and alpha</add>
         <add name="Emissive Multiple" type="float">Multiplied emissive colors</add>
-        <add name="Wet Material" type="string" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Wet Material" type="string" vercond="(User Version 2 == 130)" />
         <add name="Texture Clamp Mode" type="TexClampMode">How to handle texture borders.</add>
         <add name="Alpha" type="float" default="1.0">The material opacity (1=non-transparent).</add>
         <add name="Refraction Strength" type="float">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
@@ -5641,21 +5668,21 @@
         <add name="Specular Strength" type="float" default="1.0">Brightness of specular highlight. (0=not visible) (0-999)</add>
         <add name="Lighting Effect 1" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
         <add name="Lighting Effect 2" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
-        <add name="Subsurface Rolloff" type="float"  vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Unknown Float 1" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Backlight Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Grayscale to Palette Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Wetness Spec Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Wetness Spec Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Wetness Min Var" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Wetness Env Map Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Wetness Fresnel Power" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Wetness Metalness" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Subsurface Rolloff" type="float"  vercond="(User Version 2 == 130)" />
+        <add name="Unknown Float 1" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Backlight Power" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Grayscale to Palette Scale" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Fresnel Power" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Spec Scale" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Spec Power" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Min Var" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Env Map Scale" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Fresnel Power" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Metalness" type="float" vercond="(User Version 2 == 130)" />
         <add name="Environment Map Scale" type="float" cond="Skyrim Shader Type == 1">Scales the intensity of the environment/cube map. (0-1)</add>
-        <add name="Unknown Env Map Short" type="ushort" cond="Skyrim Shader Type == 1" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Unknown Env Map Short" type="ushort" cond="Skyrim Shader Type == 1" vercond="(User Version 2 == 130)" />
         <add name="Skin Tint Color" type="Color3" cond="Skyrim Shader Type == 5">Tints the base texture. Overridden by game settings.</add>
-        <add name="Unknown Skin Tint Int" type="uint" cond="Skyrim Shader Type == 5" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Unknown Skin Tint Int" type="uint" cond="Skyrim Shader Type == 5" vercond="(User Version 2 == 130)" />
         <add name="Hair Tint Color" type="Color3" cond="Skyrim Shader Type == 6">Tints the base texture. Overridden by game settings.</add>
         <add name="Max Passes" type="float" cond="Skyrim Shader Type == 7">Max Passes</add>
         <add name="Scale" type="float" cond="Skyrim Shader Type == 7">Scale</add>
@@ -5690,10 +5717,10 @@
         <add name="Emissive Multiple" type="float">Multiplier for Emissive Color (RGB part)</add>
         <add name="Soft Falloff Depth" type="float"></add>
         <add name="Greyscale Texture"  type="SizedString">Points to an external texture, used as palette for SLSF1_Greyscale_To_PaletteColor/SLSF1_Greyscale_To_PaletteAlpha.</add>
-        <add name="Env Map Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Normal Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Env Mask Texture" type="SizedString" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
-        <add name="Environment Map Scale" type="float" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 130)" />
+        <add name="Env Map Texture" type="SizedString" vercond="(User Version 2 == 130)" />
+        <add name="Normal Texture" type="SizedString" vercond="(User Version 2 == 130)" />
+        <add name="Env Mask Texture" type="SizedString" vercond="(User Version 2 == 130)" />
+        <add name="Environment Map Scale" type="float" vercond="(User Version 2 == 130)" />
     </niobject>
     
     <bitflags name="SkyrimWaterShaderFlags" storage="byte">

--- a/nif.xml
+++ b/nif.xml
@@ -2241,7 +2241,7 @@
 
     <niobject name="NiPSysCollider" abstract="1" inherit="NiObject">
         Particle system collider.
-        <add name="Bounce" type="float">Amount of bounce for the collider.</add>
+        <add name="Bounce" type="float" default="1.0">Amount of bounce for the collider.</add>
         <add name="Spawn on Collide" type="bool">Spawn particles on impact?</add>
         <add name="Die on Collide" type="bool">Kill particles on impact?</add>
         <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">Spawner to use for the collider.</add>
@@ -2586,7 +2586,7 @@
 
     <niobject name="NiFloatInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiFloatKeys to animate a float value over time.
-        <add name="Pose Value" type="float">Value if lacking NiFloatData.</add>
+        <add name="Pose Value" type="float" default="-3.402823466e+38">Value if lacking NiFloatData.</add>
         <add name="Data" type="Ref" template="NiFloatData" />
     </niobject>
 
@@ -2598,7 +2598,7 @@
 
     <niobject name="NiPoint3Interpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiPosKeys to animate an NiPoint3 value over time.
-        <add name="Pose Value" type="Vector3">Value if lacking NiPosData.</add>
+        <add name="Pose Value" type="Vector3" default="-3.402823466e+38, -3.402823466e+38, -3.402823466e+38">Value if lacking NiPosData.</add>
         <add name="Data" type="Ref" template="NiPosData" />
     </niobject>
 
@@ -2614,8 +2614,8 @@
 
     <niobject name="NiPathInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Used to make an object follow a predefined spline path.
-        <add name="Flags" type="PathFlags" />
-        <add name="Bank Dir" type="int">-1 = Negative, 1 = Positive</add>
+        <add name="Flags" type="PathFlags" default="3" />
+        <add name="Bank Dir" type="int" default="1">-1 = Negative, 1 = Positive</add>
         <add name="Max Bank Angle" type="float">Max angle in radians.</add>
         <add name="Smoothing" type="float" />
         <add name="Follow Axis" type="short">0, 1, or 2 representing X, Y, or Z.</add>
@@ -2625,7 +2625,7 @@
 
     <niobject name="NiBoolInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Uses NiBoolKeys to animate a bool value over time.
-        <add name="Pose Value" type="bool">Value if lacking NiBoolData.</add>
+        <add name="Pose Value" type="bool" default="2">Value if lacking NiBoolData.</add>
         <add name="Data" type="Ref" template="NiBoolData" />
     </niobject>
 
@@ -2653,20 +2653,20 @@
         <add name="Array Size" type="byte" />
         <add name="Weight Threshold" type="float" />
         <add name="Interp Count" type="byte" cond="(Flags &amp; 1) == 0" />
-        <add name="Single Index" type="byte" cond="(Flags &amp; 1) == 0" />
-        <add name="High Priority" type="char" cond="(Flags &amp; 1) == 0" />
-        <add name="Next High Priority" type="char" cond="(Flags &amp; 1) == 0" />
-        <add name="Single Time" type="float" cond="(Flags &amp; 1) == 0" />
-        <add name="High Weights Sum" type="float" cond="(Flags &amp; 1) == 0" />
-        <add name="Next High Weights Sum" type="float" cond="(Flags &amp; 1) == 0" />
-        <add name="High Ease Spinner" type="float" cond="(Flags &amp; 1) == 0" />
+        <add name="Single Index" type="byte" default="255" cond="(Flags &amp; 1) == 0" />
+        <add name="High Priority" type="char" default="-128" cond="(Flags &amp; 1) == 0" />
+        <add name="Next High Priority" type="char" default="-128" cond="(Flags &amp; 1) == 0" />
+        <add name="Single Time" type="float" default="-3.402823466e+38" cond="(Flags &amp; 1) == 0" />
+        <add name="High Weights Sum" type="float" default="-3.402823466e+38" cond="(Flags &amp; 1) == 0" />
+        <add name="Next High Weights Sum" type="float" default="-3.402823466e+38" cond="(Flags &amp; 1) == 0" />
+        <add name="High Ease Spinner" type="float" default="-3.402823466e+38" cond="(Flags &amp; 1) == 0" />
         <add name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" cond="(Flags &amp; 1) == 0" />
     </niobject>
 
     <niobject name="NiBSplineInterpolator" abstract="1" inherit="NiInterpolator">
         Abstract base class for interpolators storing data via a B-spline.
-        <add name="Start Time" type="float">Animation start time.</add>
-        <add name="Stop Time" type="float">Animation stop time.</add>
+        <add name="Start Time" type="float" default="3.402823466e+38">Animation start time.</add>
+        <add name="Stop Time" type="float" default="-3.402823466e+38">Animation stop time.</add>
         <add name="Spline Data" type="Ref" template="NiBSplineData" />
         <add name="Basis Data" type="Ref" template="NiBSplineBasisData" />
     </niobject>
@@ -2763,7 +2763,7 @@
 
     <niobject name="NiDynamicEffect" abstract="1" inherit="NiAVObject">
         Abstract base class for dynamic effects such as NiLights or projected texture effects.
-        <add name="Switch State" type="bool" ver1="10.1.0.106" vercond="User Version 2 &lt; 130">If true, then the dynamic effect is applied to affected nodes during rendering.</add>
+        <add name="Switch State" type="bool" default="1" ver1="10.1.0.106" vercond="User Version 2 &lt; 130">If true, then the dynamic effect is applied to affected nodes during rendering.</add>
         <add name="Num Affected Nodes" type="uint" ver2="4.0.0.2" />
         <add name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" ver2="3.3.0.13">If a node appears in this list, then its entire subtree will be affected by the effect.</add>
         <add name="Affected Node Pointers" type="uint" arr1="Num Affected Nodes" ver1="4.0.0.0" ver2="4.0.0.2">As of 4.0 the pointer hash is no longer stored alongside each NiObject on disk, yet this node list still refers to the pointer hashes. Cannot leave the type as Ptr because the link will be invalid.</add>
@@ -2774,10 +2774,10 @@
     <niobject name="NiLight" abstract="1" inherit="NiDynamicEffect">
         Abstract base class that represents light sources in a scene graph.
         For Bethesda Stream 130 (FO4), NiLight now directly inherits from NiAVObject.
-        <add name="Dimmer" type="float">Scales the overall brightness of all light components.</add>
-        <add name="Ambient Color" type="Color3" />
-        <add name="Diffuse Color" type="Color3" />
-        <add name="Specular Color" type="Color3" />
+        <add name="Dimmer" type="float" default="1.0">Scales the overall brightness of all light components.</add>
+        <add name="Ambient Color" type="Color3" default="0.0, 0.0, 0.0" />
+        <add name="Diffuse Color" type="Color3" default="0.0, 0.0, 0.0" />
+        <add name="Specular Color" type="Color3" default="0.0, 0.0, 0.0" />
     </niobject>
 
     <niobject name="NiProperty" abstract="1" inherit="NiObjectNET">
@@ -2794,7 +2794,7 @@
         <add name="Name" type="string">Used to locate the modifier.</add>
         <add name="Order" type="uint">Modifier ID in the particle modifier chain (always a multiple of 1000)?</add>
         <add name="Target" type="Ptr" template="NiParticleSystem">NiParticleSystem parent of this modifier.</add>
-        <add name="Active" type="bool">Whether or not the modifier is active.</add>
+        <add name="Active" type="bool" default="1">Whether or not the modifier is active.</add>
     </niobject>
 
     <niobject name="NiPSysEmitter" abstract="1" inherit="NiPSysModifier">
@@ -2806,7 +2806,7 @@
         <add name="Planar Angle" type="float">Planar Angle / Second axis.</add>
         <add name="Planar Angle Variation" type="float">Planar Angle randomness / Second axis .</add>
         <add name="Initial Color" type="Color4">Defines color of a birthed particle.</add>
-        <add name="Initial Radius" type="float">Size of a birthed particle.</add>
+        <add name="Initial Radius" type="float" default="1.0">Size of a birthed particle.</add>
         <add name="Radius Variation" type="float" ver1="10.4.0.1">Particle Radius randomness.</add>
         <add name="Life Span" type="float">Duration until a particle dies.</add>
         <add name="Life Span Variation" type="float">Adds randomness to Life Span.</add>
@@ -2831,8 +2831,8 @@
         </add>
         <add name="Frequency" type="float" default="1.0">Frequency (is usually 1.0).</add>
         <add name="Phase" type="float">Phase (usually 0.0).</add>
-        <add name="Start Time" type="float">Controller start time.</add>
-        <add name="Stop Time" type="float">Controller stop time.</add>
+        <add name="Start Time" type="float" default="3.402823466e+38">Controller start time.</add>
+        <add name="Stop Time" type="float" default="-3.402823466e+38">Controller stop time.</add>
         <add name="Target" type="Ptr" template="NiObjectNET" ver1="3.3.0.13">Controller target (object index of the first controllable ancestor of this object).</add>
         <add name="Unknown Integer" type="uint" ver2="3.1">Unknown integer.</add>
     </niobject>
@@ -3243,7 +3243,7 @@
 
     <niobject name="NiAlphaProperty" abstract="0" inherit="NiProperty">
         Transparency. Flags 0x00ED.
-        <add name="Flags" type="Flags" default="237">
+        <add name="Flags" type="Flags" default="4844">
             Bit 0 : alpha blending enable
             Bits 1-4 : source blend mode
             Bits 5-8 : destination blend mode
@@ -3274,7 +3274,7 @@
             110 GL_GEQUAL
             111 GL_NEVER
         </add>
-        <add name="Threshold" type="byte">Threshold for alpha testing (see: glAlphaFunc)</add>
+        <add name="Threshold" type="byte" default="128">Threshold for alpha testing (see: glAlphaFunc)</add>
         <add name="Unknown Short 1" type="ushort" ver2="2.3">Unknown</add>
         <add name="Unknown Int 2" type="uint" ver2="2.3">Unknown</add>
     </niobject>
@@ -3521,10 +3521,10 @@
         <add name="Weight" type="float" default="1.0" ver1="10.1.0.106">The weight of a sequence describes how it blends with other sequences at the same priority.</add>
         <add name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver1="10.1.0.106" />
         <add name="Cycle Type" type="CycleType" ver1="10.1.0.106" />
-        <add name="Frequency" type="float" ver1="10.1.0.106" />
+        <add name="Frequency" type="float" default="1.0" ver1="10.1.0.106" />
         <add name="Phase" type="float" ver1="10.1.0.106" ver2="10.4.0.1" /> <!-- Actually ver2="10.3.0.1" but WorldShift 10.4.0.1 custom version acts like 10.3.0.1 -->
-        <add name="Start Time" type="float" ver1="10.1.0.106" />
-        <add name="Stop Time" type="float" ver1="10.1.0.106" />
+        <add name="Start Time" type="float" default="3.402823466e+38" ver1="10.1.0.106" />
+        <add name="Stop Time" type="float" default="-3.402823466e+38" ver1="10.1.0.106" />
         <add name="Play Backwards" type="bool" ver1="10.1.0.106" ver2="10.1.0.106" />
         <add name="Manager" type="Ptr" template="NiControllerManager" ver1="10.1.0.106">The owner of this sequence.</add>
         <add name="Accum Root Name" type="string" ver1="10.1.0.106">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</add>
@@ -3586,7 +3586,7 @@
 
             If Bit 1 and Bit 2 are not set, but fog is enabled, Fog function is FOG_Z_LINEAR.
         </add>
-        <add name="Fog Depth" type="float">Depth of the fog in normalized units. 1.0 = begins at near plane. 0.5 = begins halfway between the near and far planes.</add>
+        <add name="Fog Depth" type="float" default="1.0">Depth of the fog in normalized units. 1.0 = begins at near plane. 0.5 = begins halfway between the near and far planes.</add>
         <add name="Fog Color" type="Color3">The color of the fog.</add>
     </niobject>
 
@@ -3672,12 +3672,12 @@
     <niobject name="NiMaterialProperty" abstract="0" inherit="NiProperty">
         Describes the surface properties of an object e.g. translucency, ambient color, diffuse color, emissive color, and specular color.
         <add name="Flags" type="Flags" ver1="3.0" ver2="10.0.1.2">Property flags.</add>
-        <add name="Ambient Color" type="Color3" vercond="(User Version 2 &lt; 26)">How much the material reflects ambient light.</add>
-        <add name="Diffuse Color" type="Color3" vercond="(User Version 2 &lt; 26)">How much the material reflects diffuse light.</add>
-        <add name="Specular Color" type="Color3">How much light the material reflects in a specular manner.</add>
-        <add name="Emissive Color" type="Color3">How much light the material emits.</add>
-        <add name="Glossiness" type="float">The material glossiness.</add>
-        <add name="Alpha" type="float">The material transparency (1=non-transparant). Refer to a NiAlphaProperty object in this material's parent NiTriShape object, when alpha is not 1.</add>
+        <add name="Ambient Color" type="Color3" default="1.0, 1.0, 1.0" vercond="(User Version 2 &lt; 26)">How much the material reflects ambient light.</add>
+        <add name="Diffuse Color" type="Color3" default="1.0, 1.0, 1.0" vercond="(User Version 2 &lt; 26)">How much the material reflects diffuse light.</add>
+        <add name="Specular Color" type="Color3" default="1.0, 1.0, 1.0">How much light the material reflects in a specular manner.</add>
+        <add name="Emissive Color" type="Color3" default="0.0, 0.0, 0.0">How much light the material emits.</add>
+        <add name="Glossiness" type="float" default="10.0">The material glossiness.</add>
+        <add name="Alpha" type="float" default="1.0">The material transparency (1=non-transparant). Refer to a NiAlphaProperty object in this material's parent NiTriShape object, when alpha is not 1.</add>
         <add name="Emissive Mult" type="float" default="1.0" vercond="(User Version 2 &gt; 21)" />
     </niobject>
 
@@ -3847,7 +3847,7 @@
         <add name="Near End" type="ushort" vercond="(User Version 2 &gt;= 83)" />
         <add name="Data" type="Ref" template="NiPSysData" vercond="(User Version 2 &gt;= 100)" />
         <!-- / Bethesda -->
-        <add name="World Space" type="bool" ver1="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</add>
+        <add name="World Space" type="bool" default="1" ver1="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</add>
         <add name="Num Modifiers" type="uint" ver1="10.1.0.0">The number of modifier references.</add>
         <add name="Modifiers" type="Ref" template="NiPSysModifier" arr1="Num Modifiers" ver1="10.1.0.0">The list of particle modifiers.</add>
     </niobject>
@@ -3917,7 +3917,7 @@
         DEPRECATED (10.2), REMOVED (20.5). Replaced by NiTransformController and NiPathInterpolator.
         Time controller for a path.
         <add name="Path Flags" type="PathFlags" ver1="10.1.0.0" />
-        <add name="Bank Dir" type="int">-1 = Negative, 1 = Positive</add>
+        <add name="Bank Dir" type="int" default="1">-1 = Negative, 1 = Positive</add>
         <add name="Max Bank Angle" type="float">Max angle in radians.</add>
         <add name="Smoothing" type="float" />
         <add name="Follow Axis" type="short">0, 1, or 2 representing X, Y, or Z.</add>
@@ -4010,7 +4010,7 @@
     <niobject name="NiPointLight" abstract="0" inherit="NiLight">
         A point light.
         <add name="Constant Attenuation" type="float" />
-        <add name="Linear Attenuation" type="float" />
+        <add name="Linear Attenuation" type="float" default="1.0" />
         <add name="Quadratic Attenuation" type="float" />
     </niobject>
 
@@ -4066,10 +4066,10 @@
     <niobject name="NiPSysDragModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies a linear drag force to particles.
         <add name="Drag Object" type="Ptr" template="NiAVObject">The object whose position and orientation are the basis of the force.</add>
-        <add name="Drag Axis" type="Vector3">The local direction of the force.</add>
-        <add name="Percentage" type="float">The amount of drag to apply to particles.</add>
-        <add name="Range" type="float">The distance up to which particles are fully affected.</add>
-        <add name="Range Falloff" type="float">The distance at which particles cease to be affected.</add>
+        <add name="Drag Axis" type="Vector3" default="1.0, 0.0, 0.0">The local direction of the force.</add>
+        <add name="Percentage" type="float" default="0.05">The amount of drag to apply to particles.</add>
+        <add name="Range" type="float" default="3.402823466e+38">The distance up to which particles are fully affected.</add>
+        <add name="Range Falloff" type="float" default="3.402823466e+38">The distance at which particles cease to be affected.</add>
     </niobject>
 
     <niobject name="NiPSysEmitterCtlrData" abstract="0" inherit="NiObject">
@@ -4082,9 +4082,9 @@
     <niobject name="NiPSysGravityModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies a gravitational force to particles.
         <add name="Gravity Object" type="Ptr" template="NiAVObject">The object whose position and orientation are the basis of the force.</add>
-        <add name="Gravity Axis" type="Vector3">The local direction of the force.</add>
+        <add name="Gravity Axis" type="Vector3" default="1.0, 0.0, 0.0">The local direction of the force.</add>
         <add name="Decay" type="float">How the force diminishes by distance.</add>
-        <add name="Strength" type="float">The acceleration of the force.</add>
+        <add name="Strength" type="float" default="1.0">The acceleration of the force.</add>
         <add name="Force Type" type="ForceType">The type of gravitational force.</add>
         <add name="Turbulence" type="float">Adds a degree of randomness.</add>
         <add name="Turbulence Scale" type="float" default="1.0">Scale for turbulence.</add>
@@ -4106,7 +4106,7 @@
         <add name="Emitter Meshes" type="Ptr" template="NiAVObject" arr1="Num Emitter Meshes">The meshes which are emitted from.</add>
         <add name="Initial Velocity Type" type="VelocityType">The method by which the initial particle velocity will be computed.</add>
         <add name="Emission Type" type="EmitFrom">The manner in which particles are emitted from the Emitter Meshes.</add>
-        <add name="Emission Axis" type="Vector3">The emission axis if VELOCITY_USE_DIRECTION.</add>
+        <add name="Emission Axis" type="Vector3" default="1.0, 0.0, 0.0">The emission axis if VELOCITY_USE_DIRECTION.</add>
     </niobject>
 
     <niobject name="NiPSysMeshUpdateModifier" abstract="0" inherit="NiPSysModifier">
@@ -4173,16 +4173,16 @@
         <add name="Rotation Angle" type="float" ver1="20.0.0.2">Initial Rotation Angle in radians.</add>
         <add name="Rotation Angle Variation" type="float" ver1="20.0.0.2">Distributes rotation angle over the range [Angle - Variation, Angle + Variation].</add>
         <add name="Random Rot Speed Sign" type="bool" ver1="20.0.0.2">Randomly negate the initial rotation speed?</add>
-        <add name="Random Axis" type="bool">Assign a random axis to new particles?</add>
-        <add name="Axis" type="Vector3">Initial rotation axis.</add>
+        <add name="Random Axis" type="bool" default="1">Assign a random axis to new particles?</add>
+        <add name="Axis" type="Vector3" default="1.0, 0.0, 0.0">Initial rotation axis.</add>
     </niobject>
 
     <niobject name="NiPSysSpawnModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that spawns additional copies of a particle.
-        <add name="Num Spawn Generations" type="ushort">Number of allowed generations for spawning. Particles whose generations are >= will not be spawned.</add>
-        <add name="Percentage Spawned" type="float">The likelihood of a particular particle being spawned. Must be between 0.0 and 1.0.</add>
-        <add name="Min Num to Spawn" type="ushort">The minimum particles to spawn for any given original particle.</add>
-        <add name="Max Num to Spawn" type="ushort">The maximum particles to spawn for any given original particle.</add>
+        <add name="Num Spawn Generations" type="ushort" default="0">Number of allowed generations for spawning. Particles whose generations are >= will not be spawned.</add>
+        <add name="Percentage Spawned" type="float" default="1.0">The likelihood of a particular particle being spawned. Must be between 0.0 and 1.0.</add>
+        <add name="Min Num to Spawn" type="ushort" default="1">The minimum particles to spawn for any given original particle.</add>
+        <add name="Max Num to Spawn" type="ushort" default="1">The maximum particles to spawn for any given original particle.</add>
         <add name="Unknown Int" type="int" ver1="10.4.0.1" ver2="10.4.0.1">WorldShift</add>
         <add name="Spawn Speed Variation" type="float">How much the spawned particle speed can vary.</add>
         <add name="Spawn Dir Variation" type="float">How much the spawned particle direction can vary.</add>
@@ -4215,7 +4215,7 @@
 
     <niobject name="NiPSysGravityFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, implements a gravity field force for particles.
-        <add name="Direction" type="Vector3">Direction of the gravity field in Field Object's space.</add>
+        <add name="Direction" type="Vector3" default="0.0, -1.0, 0.0">Direction of the gravity field in Field Object's space.</add>
     </niobject>
 
     <niobject name="NiPSysDragFieldModifier" inherit="NiPSysFieldModifier">
@@ -4230,10 +4230,10 @@
     </niobject>
 
     <niobject name="BSPSysLODModifier" inherit="NiPSysModifier">
-        <add name="LOD Begin Distance" type="float" />
-        <add name="LOD End Distance" type="float" />
-        <add name="Unknown Fade Factor 1" type="float" />
-        <add name="Unknown Fade Factor 2" type="float" />
+        <add name="LOD Begin Distance" type="float" default="0.1" />
+        <add name="LOD End Distance" type="float" default="0.7" />
+        <add name="End Emit Scale" type="float" default="0.2" />
+        <add name="End Size" type="float" default="1.0" />
     </niobject>
     
     <niobject name="BSPSysScaleModifier" inherit="NiPSysModifier">
@@ -4292,7 +4292,7 @@
 
     <niobject name="NiPSysAirFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, updates the particle velocity to simulate the effects of air movements like wind, fans, or wake.
-        <add name="Direction" type="Vector3">Direction of the particle velocity</add>
+        <add name="Direction" type="Vector3" default="-1.0, 0.0, 0.0">Direction of the particle velocity</add>
         <add name="Air Friction" type="float">How quickly particles will accelerate to the magnitude of the air field.</add>
         <add name="Inherit Velocity" type="float">How much of the air field velocity will be added to the particle velocity.</add>
         <add name="Inherit Rotation" type="bool" />
@@ -4446,7 +4446,7 @@
         A spot.
         <add name="Outer Spot Angle" type="float" />
         <add name="Inner Spot Angle" type="float" ver1="20.2.0.5" />
-        <add name="Exponent" type="float">Describes the distribution of light. (see: glLight)</add>
+        <add name="Exponent" type="float" default="1.0">Describes the distribution of light. (see: glLight)</add>
     </niobject>
 
     <niobject name="NiStencilProperty" abstract="0" inherit="NiProperty">
@@ -5613,33 +5613,34 @@
         <add name="Shader Flags 1" suffix="SK" type="SkyrimShaderPropertyFlags1" vercond="(User Version 2 != 130)" default="2185233153">Skyrim Shader Flags for setting render/shader options.</add>
         <add name="Shader Flags 2" suffix="SK" type="SkyrimShaderPropertyFlags2" vercond="(User Version 2 != 130)" default="32801">Skyrim Shader Flags for setting render/shader options.</add>
         <add name="Shader Flags 1" suffix="FO4" type="Fallout4ShaderPropertyFlags1" vercond="(User Version 2 == 130)" default="2151678465">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</add>
-        <add name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" vercond="(User Version 2 == 130)" default="129">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</add>
+        <add name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" vercond="(User Version 2 == 130)" default="1">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</add>
         <add name="UV Offset" type="TexCoord">Offset UVs</add>
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures, see above.</add>
         <add name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</add>
-        <add name="Emissive Color" type="Color3">Glow color and alpha</add>
+        <add name="Emissive Color" type="Color3" default="0.0, 0.0, 0.0">Glow color and alpha</add>
         <add name="Emissive Multiple" type="float">Multiplied emissive colors</add>
         <add name="Wet Material" type="string" vercond="(User Version 2 == 130)" />
-        <add name="Texture Clamp Mode" type="TexClampMode">How to handle texture borders.</add>
+        <add name="Texture Clamp Mode" type="TexClampMode" default="3">How to handle texture borders.</add>
         <add name="Alpha" type="float" default="1.0">The material opacity (1=non-transparent).</add>
         <add name="Refraction Strength" type="float">The amount of distortion. **Not based on physically accurate refractive index** (0=none) (0-1)</add>
-        <add name="Glossiness" type="float">The material specular power, or glossiness (0-999).</add>
+        <add name="Glossiness" type="float" default="80" vercond="User Version 2 &lt; 130">The material specular power, or glossiness (0-999).</add>
+        <add name="Smoothness" type="float" default="1.0" vercond="(User Version 2 == 130)">The base roughness (0.0-1.0), multiplied by the smoothness map.</add>
         <add name="Specular Color" type="Color3">Adds a colored highlight.</add>
         <add name="Specular Strength" type="float" default="1.0">Brightness of specular highlight. (0=not visible) (0-999)</add>
-        <add name="Lighting Effect 1" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
-        <add name="Lighting Effect 2" type="float" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
-        <add name="Subsurface Rolloff" type="float"  vercond="(User Version 2 == 130)" />
-        <add name="Unknown Float 1" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Backlight Power" type="float" vercond="(User Version 2 == 130)" />
+        <add name="Lighting Effect 1" type="float" default="0.3" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
+        <add name="Lighting Effect 2" type="float" default="2.0" vercond="User Version 2 &lt; 130">Controls strength for envmap/backlight/rim/softlight lighting effect?</add>
+        <add name="Subsurface Rolloff" type="float" default="0.3" vercond="(User Version 2 == 130)" />
+        <add name="Rimlight Power" type="float" default="3.402823466e+38" vercond="(User Version 2 == 130)" />
+        <add name="Backlight Power" type="float" cond="Rimlight Power == 0x7F7FFFFF" vercond="(User Version 2 == 130)" />
         <add name="Grayscale to Palette Scale" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Fresnel Power" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Wetness Spec Scale" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Wetness Spec Power" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Wetness Min Var" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Wetness Env Map Scale" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Wetness Fresnel Power" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Wetness Metalness" type="float" vercond="(User Version 2 == 130)" />
-        <add name="Environment Map Scale" type="float" cond="Skyrim Shader Type == 1">Scales the intensity of the environment/cube map. (0-1)</add>
+        <add name="Fresnel Power" type="float" default="5.0" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Spec Scale" type="float" default="-1.0" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Spec Power" type="float" default="-1.0" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Min Var" type="float" default="-1.0" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Env Map Scale" type="float" default="-1.0" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Fresnel Power" type="float" default="-1.0" vercond="(User Version 2 == 130)" />
+        <add name="Wetness Metalness" type="float" default="-1.0" vercond="(User Version 2 == 130)" />
+        <add name="Environment Map Scale" type="float" default="1.0" cond="Skyrim Shader Type == 1">Scales the intensity of the environment/cube map. (0-1)</add>
         <add name="Unknown Env Map Short" type="ushort" cond="Skyrim Shader Type == 1" vercond="(User Version 2 == 130)" />
         <add name="Skin Tint Color" type="Color3" cond="Skyrim Shader Type == 5">Tints the base texture. Overridden by game settings.</add>
         <add name="Unknown Skin Tint Int" type="uint" cond="Skyrim Shader Type == 5" vercond="(User Version 2 == 130)" />

--- a/nif.xml
+++ b/nif.xml
@@ -1638,6 +1638,16 @@
 		<add name="Eye Data" type="float" cond="(ARG &amp; 4096) != 0" />
 	</compound>
 
+    <compound name="BSVertexDesc">
+        <add name="VF1" type="byte" />
+        <add name="VF2" type="byte" />
+        <add name="VF3" type="byte" />
+        <add name="VF4" type="byte" />
+        <add name="VF5" type="byte" />
+        <add name="Vertex Attributes" type="VertexFlags" />
+        <add name="VF8" type="byte" />
+    </compound>
+
     <compound name="SkinPartition" ver1="4.2.1.0">
         Skinning data for a submesh, optimized for hardware skinning. Part of NiSkinPartition.
         <add name="Num Vertices" type="ushort">Number of vertices in this submesh.</add>
@@ -1661,13 +1671,7 @@
         <add name="Has Bone Indices" type="bool">Do we have bone indices?</add>
         <add name="Bone Indices" type="byte" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into 'Bones'.</add>
 		<add name="Unknown Short" type="ushort" vercond="User Version 2 &gt; 34">Unknown</add>
-		<add name="Vertex Size" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="Float Size" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF3" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF4" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF5" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF" type="VertexFlags" ver="20.2.0.7" userver2="100" />
-		<add name="VF8" type="byte" ver="20.2.0.7" userver2="100" />
+		<add name="Vertex Desc" type="BSVertexDesc" ver="20.2.0.7" userver2="100" />
 		<add name="Triangles Copy" type="Triangle" arr1="Num Triangles" ver="20.2.0.7" userver2="100" />
         <!-- related to the file posted in tracker item #3117836:
             http://sourceforge.net/tracker/?func=detail&aid=3117836&group_id=149157&atid=776343 -->
@@ -2122,17 +2126,7 @@
         <add name="Part Flag" type="BSPartFlag" default="257">Flags related to the Body Partition</add>
         <add name="Body Part" type="BSDismemberBodyPartType">Body Part Index</add>
     </compound>
-    
-    <compound name="BSVertexDesc">
-        <add name="VF1" type="byte" />
-        <add name="VF2" type="byte" />
-        <add name="VF3" type="byte" />
-        <add name="VF4" type="byte" />
-        <add name="VF5" type="byte" />
-        <add name="VF" type="VertexFlags" />
-        <add name="VF8" type="byte" />
-    </compound>
-    
+
     <compound name="BSGeometrySegmentData">
         Bethesda-specific node.
         <add name="Flags" type="byte" />
@@ -3133,7 +3127,8 @@
         <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &lt; 100)" />
         <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
         <!-- Bethesda -->
-        <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" ver1="20.2.0.7" userver="12">Two property links, used by Bethesda.</add>
+        <add name="Shader Property" type="Ref" template="NiProperty" ver1="20.2.0.7" userver="12" />
+        <add name="Alpha Property" type="Ref" template="NiAlphaProperty" ver1="20.2.0.7" userver="12" />
     </niobject>
 
     <niobject name="NiTriBasedGeom" abstract="1" inherit="NiGeometry">
@@ -4428,14 +4423,8 @@
 		<add name="Skin Partition Blocks" type="SkinPartition" arr1="Num Skin Partition Blocks" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version 2 == 100))">Skin partition objects.</add>
 		<add name="Data Size" type="uint" ver="20.2.0.7" userver2="100" />
 		<add name="Vertex Size" type="uint" ver="20.2.0.7" userver2="100" />
-		<add name="VF1" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF2" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF3" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF4" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF5" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="VF" type="VertexFlags" ver="20.2.0.7" userver2="100" />
-		<add name="VF8" type="byte" ver="20.2.0.7" userver2="100" />
-		<add name="Vertex Data" type="BSVertexDataSSE" arg="VF" arr1="Data Size / Vertex Size" cond="Data Size &gt; 0" ver="20.2.0.7" userver2="100" />
+		<add name="Vertex Desc" type="BSVertexDesc" ver="20.2.0.7" userver2="100" />
+		<add name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc" arr1="Data Size / Vertex Size" cond="Data Size &gt; 0" ver="20.2.0.7" userver2="100" />
 		<add name="Partition" type="SkinPartition" arr1="Num Skin Partition Blocks" ver="20.2.0.7" userver2="100" />
     </niobject>
 
@@ -6968,20 +6957,15 @@
         Fallout 4 Tri Shape
         <add name="Bounding Sphere" type="NiBound" />
         <add name="Skin" type="Ref" template="NiObject" />
-        <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" />
-        <add name="Vertex Size" type="byte" />
-        <add name="Float Size" type="byte" />
-        <add name="VF3" type="byte" />
-        <add name="VF4" type="byte" />
-        <add name="VF5" type="byte" />
-        <add name="VF" type="VertexFlags" />
-        <add name="VF8" type="byte" />
+        <add name="Shader Property" type="Ref" template="NiProperty" />
+        <add name="Alpha Property" type="Ref" template="NiAlphaProperty" />
+        <add name="Vertex Desc" type="BSVertexDesc" />
         <add name="Num Triangles" type="uint" userver2="130" />
         <add name="Num Triangles" type="ushort" vercond="User Version 2 &lt; 130" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF" cond="Data Size &gt; 0" userver2="130" />
-        <add name="Vertex Data" type="BSVertexDataSSE" arr1="Num Vertices" arg="VF" cond="Data Size &gt; 0" userver2="100" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Desc" cond="Data Size &gt; 0" userver2="130" />
+        <add name="Vertex Data" type="BSVertexDataSSE" arr1="Num Vertices" arg="Vertex Desc" cond="Data Size &gt; 0" userver2="100" />
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
         <add name="Particle Data Size" type="uint" userver2="100" />
         <add name="Vertices" type="Vector3" arr1="Num Vertices" cond="Particle Data Size &gt; 0" userver2="100" />
@@ -7162,14 +7146,7 @@
     
     <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
         Fallout 4 Packed Combined Geometry Data
-        <add name="VF1" type="byte" />
-        <add name="VF2" type="byte" />
-        <add name="VF3" type="byte" />
-        <add name="VF4" type="byte" />
-        <add name="VF5" type="byte" />
-        <add name="VF6" type="byte" />
-        <add name="VF7" type="byte" />
-        <add name="VF8" type="byte" />
+        <add name="Vertex Desc" type="BSVertexDesc" />
         <add name="Num Vertices" type="uint" />
         <add name="Num Triangles" type="uint" />
         <add name="Unknown Flags 1" type="uint" />

--- a/nif.xml
+++ b/nif.xml
@@ -6322,6 +6322,27 @@
         <add name="Unknown 2" type="int"></add>
     </niobject>
 
+    <niobject name="NiPSAlignedQuadGenerator" inherit="NiMeshModifier">
+        <add name="Scale Amount U" type="float" />
+        <add name="Scale Limit U" type="float" />
+        <add name="Scale Rest U" type="float" />
+        <add name="Scale Amount V" type="float" />
+        <add name="Scale Limit V" type="float" />
+        <add name="Scale Rest V" type="float" />
+        <add name="Center U " type="float" />
+        <add name="Center V" type="float" />
+        <add name="UV Scrolling" type="bool" />
+        <add name="Num Frames Across" type="ushort" />
+        <add name="Num Frames Down" type="ushort" />
+        <add name="Ping Pong" type="bool" />
+        <add name="Initial Frame" type="ushort" />
+        <add name="Initial Frame Variation" type="float" />
+        <add name="Num Frames" type="ushort" />
+        <add name="Num Frames Variation" type="float" />
+        <add name="Initial Time" type="float" />
+        <add name="Final Time" type="float" />
+    </niobject>
+
     <niobject name="NiPSSimulator" inherit="NiMeshModifier">
         The mesh modifier that performs all particle system simulation.
         <add name="Num Simulation Steps" type="uint">The number of simulation steps in this modifier.</add>

--- a/nif.xml
+++ b/nif.xml
@@ -143,6 +143,19 @@
         These are like C enums and consist of a list of options.  They can appear
         as parts of compounds or niobjects.-->
 
+    <bitflags name="AccumFlags" storage="uint">
+        Describes the options for the accum root on NiControllerSequence.
+        <option value="0" name="ACCUM_X_TRANS">X Translation will be accumulated.</option>
+        <option value="1" name="ACCUM_Y_TRANS">Y Translation will be accumulated.</option>
+        <option value="2" name="ACCUM_Z_TRANS">Z Translation will be accumulated.</option>
+        <option value="3" name="ACCUM_X_ROT">X Rotation will be accumulated.</option>
+        <option value="4" name="ACCUM_Y_ROT">Y Rotation will be accumulated.</option>
+        <option value="5" name="ACCUM_Z_ROT">Z Rotation will be accumulated.</option>
+        <option value="6" name="ACCUM_X_FRONT">+X is front facing. (Default)</option>
+        <option value="7" name="ACCUM_Y_FRONT">+Y is front facing.</option>
+        <option value="8" name="ACCUM_Z_FRONT">+Z is front facing.</option>
+        <option value="9" name="ACCUM_NEG_FRONT">-X is front facing.</option>
+    </bitflags>
 
     <enum name="ApplyMode" storage="uint">
         Describes how the vertex colors are blended with the filtered texture color.
@@ -924,12 +937,18 @@
         <option value="1" name="ENDIAN_LITTLE">The numbers are stored in little endian format, such as those used by Intel and AMD x86 processors.</option>
     </enum>
 
-    <enum name="TargetColor" storage="ushort">
+    <enum name="MaterialColor" storage="ushort">
         Used by NiMaterialColorControllers to select which type of color in the controlled object that will be animated.
         <option value="0" name="TC_AMBIENT">Control the ambient color.</option>
         <option value="1" name="TC_DIFFUSE">Control the diffuse color.</option>
         <option value="2" name="TC_SPECULAR">Control the specular color.</option>
         <option value="3" name="TC_SELF_ILLUM">Control the self illumination color.</option>
+    </enum>
+
+    <enum name="LightColor" storage="ushort">
+        Used by NiLightColorControllers to select which type of color in the controlled object that will be animated.
+        <option value="0" name="LC_DIFFUSE">Control the diffuse color.</option>
+        <option value="1" name="LC_AMBIENT">Control the ambient color.</option>
     </enum>
 
     <enum name="ConsistencyType" storage="ushort">
@@ -1404,31 +1423,39 @@
         <add name="AV Object" type="Ptr" template="NiAVObject">Object reference.</add>
     </compound>
 
-    <compound name="ControllerLink" ver1="10.2.0.0">
+    <compound name="ControlledBlock">
         In a .kf file, this links to a controllable object, via its name (or for version 10.2.0.0 and up, a link and offset to a NiStringPalette that contains the name), and a sequence of interpolators that apply to this controllable object, via links.
-        <add name="Target Name" type="string" ver2="10.1.0.0">Name of a controllable object in another NIF file.</add>
-        <add name="Controller" type="Ref" template="NiTimeController" ver2="10.1.0.0">Link to a controller.</add>
-        <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.106">Link to an interpolator.</add>
-        <add name="Controller" type="Ref" template="NiTimeController" ver1="10.1.0.106">Unknown link. Usually -1.</add>
-        <add name="Unknown Link 2" type="Ref" template="NiObject" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
-        <add name="Unknown Short 0" type="ushort" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
-        <add name="Priority" type="byte" ver1="10.1.0.106" vercond="(User Version >= 10)">Idle animations tend to have low values for this, and NIF objects that have high values tend to correspond with the important parts of the animation.</add>
-        <add name="String Palette" type="Ref" template="NiStringPalette" ver1="10.2.0.0" ver2="20.0.0.5">Refers to the NiStringPalette which contains the name of the controlled NIF object.</add>
-        <add name="Node Name" type="string" ver1="10.1.0.106" ver2="10.1.0.106">The name of the animated node.</add>
-        <add name="Node Name" type="string" ver1="20.1.0.3">The name of the animated node.</add>
-        <add name="Node Name Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.0.0.5">Offset in the string palette where the name of the controlled node (NiNode, NiTriShape, ...) starts.</add>
-        <add name="Property Type" type="string" ver1="10.1.0.106" ver2="10.1.0.106">Name of the property (NiMaterialProperty, ...), if this controller controls a property.</add>
-        <add name="Property Type" type="string" ver1="20.1.0.3">Name of the property (NiMaterialProperty, ...), if this controller controls a property.</add>
-        <add name="Property Type Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.0.0.5">Offset in the string palette where the property (NiMaterialProperty, ...) starts, if this controller controls a property. Otherwise, -1.</add>
-        <add name="Controller Type" type="string" ver1="10.1.0.106" ver2="10.1.0.106">Probably the object type name of the controller in the NIF file that is child of the controlled object.</add>
-        <add name="Controller Type" type="string" ver1="20.1.0.3">Probably the object type name of the controller in the NIF file that is child of the controlled object.</add>
-        <add name="Controller Type Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.0.0.5">Apparently the offset in the string palette of some type of controller related to Interpolator (for example, a &#039;NiTransformInterpolator&#039; will have here a &#039;NiTransformController&#039;, etc.). Sometimes the type of controller that links to the interpolator. Probably it refers to the controller in the NIF file that is child of the controlled object, via its type name.</add>
-        <add name="Variable 1" type="string" ver1="10.1.0.106" ver2="10.1.0.106">Some variable string (such as &#039;SELF_ILLUM&#039;, &#039;0-0-TT_TRANSLATE_U&#039;, &#039;tongue_out&#039;, etc.).</add>
-        <add name="Variable 1" type="string" ver1="20.1.0.3">Some variable string (such as &#039;SELF_ILLUM&#039;, &#039;0-0-TT_TRANSLATE_U&#039;, &#039;tongue_out&#039;, etc.).</add>
-        <add name="Variable 1 Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.0.0.5">Offset in the string palette where some variable string starts (such as &#039;SELF_ILLUM&#039;, &#039;0-0-TT_TRANSLATE_U&#039;, &#039;tongue_out&#039;, etc.). Usually, -1.</add>
-        <add name="Variable 2" type="string" ver1="10.1.0.106" ver2="10.1.0.106">Another variable string, apparently used for particle system controllers.</add>
-        <add name="Variable 2" type="string" ver1="20.1.0.3">Another variable string, apparently used for particle system controllers.</add>
-        <add name="Variable 2 Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.0.0.5">Offset in the string palette where some variable string starts (so far only &#039;EmitterActive&#039; and &#039;BirthRate&#039; have been observed in official files, used for particle system controllers). Usually, -1.</add>
+        For Controller ID, NiInterpController::GetCtlrID() virtual function returns a string formatted specifically for the derived type.
+        For Interpolator ID, NiInterpController::GetInterpolatorID() virtual function returns a string formatted specifically for the derived type.
+        The string formats are documented on the relevant niobject blocks.
+        <add name="Target Name" type="string" ver2="10.1.0.103">Name of a controllable object in another NIF file.</add>
+        <!-- NiControllerSequence::InterpArrayItem -->
+        <add name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.106" />
+        <add name="Controller" type="Ref" template="NiTimeController" />
+        <add name="Blend Interpolator" type="Ref" template="NiBlendInterpolator" ver1="10.1.0.104" ver2="10.1.0.110" />
+        <add name="Blend Index" type="ushort" ver1="10.1.0.104" ver2="10.1.0.110" />
+        <!-- Bethesda-only -->
+        <add name="Priority" type="byte" ver1="10.1.0.106" vercond="(User Version 2 &gt; 0)">Idle animations tend to have low values for this, and high values tend to correspond with the important parts of the animations.</add>
+        <!-- NiControllerSequence::IDTag, post-10.1.0.104 only -->
+        <!-- Until 10.2 -->
+        <add name="Node Name" type="string" ver1="10.1.0.104" ver2="10.1.0.113">The name of the animated NiAVObject.</add>
+        <add name="Property Type" type="string" ver1="10.1.0.104" ver2="10.1.0.113">The RTTI type of the NiProperty the controller is attached to, if applicable.</add>
+        <add name="Controller Type" type="string" ver1="10.1.0.104" ver2="10.1.0.113">The RTTI type of the NiTimeController.</add>
+        <add name="Controller ID" type="string" ver1="10.1.0.104" ver2="10.1.0.113">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</add>
+        <add name="Interpolator ID" type="string" ver1="10.1.0.104" ver2="10.1.0.113">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</add>
+        <!-- From 10.2 to 20.1 -->
+        <add name="String Palette" type="Ref" template="NiStringPalette" ver1="10.2.0.0" ver2="20.1.0.0">Refers to the NiStringPalette which contains the name of the controlled NIF object.</add>
+        <add name="Node Name Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to the name of the animated NiAVObject.</add>
+        <add name="Property Type Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to the RTTI type of the NiProperty the controller is attached to, if applicable.</add>
+        <add name="Controller Type Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to the RTTI type of the NiTimeController.</add>
+        <add name="Controller ID Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to an ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</add>
+        <add name="Interpolator ID Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to an ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</add>
+        <!-- After 20.1 -->
+        <add name="Node Name" type="string" ver1="20.1.0.1">The name of the animated NiAVObject.</add>
+        <add name="Property Type" type="string" ver1="20.1.0.1">The RTTI type of the NiProperty the controller is attached to, if applicable.</add>
+        <add name="Controller Type" type="string" ver1="20.1.0.1">The RTTI type of the NiTimeController.</add>
+        <add name="Controller ID" type="string" ver1="20.1.0.1">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</add>
+        <add name="Interpolator ID" type="string" ver1="20.1.0.1">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</add>
     </compound>
 
     <compound name="ExportInfo">
@@ -2870,7 +2897,7 @@
     <niobject name="NiKeyframeController" abstract="0" inherit="NiSingleInterpController">
         DEPRECATED (10.2), RENAMED (10.2) to NiTransformController
         A time controller object for animation key frames.
-        <add name="Data" type="Ref" template="NiKeyframeData" ver2="10.1.0.0">Keyframe controller data index.</add>
+        <add name="Data" type="Ref" template="NiKeyframeData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiTransformController" abstract="0" inherit="NiKeyframeController">
@@ -2879,13 +2906,18 @@
 
     <niobject name="NiPSysModifierCtlr" abstract="1" inherit="NiSingleInterpController">
         A particle system modifier controller.
-        <add name="Modifier Name" type="string">Refers to modifier object by its name?</add>
+        NiInterpController::GetCtlrID() string format:
+            '%s'
+        Where %s = Value of "Modifier Name"
+        <add name="Modifier Name" type="string">Used to find the modifier pointer.</add>
     </niobject>
 
     <niobject name="NiPSysEmitterCtlr" abstract="0" inherit="NiPSysModifierCtlr">
         Particle system emitter controller.
-        <add name="Data" type="Ref" template="NiPSysEmitterCtlrData" ver2="10.1.0.0">This controller's data</add>
-        <add name="Visibility Interpolator" type="Ref" template="NiInterpolator" ver1="10.2.0.0">Links to a bool interpolator. Controls emitter&#039;s visibility status?</add>
+        NiInterpController::GetInterpolatorID() string format:
+            ['BirthRate', 'EmitterActive'] (for "Interpolator" and "Visibility Interpolator" respectively)
+        <add name="Visibility Interpolator" type="Ref" template="NiInterpolator" ver1="10.2.0.0" />
+        <add name="Data" type="Ref" template="NiPSysEmitterCtlrData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPSysModifierBoolCtlr" abstract="1" inherit="NiPSysModifierCtlr">
@@ -2894,12 +2926,12 @@
 
     <niobject name="NiPSysModifierActiveCtlr" abstract="0" inherit="NiPSysModifierBoolCtlr">
         A particle system modifier controller that animates active/inactive state for particles.
-        <add name="Data" type="Ref" template="NiVisData" ver2="10.1.0.0">This controller's data.</add>
+        <add name="Data" type="Ref" template="NiVisData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPSysModifierFloatCtlr" abstract="1" inherit="NiPSysModifierCtlr">
         A particle system modifier controller that animates a floating point value for particles.
-        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0">This controller's data.</add>
+        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPSysEmitterDeclinationCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
@@ -2947,15 +2979,18 @@
 
     <niobject name="NiAlphaController" abstract="0" inherit="NiFloatInterpController">
         Animates the alpha value of a property using an interpolator.
-        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0">Alpha controller data index.</add>
+        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiTextureTransformController" abstract="0" inherit="NiFloatInterpController">
         Used to animate a single member of an NiTextureTransform.
+        NiInterpController::GetCtlrID() string formats:
+            ['%1-%2-TT_TRANSLATE_U', '%1-%2-TT_TRANSLATE_V', '%1-%2-TT_ROTATE', '%1-%2-TT_SCALE_U', '%1-%2-TT_SCALE_V']
+        (Depending on "Operation" enumeration, %1 = Value of "Shader Map", Value of %2 = "Texture Slot")
         <add name="Shader Map" type="bool">Is the target map a shader map?</add>
         <add name="Texture Slot" type="TexType">The target texture slot.</add>
         <add name="Operation" type="TransformMember">Controls which aspect of the texture transform to modify.</add>
-        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0" />
+        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiLightDimmerController" abstract="0" inherit="NiFloatInterpController">
@@ -2968,7 +3003,7 @@
 
     <niobject name="NiVisController" abstract="0" inherit="NiBoolInterpController">
         Animates the visibility of an NiAVObject.
-        <add name="Data" type="Ref" template="NiVisData" ver2="10.1.0.0">Visibility controller data object index.</add>
+        <add name="Data" type="Ref" template="NiVisData" ver2="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPoint3InterpController" abstract="1" inherit="NiSingleInterpController">
@@ -2978,25 +3013,53 @@
     <niobject name="NiMaterialColorController" abstract="0" inherit="NiPoint3InterpController">
         Time controller for material color. Flags are used for color selection in versions below 10.1.0.0.
         Bits 4-5: Target Color (00 = Ambient, 01 = Diffuse, 10 = Specular, 11 = Emissive)
-        <add name="Target Color" type="TargetColor" ver1="10.1.0.0">Selects which color to control.</add>
-        <add name="Data" type="Ref" template="NiPosData" ver2="10.1.0.0">Material color controller data object index. Points to NiPosData.</add>
+        NiInterpController::GetCtlrID() string formats:
+            ['AMB', 'DIFF', 'SPEC', 'SELF_ILLUM'] (Depending on "Target Color")
+        <add name="Target Color" type="MaterialColor" ver1="10.1.0.0">Selects which color to control.</add>
+        <add name="Data" type="Ref" template="NiPosData" ver2="10.1.0.103" />
     </niobject>
 
-    <niobject name="NiLightColorController" abstract="0" inherit="NiMaterialColorController">
+    <niobject name="NiLightColorController" abstract="0" inherit="NiPoint3InterpController">
         Animates the ambient, diffuse and specular colors of an NiLight.
+        NiInterpController::GetCtlrID() string formats:
+            ['Diffuse', 'Ambient'] (Depending on "Target Color")
+        <add name="Target Color" type="LightColor" ver1="10.1.0.0" />
+        <add name="Data" type="Ref" template="NiPosData" ver2="10.1.0.103" />
     </niobject>
 
 
     <niobject name="NiExtraDataController" abstract="1" inherit="NiSingleInterpController">
         Abstract base class for all extra data controllers.
+        NiInterpController::GetCtlrID() string format:
+            '%s'
+        Where %s = Value of "Extra Data Name"
+        <add name="Extra Data Name" type="string" ver1="10.2.0.0" />
     </niobject>
 
     <niobject name="NiFloatExtraDataController" abstract="0" inherit="NiExtraDataController">
         Animates an NiFloatExtraData object attached to an NiAVObject.
-        <add name="Controller Data" type="string" ver1="10.2.0.0">Refers to a NiFloatExtraData name.</add>
+        NiInterpController::GetCtlrID() string format is same as parent.
         <add name="Num Extra Bytes" type="byte" ver2="10.1.0.0">Number of extra bytes.</add>
         <add name="Unknown Bytes" type="byte" arr1="7" ver2="10.1.0.0">Unknown.</add>
         <add name="Unknown Extra Bytes" type="byte" arr1="Num Extra Bytes" ver2="10.1.0.0">Unknown.</add>
+        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+    </niobject>
+
+    <niobject name="NiFloatsExtraDataController" abstract="0" inherit="NiExtraDataController">
+        Animates an NiFloatsExtraData object attached to an NiAVObject.
+        NiInterpController::GetCtlrID() string format:
+            '%s[%d]'
+        Where %s = Value of "Extra Data Name", %d = Value of "Floats Extra Data Index"
+        <add name="Floats Extra Data Index" type="int" />
+        <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+    </niobject>
+
+    <niobject name="NiFloatsExtraDataPoint3Controller" abstract="0" inherit="NiExtraDataController">
+        Animates an NiFloatsExtraData object attached to an NiAVObject.
+        NiInterpController::GetCtlrID() string format:
+            '%s[%d]'
+        Where %s = Value of "Extra Data Name", %d = Value of "Floats Extra Data Index"
+        <add name="Floats Extra Data Index" type="int" />
     </niobject>
 
     <niobject name="NiBoneLODController" abstract="0" inherit="NiTimeController">
@@ -3445,35 +3508,35 @@
     </niobject>
 
     <niobject name="NiSequence" abstract="0" inherit="NiObject">
-        Root node used in some Empire Earth II .kf files (version 4.2.2.0).
-        <add name="Name" type="string">Name of this object. This is also the name of the action associated with this file. For instance, if the original NIF file is called &quot;demon.nif&quot; and this animation file contains an attack sequence, then the file would be called &quot;demon_attack1.kf&quot; and this field would contain the string &quot;attack1&quot;.</add>
-        <add name="Text Keys Name" type="string" ver2="10.1.0.0">Name of following referenced NiTextKeyExtraData class.</add>
-        <add name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver2="10.1.0.0">Link to NiTextKeyExtraData.</add>
-        <add name="Unknown Int 4" type="int" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Unknown</add>
-        <add name="Unknown Int 5" type="int" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Unknown</add>
-        <add name="Num Controlled Blocks" type="uint">Number of controlled objects.</add>
-        <add name="Array Grow By" type="uint" ver1="10.1.0.106">Unknown.</add>
-        <add name="Controlled Blocks" type="ControllerLink" arr1="Num Controlled Blocks">Refers to controlled objects.</add>
+        Root node in NetImmerse .kf files (until version 10.0).
+        <add name="Name" type="string">The sequence name by which the animation system finds and manages this sequence.</add>
+        <add name="Accum Root Name" type="string" ver2="10.1.0.103">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</add>
+        <add name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver2="10.1.0.103" />
+        <add name="Unknown Int 4" type="int" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Divinity 2</add>
+        <add name="Unknown Int 5" type="int" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Divinity 2</add>
+        <add name="Num Controlled Blocks" type="uint" />
+        <add name="Array Grow By" type="uint" ver1="10.1.0.106" />
+        <add name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" />
     </niobject>
 
     <niobject name="NiControllerSequence" abstract="0" inherit="NiSequence">
-        Root node in .kf files (version 10.0.1.0 and up).
-        <add name="Weight" type="float" default="1.0" ver1="10.1.0.106">Weight/priority of animation?</add>
-        <add name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver1="10.1.0.106">Link to NiTextKeyExtraData. Replaces the other Text Keys field in versions 10.1.0.106 and up.</add>
-        <add name="Cycle Type" type="CycleType" ver1="10.1.0.106">Anim cycle type? Is part of &quot;Flags&quot; in other objects?</add>
-        <add name="Unknown Int 0" type="uint" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
-        <add name="Frequency" type="float" ver1="10.1.0.106">The animation frequency.</add>
-        <add name="Start Time" type="float" ver1="10.1.0.106">The controller sequence start time?</add>
-        <add name="Unknown Float 2" type="float" ver1="10.2.0.0" ver2="10.4.0.1">Unknown.</add>
-        <add name="Stop Time" type="float" ver1="10.1.0.106">The controller sequence stop time?</add>
-        <add name="Unknown Byte" type="byte" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
-        <add name="Manager" type="Ptr" template="NiControllerManager" ver1="10.1.0.106">Refers to NiControllerManager which references this object, if any.</add>
-        <add name="Target Name" type="string" ver1="10.1.0.106">Name of target node Controller acts on.</add>
-        <add name="String Palette" type="Ref" template="NiStringPalette" ver1="10.2.0.0" ver2="20.0.0.5">Refers to NiStringPalette.</add>
-        <add name="Anim Notes" type="Ref" template="BSAnimNotes" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt;= 24) &amp;&amp; (User Version 2 &lt;= 28)">Unknown</add>
-        <add name="Num Anim Note Arrays" type="ushort" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 28)">Number of anim notes objects.</add>
-        <add name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 28)">Indices of anim notes objects.</add>
-        <add name="Unknown Int 3" type="uint" ver1="20.3.0.9" default="64">Unknown, found in some Lazeska and Krazy Rain .KFs (seems to be 64 when present).</add>
+        Root node in Gamebryo .kf files (version 10.0.1.0 and up).
+        <add name="Weight" type="float" default="1.0" ver1="10.1.0.106">The weight of a sequence describes how it blends with other sequences at the same priority.</add>
+        <add name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver1="10.1.0.106" />
+        <add name="Cycle Type" type="CycleType" ver1="10.1.0.106" />
+        <add name="Frequency" type="float" ver1="10.1.0.106" />
+        <add name="Phase" type="float" ver1="10.1.0.106" ver2="10.4.0.1" /> <!-- Actually ver2="10.3.0.1" but WorldShift 10.4.0.1 custom version acts like 10.3.0.1 -->
+        <add name="Start Time" type="float" ver1="10.1.0.106" />
+        <add name="Stop Time" type="float" ver1="10.1.0.106" />
+        <add name="Play Backwards" type="bool" ver1="10.1.0.106" ver2="10.1.0.106" />
+        <add name="Manager" type="Ptr" template="NiControllerManager" ver1="10.1.0.106">The owner of this sequence.</add>
+        <add name="Accum Root Name" type="string" ver1="10.1.0.106">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</add>
+        <add name="Accum Flags" type="AccumFlags" ver1="20.3.0.8" default="ACCUM_X_FRONT" />
+        <add name="String Palette" type="Ref" template="NiStringPalette" ver1="10.1.0.113" ver2="20.1.0.0" />
+        <!-- Bethesda -->
+        <add name="Anim Notes" type="Ref" template="BSAnimNotes" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt;= 24) &amp;&amp; (User Version 2 &lt;= 28)" />
+        <add name="Num Anim Note Arrays" type="ushort" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 28)" />
+        <add name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" ver1="20.2.0.7" vercond="(User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 28)" />
     </niobject>
 
     <niobject name="NiAVObjectPalette" abstract="1" inherit="NiObject">
@@ -5740,10 +5803,8 @@
     </niobject>
 
 
-    <niobject name="BSPSysMultiTargetEmitterCtlr" inherit="NiPSysModifierCtlr">
+    <niobject name="BSPSysMultiTargetEmitterCtlr" inherit="NiPSysEmitterCtlr">
         Particle system (multi?) emitter controller.
-        <add name="Data" type="Ref" template="NiPSysEmitterCtlrData" ver2="10.1.0.0">This controller's data</add>
-        <add name="Visibility Interpolator" type="Ref" template="NiInterpolator" ver1="10.2.0.0">Links to a bool interpolator. Controls emitter&#039;s visibility status?</add>
         <add name="Max Emitters" type="ushort" />
         <add name="Master Particle System" type="Ptr" template="BSMasterParticleSystem" />
     </niobject>

--- a/nif.xml
+++ b/nif.xml
@@ -1491,15 +1491,6 @@
         <add name="TBC" type="TBC" cond="ARG == 3">The TBC of the key.</add>
     </compound>
 
-    <!-- no longer used
-    <compound name="RotationKeyArray" istemplate="1">
-        Rotation key array.
-        <add name="Num Keys" type="uint">Number of keys.</add>
-        <add name="Key Type" type="KeyType" cond="Num Keys != 0">Key type (LINEAR_KEY, QUADRATIC_KEY, TBC_KEY, or XYZ_ROTATION_KEY).</add>
-        <add name="Keys" type="QuatKey" arg="Key Type" template="TEMPLATE" arr1="Num Keys">The rotation keys.</add>
-    </compound>
-    -->
-
     <compound name="TexCoord" niflibtype="TexCoord">
         Texture coordinates (u,v). As in OpenGL; image origin is in the lower left corner.
         <add name="u" type="float">First coordinate.</add>
@@ -1511,6 +1502,12 @@
         <add name="u" type="hfloat">First coordinate.</add>
         <add name="v" type="hfloat">Second coordinate.</add>
     </compound>
+    
+    <enum name="TransformMethod" storage="uint" prefix="TM">
+        <option value="0" name="Maya Deprecated" />
+        <option value="1" name="Max" />
+        <option value="2" name="Maya" />
+    </enum>
 
     <compound name="TexDesc">
         Texture description.
@@ -1528,7 +1525,7 @@
         <add name="Translation" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The amount to translate the texture coordinates in each direction?</add>
         <add name="Tiling" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0" default="1.0, 1.0">The number of times the texture is tiled in each direction?</add>
         <add name="W Rotation" type="float" default="0.0" cond="Has Texture Transform" ver1="10.1.0.0">2D Rotation of texture image around third W axis after U and V.</add>
-        <add name="Transform Type?" type="uint" default="0" cond="Has Texture Transform" ver1="10.1.0.0">The texture transform type?  Doesn&#039;t seem to do anything.</add>
+        <add name="Transform Method" type="TransformMethod" default="0" cond="Has Texture Transform" ver1="10.1.0.0">Depending on the source, scaling can occur before or after rotation.</add>
         <add name="Center Offset" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The offset from the origin?</add>
     </compound>
 
@@ -1539,20 +1536,6 @@
         <add name="Map Index" type="uint" cond="Is Used">Map Index</add>
     </compound>
 
-    <compound name="TexSource">
-        A texture source.
-        <add name="Use External" type="byte">Is the texture external?</add>
-        <add name="File Name" type="FilePath" cond="Use External == 1">
-            The external texture file name.
-
-            Note: all original morrowind nifs use name.ext only for addressing the textures, but most mods use something like textures/[subdir/]name.ext. This is due to a feature in Morrowind resource manager: it loads name.ext, textures/name.ext and textures/subdir/name.ext but NOT subdir/name.ext.
-        </add>
-        <add name="Unknown Link" type="Ref" template="NiObject" cond="Use External == 1" ver1="10.1.0.0">Unknown.</add>
-        <add name="Unknown Byte" type="byte" cond="Use External == 0" ver2="10.0.1.0">Unknown.</add>
-        <add name="File Name" type="FilePath" cond="Use External == 0" ver1="10.1.0.0">The original source filename of the image embedded by the referred NiPixelData object.</add>
-        <add name="Pixel Data" type="Ref" template="NiPixelData" cond="Use External == 0">Pixel data object index.</add>
-    </compound>
-
     <compound name="Triangle" niflibtype="Triangle">
         List of three vertex indices.
         <add name="v1" type="ushort">First vertex index.</add>
@@ -1560,23 +1543,20 @@
         <add name="v3" type="ushort">Third vertex index.</add>
     </compound>
 	
-	<bitflags name="VertexFlags" storage="ushort">
-		<option value="0" name="VF_Unknown_1" />       <!-- & 1 -->
-		<option value="1" name="VF_Unknown_2" />       <!-- & 2 -->
-		<option value="2" name="VF_Unknown_3" />       <!-- & 4 -->
-		<option value="3" name="VF_Unknown_4" />       <!-- & 8 -->
-		<option value="4" name="VF_Vertex" />          <!-- & 16 -->
-		<option value="5" name="VF_UVs" />             <!-- & 32 -->
-		<option value="6" name="VF_Unknown_5" />       <!-- & 64 -->
-		<option value="7" name="VF_Normals" />         <!-- & 128 -->
-		<option value="8" name="VF_Tangents" />        <!-- & 256 -->
-		<option value="9" name="VF_Vertex_Colors" />   <!-- & 512 -->
-		<option value="10" name="VF_Skinned" />        <!-- & 1024 -->
-		<option value="11" name="VF_Unknown_6" />      <!-- & 2048 -->
-		<option value="12" name="VF_Eye_Data" />       <!-- & 4096 -->
-		<option value="13" name="VF_Unknown_7" />      <!-- & 8192 -->
-		<option value="14" name="VF_Full_Precision" /> <!-- & 16384 -->
-		<option value="15" name="VF_Unknown_8" />      <!-- & 32768 -->
+	<bitflags name="VertexFlags" storage="ushort" prefix="VF">
+		<!-- First 4 bits are unused -->
+		<option value="4" name="Vertex" />          <!-- & 16 -->
+		<option value="5" name="UVs" />             <!-- & 32 -->
+		<option value="6" name="UVs_2" />           <!-- & 64 -->
+		<option value="7" name="Normals" />         <!-- & 128 -->
+		<option value="8" name="Tangents" />        <!-- & 256 -->
+		<option value="9" name="Vertex_Colors" />   <!-- & 512 -->
+		<option value="10" name="Skinned" />        <!-- & 1024 -->
+		<option value="11" name="Land_Data" />      <!-- & 2048 -->
+		<option value="12" name="Eye_Data" />       <!-- & 4096 -->
+		<option value="13" name="Instance" />       <!-- & 8192 -->
+		<option value="14" name="Full_Precision" /> <!-- & 16384 -->
+		<!-- Last bit unused -->
 	</bitflags>
     
 	<compound name="BSVertexData" niflibtype="BSVertexData">
@@ -1667,27 +1647,26 @@
         <add name="f5" type="float"></add>
     </compound>-->
 
+    <compound name="NiPlane">
+        A plane.
+        <add name="Normal" type="Vector3">The plane normal.</add>
+        <add name="Constant" type="float">The plane constant.</add>
+    </compound>
+
     <compound name="NiBound">
         A sphere.
         <add name="Center" type="Vector3">The sphere's center.</add>
         <add name="Radius" type="float">The sphere's radius.</add>
     </compound>
 
-    <compound name="QTransform">
-        <add name="Translation" type="Vector3">Translation.</add>
-        <add name="Rotation" type="Quaternion">Rotation.</add>
-        <add name="Scale" type="float" default="1.0">Scale.</add>
+    <compound name="NiQuatTransform">
+        <add name="Translation" type="Vector3" />
+        <add name="Rotation" type="Quaternion" />
+        <add name="Scale" type="float" default="1.0" />
+        <add name="TRS Valid" type="bool" arr1="3" ver2="10.1.0.109">Whether each transform component is valid.</add>
     </compound>
 
-    <compound name="MTransform">
-        <add name="Translation" type="Vector3">Translation.</add>
-        <add name="Rotation" type="Matrix33">Rotation.</add>
-        <add name="Scale" type="float" default="1.0">Scale.</add>
-    </compound>
-
-    <!-- SkinTransform is like MTansform, but rotation comes first; used in skinning -->
-    <!-- TODO unify all transform types via a general purpose template type? -->
-    <compound name="SkinTransform">
+    <compound name="NiTransform">
         <add name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</add>
         <add name="Translation" type="Vector3">The translation vector.</add>
         <add name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</add>
@@ -1759,7 +1738,7 @@
 
     <compound name="SkinData">
         Skinning data component.
-        <add name="Skin Transform" type="SkinTransform">Offset of the skin from this bone in bind position.</add>
+        <add name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</add>
         <add name="Bounding Sphere Offset" type="Vector3">Translation offset of a bounding sphere holding all vertices. (Note that its a Sphere Containing Axis Aligned Box not a minimum volume Sphere)</add>
         <add name="Bounding Sphere Radius" type="float">Radius for bounding sphere holding all vertices.</add>
         <add name="Unknown 13 Shorts" type="short" arr1="13" ver1="20.3.0.9" ver2="20.3.0.9" userver="131072">Unknown, always 0?</add>
@@ -2039,9 +2018,8 @@
     </compound>
 
     <compound name="HalfSpaceBV">
-        <add name="Normal" type="Vector3">Normal</add>
-        <add name="Center" type="Vector3">Center</add>
-        <add name="Unknown Float 1" type="float">Unknown.</add>
+        <add name="Plane" type="NiPlane" />
+        <add name="Center" type="Vector3" />
     </compound>
 
     <compound name="BoundingVolume">
@@ -2600,11 +2578,7 @@
 
     <niobject name="NiTransformInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         An interpolator for transform keyframes.
-        <!-- TODO use QTransform -->
-        <add name="Translation" type="Vector3">Translate.</add>
-        <add name="Rotation" type="Quaternion">Rotation.</add>
-        <add name="Scale" type="float">Scale.</add>
-        <add name="Unknown Bytes" type="byte" arr1="3" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
+        <add name="Transform" type="NiQuatTransform" />
         <add name="Data" type="Ref" template="NiTransformData">Refers to NiTransformData.</add>
     </niobject>
 
@@ -2614,15 +2588,15 @@
         <add name="Data" type="Ref" template="NiPosData">Reference to NiPosData.</add>
     </niobject>
 
-    <enum name="PathFlags" storage="ushort">
-        <option value="0x1" name="NIPI_CVDataNeedsUpdate">CVDataNeedsUpdate</option>
-        <option value="0x2" name="NIPI_CurveTypeOpen">CurveTypeOpen</option>
-        <option value="0x4" name="NIPI_AllowFlip">AllowFlip</option>
-        <option value="0x8" name="NIPI_Bank">Bank</option>
-        <option value="0x10" name="NIPI_ConstantVelocity">ConstantVelocity</option>
-        <option value="0x20" name="NIPI_Follow">Follow</option>
-        <option value="0x40" name="NIPI_Flip">Flip</option>
-    </enum>
+    <bitflags name="PathFlags" storage="ushort" prefix="NIPI">
+        <option value="0" name="CVDataNeedsUpdate" />
+        <option value="1" name="CurveTypeOpen" />
+        <option value="2" name="AllowFlip" />
+        <option value="3" name="Bank" />
+        <option value="4" name="ConstantVelocity" />
+        <option value="5" name="Follow" />
+        <option value="6" name="Flip" />
+    </bitflags>
 
     <niobject name="NiPathInterpolator" abstract="0" inherit="NiKeyBasedInterpolator">
         Used to make an object follow a predefined spline path.
@@ -2760,7 +2734,6 @@
         Abstract audio-visual base class from which all of Gamebryo's scene graph objects inherit.
         <add name="Flags" type="uint" default="14" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26)">Basic flags for AV objects.</add>
         <add name="Flags" type="Flags" ver1="3.0" vercond="!((Version == 20.2.0.7) &amp;&amp; (User Version &gt;= 11) &amp;&amp; (User Version 2 &gt; 26))">Basic flags for AV objects; commonly 0x000C or 0x000A.</add>
-        <!-- TODO use MTransform -->
         <add name="Translation" type="Vector3">The translation vector.</add>
         <add name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</add>
         <add name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</add>
@@ -3606,33 +3579,28 @@
         <add name="Scales" type="KeyGroup" template="float">Scale keys.</add>
     </niobject>
 
-    <enum name="LookAtFlags" storage="ushort">
-        Should be a bitfield for flip toggle.
-        <option value="0" name="LOOK_X_AXIS">X-Axis</option>
-        <option value="1" name="LOOK_FLIP">Flip</option>
-        <option value="2" name="LOOK_Y_AXIS">Y-Axis</option>
-        <option value="4" name="LOOK_Z_AXIS">Z-Axis</option>
-    </enum>
+    <bitflags name="LookAtFlags" storage="ushort">
+        <option value="0" name="LOOK_FLIP">Flip</option>
+        <option value="1" name="LOOK_Y_AXIS">Y-Axis</option>
+        <option value="2" name="LOOK_Z_AXIS">Z-Axis</option>
+    </bitflags>
 
     <niobject name="NiLookAtController" abstract="0" inherit="NiTimeController">
         DEPRECATED (10.2), REMOVED (20.5)
         Replaced by NiTransformController and NiLookAtInterpolator.
-        <add name="Unknown1" type="ushort" ver1="10.1.0.0">Unknown.</add>
-        <add name="Look At Node" type="Ptr" template="NiNode">Link to the node to look at?</add>
+        <add name="Flags" type="LookAtFlags" ver1="10.1.0.0" />
+        <add name="Look At" type="Ptr" template="NiNode" />
     </niobject>
 
     <niobject name="NiLookAtInterpolator" abstract="0" inherit="NiInterpolator">
         NiLookAtInterpolator rotates an object so that it always faces a target object.
         <add name="Flags" type="LookAtFlags" />
-        <add name="Look At" type="Ptr" template="NiNode">Refers to a Node to focus on.</add>
-        <add name="Look At Name" type="string">Target node name.</add>
-        <!-- TODO use QTransform -->
-        <add name="Translation" type="Vector3" ver2="20.5.0.0">Translate.</add>
-        <add name="Rotation" type="Quaternion" ver2="20.5.0.0">Rotation.</add>
-        <add name="Scale" type="float" ver2="20.5.0.0">Scale.</add>
-        <add name="Interpolator: Translation" type="Ref" template="NiPoint3Interpolator">Refers to NiPoint3Interpolator.</add>
-        <add name="Interpolator: Roll" type="Ref" template="NiFloatInterpolator">Refers to a NiFloatInterpolator.</add>
-        <add name="Interpolator: Scale" type="Ref" template="NiFloatInterpolator">Refers to a NiFloatInterpolator.</add>
+        <add name="Look At" type="Ptr" template="NiNode" />
+        <add name="Look At Name" type="string" />
+        <add name="Transform" type="NiQuatTransform" ver2="20.5.0.0" />
+        <add name="Interpolator: Translation" type="Ref" template="NiPoint3Interpolator" />
+        <add name="Interpolator: Roll" type="Ref" template="NiFloatInterpolator" />
+        <add name="Interpolator: Scale" type="Ref" template="NiFloatInterpolator" />
     </niobject>
 
     <niobject name="NiMaterialProperty" abstract="0" inherit="NiProperty">
@@ -4332,7 +4300,7 @@
 
     <niobject name="NiSkinData" abstract="0" inherit="NiObject">
         Skinning data.
-        <add name="Skin Transform" type="SkinTransform">Offset of the skin from this bone in bind position.</add>
+        <add name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</add>
         <add name="Num Bones" type="uint">Number of bones.</add>
         <add name="Skin Partition" type="Ref" template="NiSkinPartition" ver1="4.0.0.2" ver2="10.1.0.0">This optionally links a NiSkinPartition for hardware-acceleration information.</add>
         <add name="Has Vertex Weights" type="byte" ver1="4.2.1.0" default="1">Enables Vertex Weights for this NiSkinData.</add>
@@ -4480,11 +4448,10 @@
         <add name="Coordinate Generation Type" default="CG_SPHERE_MAP" type="CoordGenType">The method that will be used to generate UV coordinates for the texture effect.</add>
         <add name="Image" type="Ref" template="NiImage" ver2="3.1">Image index.</add>
         <add name="Source Texture" type="Ref" template="NiSourceTexture" ver1="4.0.0.0">Source texture index.</add>
-        <add name="Clipping Plane" default="0" type="byte">Determines whether a clipping plane is used.  0 means that a plane is not used.</add>
-        <add name="Unknown Vector" type="Vector3" default="1.0, 0.0, 0.0">Unknown: (1,0,0)?</add>
-        <add name="Unknown Float" type="float">Unknown. 0?</add>
-        <add name="PS2 L" type="short" default="0" ver2="10.2.0.0">0?</add>
-        <add name="PS2 K" type="short" default="-75" ver2="10.2.0.0">-75?</add>
+        <add name="Enable Plane" default="0" type="byte">Determines whether a clipping plane is used.</add> <!-- Not bool as always 8-bit -->
+        <add name="Plane" type="NiPlane" />
+        <add name="PS2 L" type="short" default="0" ver2="10.2.0.0" />
+        <add name="PS2 K" type="short" default="-75" ver2="10.2.0.0" />
         <add name="Unknown Short" type="ushort" ver2="4.1.0.12">Unknown: 0.</add>
     </niobject>
 
@@ -4598,16 +4565,6 @@
         <add name="Child 3" type="Ref" template="NiObject">unknown</add>
     </niobject>
 
-    <!--
-    <niobject name="NiEnvMappedTriShapeData" abstract="0" inherit="NiTriBasedGeomData">
-        Holds mesh data using a list of singular triangles.
-        <add name="Num Triangle Points" type="uint">Num Triangles times 3.</add>
-        <add name="Has Triangles" type="bool">Do we have triangle data?</add>
-        <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Has Triangles != 0">Triangle face data.</add>
-        <add name="Num Match Groups" type="ushort">Number of shared normals groups.</add>
-        <add name="Match Groups" type="MatchGroup" arr1="Num Match Groups">The shared normals.</add>
-    </niobject>
-    -->
     <niobject name="NiEnvMappedTriShapeData" abstract="0" inherit="NiTriShapeData">
         Holds mesh data using a list of singular triangles.
     </niobject>
@@ -5167,14 +5124,14 @@
 
     <niobject name="NiRoom" inherit="NiNode">
         NiRoom objects represent cells in a cell-portal culling system.
-        <add name="Num Walls" type="int">Number of walls in a room?</add>
-        <add name="Wall Plane" type="Vector4" arr1="Num Walls">Face normal and unknown value.</add>
-        <add name="Num In Portals" type="int">Number of doors into room</add>
-        <add name="In Portals" type="Ptr" template="NiPortal" arr1="Num In Portals">Number of portals into room</add>
-        <add name="Num Portals 2" type="int">Number of doors out of room</add>
-        <add name="Portals 2" type="Ptr" template="NiPortal" arr1="Num Portals 2">Number of portals out of room</add>
-        <add name="Num Items" type="int">Number of unknowns</add>
-        <add name="Items" type="Ptr" template="NiAVObject" arr1="Num Items">All geometry associated with room.</add>
+        <add name="Num Walls" type="int" />
+        <add name="Wall Planes" type="NiPlane" arr1="Num Walls" />
+        <add name="Num In Portals" type="uint" />
+        <add name="In Portals" type="Ptr" template="NiPortal" arr1="Num In Portals">The portals which see into the room.</add>
+        <add name="Num Out Portals" type="uint" />
+        <add name="Out Portals" type="Ptr" template="NiPortal" arr1="Num Out Portals">The portals which see out of the room.</add>
+        <add name="Num Fixtures" type="uint" />
+        <add name="Fixtures" type="Ptr" template="NiAVObject" arr1="Num Fixtures">All geometry associated with the room.</add>
     </niobject>
 
     <niobject name="NiPortal" inherit="NiAVObject">
@@ -5841,19 +5798,11 @@
         <add name="Unknown Float 2" type="float" />
     </niobject>
 
-    <compound name="BSTreadTransformData">
-        Bethesda-specific node.
-        <!-- TODO use QTransform -->
-        <add name="Translation" type="Vector3">Translation.</add>
-        <add name="Rotation" type="Quaternion">Rotation.</add>
-        <add name="Scale" type="float">Scale (usually float_min).</add>
-    </compound>
-
     <compound name="BSTreadTransform">
         Bethesda-specific compound.
-        <add name="Name" type="string">Name of affected node?</add>
-        <add name="Transform 1" type="BSTreadTransformData">Transform data.</add>
-        <add name="Transform 2" type="BSTreadTransformData">Transform data.</add>
+        <add name="Name" type="string" />
+        <add name="Transform 1" type="NiQuatTransform" />
+        <add name="Transform 2" type="NiQuatTransform" />
     </compound>
 
     <niobject name="BSTreadTransfInterpolator" abstract="0" inherit="NiInterpolator">
@@ -6348,10 +6297,10 @@
             RECOMPUTE_BOUNDS = 0x0002
         </add>
         <add name="Skeleton Root" type="Ptr" template="NiAVObject">The root bone of the skeleton.</add><!-- Root Bone Parent -->
-        <add name="Skeleton Transform" type="SkinTransform">The transform that takes the root bone parent coordinate system into the skin coordinate system.</add><!-- Root Bone Parent To Skin Transform -->
+        <add name="Skeleton Transform" type="NiTransform">The transform that takes the root bone parent coordinate system into the skin coordinate system.</add><!-- Root Bone Parent To Skin Transform -->
         <add name="Num Bones" type="uint">The number of bones referenced by this mesh modifier.</add>
         <add name="Bones" type="Ptr" template="NiAVObject" arr1="Num Bones">Pointers to the bone nodes that affect this skin.</add>
-        <add name="Bone Transforms" type="SkinTransform" arr1="Num Bones">The transforms that go from bind-pose space to bone space.</add><!-- Skin To Bone Transforms -->
+        <add name="Bone Transforms" type="NiTransform" arr1="Num Bones">The transforms that go from bind-pose space to bone space.</add><!-- Skin To Bone Transforms -->
         <add name="Bone Bounds" type="NiBound" cond="(Flags &amp; 2)!=0" arr1="Num Bones">The bounds of the bones.  Only stored if the RECOMPUTE_BOUNDS bit is set.</add>
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -4404,7 +4404,7 @@
 		<add name="Data Size" type="uint" ver="20.2.0.7" userver2="100" />
 		<add name="Vertex Size" type="uint" ver="20.2.0.7" userver2="100" />
 		<add name="Vertex Desc" type="BSVertexDesc" ver="20.2.0.7" userver2="100" />
-		<add name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc" arr1="Data Size / Vertex Size" cond="Data Size &gt; 0" ver="20.2.0.7" userver2="100" />
+		<add name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc\Vertex Attributes" arr1="Data Size / Vertex Size" cond="Data Size &gt; 0" ver="20.2.0.7" userver2="100" />
 		<add name="Partition" type="SkinPartition" arr1="Num Skin Partition Blocks" ver="20.2.0.7" userver2="100" />
     </niobject>
 
@@ -7099,8 +7099,8 @@
         <add name="Num Triangles" type="ushort" vercond="User Version 2 &lt; 130" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Desc" cond="Data Size &gt; 0" userver2="130" />
-        <add name="Vertex Data" type="BSVertexDataSSE" arr1="Num Vertices" arg="Vertex Desc" cond="Data Size &gt; 0" userver2="100" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Desc\Vertex Attributes" cond="Data Size &gt; 0" userver2="130" />
+        <add name="Vertex Data" type="BSVertexDataSSE" arr1="Num Vertices" arg="Vertex Desc\Vertex Attributes" cond="Data Size &gt; 0" userver2="100" />
         <add name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size &gt; 0" />
         <add name="Particle Data Size" type="uint" userver2="100" />
         <add name="Vertices" type="Vector3" arr1="Num Vertices" cond="Particle Data Size &gt; 0" userver2="100" />
@@ -7254,7 +7254,7 @@
         <add name="Num Combined" type="uint" />
         <add name="Combined" type="BSPackedGeomDataCombined" arr1="Num Combined" />
         <add name="Vertex Desc" type="BSVertexDesc" />
-        <add name="Vertex Data" type="BSVertexData" arr1="Num Verts" arg="Vertex Desc" cond="!BSPackedCombinedSharedGeomDataExtra" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Verts" arg="Vertex Desc\Vertex Attributes" cond="!BSPackedCombinedSharedGeomDataExtra" />
         <add name="Triangles" type="Triangle" arr1="Tri Count LOD0 + Tri Count LOD1 + Tri Count LOD2" cond="!BSPackedCombinedSharedGeomDataExtra" />
     </compound>
 	

--- a/nif.xml
+++ b/nif.xml
@@ -43,7 +43,7 @@
     <version num="20.6.5.0">Epic Mickey</version>
     <version num="30.0.0.2">Emerge</version>
     <version num="30.1.0.3">Rocksmith, Rocksmith 2014</version>
-    <version num="30.2.0.3"></version>
+    <version num="30.2.0.3">Ghost In The Shell: First Assault, MapleStory 2</version>
 
     <!--Basic Types-->
 
@@ -3943,7 +3943,7 @@
         but actually a member class loaded at the top of each. The two classes are not related.
         However, faking this inheritance is useful for several things.    
     -->
-    <niobject name="NiPixelFormat" abstract="1" inherits="NiObject">
+    <niobject name="NiPixelFormat" abstract="1" inherit="NiObject">
         <add name="Pixel Format" type="PixelFormat">The format of the pixels in this internally stored image.</add>
         <add name="Red Mask" type="uint" ver2="10.3.0.2">0x000000ff (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>
         <add name="Green Mask" type="uint" ver2="10.3.0.2">0x0000ff00 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</add>

--- a/nif.xml
+++ b/nif.xml
@@ -6976,8 +6976,8 @@
         <add name="VF5" type="byte" />
         <add name="VF" type="VertexFlags" />
         <add name="VF8" type="byte" />
-        <add name="Num Triangles" suffix="FO4" type="uint" userver2="130" />
-        <add name="Num Triangles" suffix="SSE" type="ushort" vercond="User Version 2 &lt; 130" />
+        <add name="Num Triangles" type="uint" userver2="130" />
+        <add name="Num Triangles" type="ushort" vercond="User Version 2 &lt; 130" />
         <add name="Num Vertices" type="ushort" />
         <add name="Data Size" type="uint" />
         <add name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="VF" cond="Data Size &gt; 0" userver2="130" />

--- a/nif.xml
+++ b/nif.xml
@@ -3151,7 +3151,7 @@
            "Num Vertices" is renamed to "BS Max Vertices" for Bethesda 20.2 because Vertices, Normals, Tangents, Colors, and UV arrays
            do not have length for NiPSysData regardless of "Num" or booleans.
         -->
-        <add name="Unknown Int" type="int" ver1="10.2.0.0">Unknown identifier. Always 0.</add>
+        <add name="Group ID" type="int" ver1="10.1.0.114">Always zero.</add>
         <add name="Num Vertices" type="ushort" cond="!NiPSysData">Number of vertices.</add>
         <add name="Num Vertices" type="ushort" cond="NiPSysData" vercond="(User Version 2 &lt; 34)">Number of vertices.</add>
         <add name="BS Max Vertices" type="ushort" cond="NiPSysData" vercond="(User Version 2 &gt;= 34)">Bethesda uses this for max number of particles in NiPSysData.</add>
@@ -6268,7 +6268,7 @@
         <option value="0x8070" name="SYNC_REFLECTIONS">Synchronize after all data necessary to calculate reflections is ready.</option>
     </enum>
 
-    <niobject name="NiMeshModifier" inherit="NiObject">
+    <niobject name="NiMeshModifier" abstract="1" inherit="NiObject">
         Base class for mesh modifiers.
         <add name="Num Submit Points" type="uint" />
         <add name="Submit Points" type="SyncPoint" arr1="Num Submit Points">The sync points supported by this mesh modifier for SubmitTasks.</add>
@@ -7064,9 +7064,9 @@
 
 	<niobject name="BSLODTriShape" inherit="NiTriBasedGeom">
 		A variation on NiTriShape, for visibility control over vertex groups.
-		<add name="Level 0 Size" type="uint" />
-		<add name="Level 1 Size" type="uint" />
-		<add name="Level 2 Size" type="uint" />
+		<add name="LOD0 Size" type="uint" />
+		<add name="LOD1 Size" type="uint" />
+		<add name="LOD2 Size" type="uint" />
 	</niobject>
 
 	<niobject name="BSFurnitureMarkerNode" inherit="BSFurnitureMarker">

--- a/nif.xml
+++ b/nif.xml
@@ -686,13 +686,23 @@
 
     <enum name="PixelLayout" storage="uint" prefix="PX">
         An unsigned 32-bit integer, describing the color depth of a texture.
-        <option value="0" name="LAY_PALETTISED">Texture is in 8-bit paletized format.</option>
+        <option value="0" name="LAY_PALETTIZED_8">Texture is in 8-bit palettized format.</option>
         <option value="1" name="LAY_HIGH_COLOR_16">Texture is in 16-bit high color format.</option>
         <option value="2" name="LAY_TRUE_COLOR_32">Texture is in 32-bit true color format.</option>
         <option value="3" name="LAY_COMPRESSED">Texture is compressed.</option>
         <option value="4" name="LAY_BUMPMAP">Texture is a grayscale bump map.</option>
-        <option value="5" name="LAY_PALETTISED_4">Texture is in 4-bit paletized format.</option>
+        <option value="5" name="LAY_PALETTIZED_4">Texture is in 4-bit palettized format.</option>
         <option value="6" name="LAY_DEFAULT">Use default setting.</option>
+        <option value="7" name="LAY_SINGLE_COLOR_8" />
+        <option value="8" name="LAY_SINGLE_COLOR_16" />
+        <option value="9" name="LAY_SINGLE_COLOR_32" />
+        <option value="10" name="LAY_DOUBLE_COLOR_32" />
+        <option value="11" name="LAY_DOUBLE_COLOR_64" />
+        <option value="12" name="LAY_FLOAT_COLOR_32" />
+        <option value="13" name="LAY_FLOAT_COLOR_64" />
+        <option value="14" name="LAY_FLOAT_COLOR_128" />
+        <option value="15" name="LAY_SINGLE_COLOR_4" />
+        <option value="16" name="LAY_DEPTH_24_X8" />
     </enum>
 
     <enum name="TexClampMode" storage="uint">

--- a/nif.xml
+++ b/nif.xml
@@ -5772,7 +5772,7 @@
         <add name="Restitution" type="float" default="0.8" />
         <add name="Friction" type="float" default="0.3" />
         <add name="Radius" type="float" default="1.0" />
-        <add name="Material" type="HavokMaterial" default="7" />
+        <add name="Material" type="HavokMaterial" />
         <add name="Num Constraints" type="uint" />
         <add name="Constraint" type="ConstraintData" arr1="Num Constraints" />
     </niobject>
@@ -6735,7 +6735,7 @@
         <add name="Skeleton Root" type="Ptr" template="NiAVObject" />
         <add name="Data" type="Ref" template="BSSkin::BoneData" />
         <add name="Num Bones" type="uint" />
-        <add name="Bones" type="Ptr" arr1="Num Bones" />
+        <add name="Bones" type="Ptr" template="NiNode" arr1="Num Bones" />
         <add name="Num Unknown" type="uint" />
         <add name="Unknown" type="Vector3" arr1="Num Unknown" />
     </niobject>

--- a/nif.xml
+++ b/nif.xml
@@ -2007,14 +2007,10 @@
 
     <compound name="CapsuleBV">
         Capsule Bounding Volume
-        <add name="Center" type="Vector3">Center</add>
-        <add name="Origin" type="Vector3">Origin</add>
-        <!--<add name="Direction" type="Vector3">Direction</add>
-      <add name="Radius" type="float">Radius</add>-->
-        <!-- direction and radius seem not present in ffvt3r 10.1.0.0 nifs 
-      instead, there's two floats -->
-        <add name="Unknown Float 1" type="float">Unknown.</add>
-        <add name="Unknown Float 2" type="float">Unknown.</add>
+        <add name="Center" type="Vector3" />
+        <add name="Origin" type="Vector3" />
+        <add name="Extent" type="float" />
+        <add name="Radius" type="float" />
     </compound>
 
     <compound name="HalfSpaceBV">
@@ -2838,7 +2834,7 @@
         <add name="Extra Flags" type="Flags" ver1="10.0.1.2">Unknown.</add>
         <add name="Unknown 2" type="byte" ver1="10.1.0.106" ver2="10.1.0.106">Unknown.</add>
         <add name="Data" type="Ref" template="NiMorphData">Geometry morphing data index.</add>
-        <add name="Always Update" type="byte">Always Update</add>
+        <add name="Always Update" type="byte" ver1="4.0.0.1" />
         <add name="Num Interpolators" type="uint" ver1="10.1.0.106">The number of interpolator objects.</add>
         <add name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" ver1="10.1.0.106" ver2="20.0.0.5">List of interpolators.</add>
         <add name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" ver1="20.1.0.3">Weighted Interpolators?</add>
@@ -2928,8 +2924,8 @@
         Changes the image a Map (TexDesc) will use. Uses a float interpolator to animate the texture index.
         Often used for performing flipbook animation.
         <add name="Texture Slot" type="TexType">Target texture slot (0=base, 4=glow).</add>
-        <add name="Unknown Int 2" type="uint" ver1="4.0.0.0" ver2="10.1.0.0">0?</add>
-        <add name="Delta" type="float" ver2="10.1.0.0">
+        <add name="Start Time" type="float" ver1="3.3.0.13" ver2="10.1.0.103" />
+        <add name="Delta" type="float" ver2="10.1.0.103">
             Time between two flips.
             delta = (start_time - stop_time) / sources.num_indices
         </add>
@@ -2945,7 +2941,7 @@
 
     <niobject name="NiTextureTransformController" abstract="0" inherit="NiFloatInterpController">
         Texture transformation controller. The target texture slot should have "Has Texture Transform" enabled.
-        <add name="Unknown2" type="byte">Unknown.</add>
+        <add name="Shader Map" type="bool">Is the target map a shader map?</add>
         <add name="Texture Slot" type="TexType"> The target texture slot.</add>
         <add name="Operation" type="TexTransform">Determines how this controller animates the UV Coordinates.</add>
         <add name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.0">Link to NiFloatData.</add>
@@ -3033,7 +3029,7 @@
         <add name="Unknown Integer" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Unknown value, usually -1. (Not a link)</add>
         <add name="Unknown Byte" type="byte" default="255" userver="1">Cyanide extension (only in version 10.2.0.0?).</add>
         <add name="Unknown Integer 2" type="int" ver1="10.4.0.1" ver2="10.4.0.1">Unknown.</add>
-        <add name="Dirty Flag" type="bool" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt; 100)">Dirty Flag?</add>
+        <add name="Dirty Flag" type="bool" vercond="(Version &gt;= 20.2.0.7) &amp;&amp; (User Version 2 &lt; 100)">Dirty Flag?</add>
         <add name="Dirty Flag" type="bool" cond="NiTriBasedGeom" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 == 100)">Dirty Flag?</add>
         <add name="Unknown Integer 3" type="int" cond="NiParticleSystem" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt;= 100)">Dirty Flag?</add>
         <add name="BS Properties" type="Ref" template="NiProperty" arr1="2" ver1="20.2.0.7" userver="12">Two property links, used by Bethesda.</add>
@@ -3258,7 +3254,7 @@
         <add name="Unknown Int 1" type="int">Unknown.</add>
     </compound>
 
-    <niobject name="NiPSysData" abstract="0" inherit="NiRotatingParticlesData">
+    <niobject name="NiPSysData" abstract="0" inherit="NiParticlesData">
         Particle system data.
         <add name="Particle Descriptions" type="ParticleDesc" arr1="Num Vertices" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Unknown.</add>
         <add name="Has Unknown Floats 3" type="bool" ver1="20.0.0.4" vercond="!((Version >= 20.2.0.7) &amp;&amp; (User Version >= 11))">Unknown.</add>
@@ -3526,7 +3522,7 @@
 
     <niobject name="NiGravity" abstract="0" inherit="NiParticleModifier">
         LEGACY (pre-10.1) particle modifier. Applies a gravitational field on the particles.
-        <add name="Unknown Float 1" type="float" ver1="4.0.0.2">Unknown.</add>
+        <add name="Unknown Float 1" type="float" ver1="3.3.0.13">Unknown.</add>
         <add name="Force" type="float">The strength/force of this gravity.</add>
         <add name="Type" type="FieldType">The force field&#039;s type.</add>
         <add name="Position" type="Vector3">The position of the mass point relative to the particle system. (TODO: check for versions &lt;= 3.1)</add>
@@ -3573,7 +3569,7 @@
         <add name="Num Rotation Keys" type="uint">The number of quaternion rotation keys. If the rotation type is XYZ (type 4) then this *must* be set to 1, and in this case the actual number of keys is stored in the XYZ Rotations field.</add>
         <add name="Rotation Type" type="KeyType" cond="Num Rotation Keys != 0">The type of interpolation to use for rotation.  Can also be 4 to indicate that separate X, Y, and Z values are used for the rotation instead of Quaternions.</add>
         <add name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" arr1="Num Rotation Keys" cond="Rotation Type != 4">The rotation keys if Quaternion rotation is used.</add>
-        <add name="Unknown Float" type="float" cond="Rotation Type == 4" ver2="10.1.0.0">Possibly a vestigial time value?  Doesn&#039;t appear to be significant.</add>
+        <add name="Order" type="float" cond="Rotation Type == 4" ver2="10.1.0.0" />
         <add name="XYZ Rotations" type="KeyGroup" template="float" arr1="3" cond="Rotation Type == 4">Individual arrays of keys for rotating X, Y, and Z individually.</add>
         <add name="Translations" type="KeyGroup" template="Vector3">Translation keys.</add>
         <add name="Scales" type="KeyGroup" template="float">Scale keys.</add>
@@ -3714,9 +3710,10 @@
 
     <niobject name="NiPalette" abstract="0" inherit="NiObject">
         NiPalette objects represent mappings from 8-bit indices to 24-bit RGB or 32-bit RGBA colors.
-        <add name="Unknown Byte" type="byte">Unknown, Usually = 0.</add>
-        <add name="Num Entries" type="uint" default="256">The number of palette entries.  Always = 256.</add>
-        <add name="Palette" type="ByteColor4" arr1="256">The color palette.</add>
+        <add name="Has Alpha" type="byte" /> <!-- Not bool as always 8-bit -->
+        <add name="Num Entries" type="uint" default="256">The number of palette entries. Always 256 but can also be 16.</add>
+        <add name="Palette" type="ByteColor4" arr1="16" cond="Num Entries == 16">The color palette.</add>
+        <add name="Palette" type="ByteColor4" arr1="256" cond="Num Entries != 16">The color palette.</add>
     </niobject>
 
     <niobject name="NiParticleBomb" abstract="0" inherit="NiParticleModifier">
@@ -3849,13 +3846,13 @@
     <niobject name="NiPathController" abstract="0" inherit="NiTimeController">
         DEPRECATED (10.2), REMOVED (20.5). Replaced by NiTransformController and NiPathInterpolator.
         Time controller for a path.
-        <add name="Unknown Short 2" type="ushort" ver1="10.1.0.0">Unknown.</add>
-        <add name="Unknown Int 1" type="uint">Unknown, always 1?</add>
-        <add name="Unknown Float 2" type="float">Unknown, often 0?</add>
-        <add name="Unknown Float 3" type="float">Unknown, often 0?</add>
-        <add name="Unknown Short" type="ushort">Unknown, always 0?</add>
-        <add name="Pos Data" type="Ref" template="NiPosData">Path controller data index (position data). ?</add>
-        <add name="Float Data" type="Ref" template="NiFloatData">Path controller data index (float data). ?</add>
+        <add name="Path Flags" type="PathFlags" ver1="10.1.0.0" />
+        <add name="Bank Dir" type="int">-1 = Negative, 1 = Positive</add>
+        <add name="Max Bank Angle" type="float">Max angle in radians.</add>
+        <add name="Smoothing" type="float" />
+        <add name="Follow Axis" type="short">0, 1, or 2 representing X, Y, or Z.</add>
+        <add name="Path Data" type="Ref" template="NiPosData" />
+        <add name="Percent Data" type="Ref" template="NiFloatData" />
     </niobject>
 
     <compound name="PixelFormatComponent">
@@ -4227,12 +4224,12 @@
     <niobject name="NiPSysAirFieldModifier" inherit="NiPSysFieldModifier">
         Particle system modifier, updates the particle velocity to simulate the effects of air movements like wind, fans, or wake.
         <add name="Direction" type="Vector3">Direction of the particle velocity</add>
-        <add name="Unknown Float 2" type="float">Unknown</add>
-        <add name="Unknown Float 3" type="float">Unknown</add>
-        <add name="Unknown Boolean 1" type="bool">Unknown</add>
-        <add name="Unknown Boolean 2" type="bool">Unknown</add>
-        <add name="Unknown Boolean 3" type="bool">Unknown</add>
-        <add name="Unknown Float 4" type="float">Unknown</add>
+        <add name="Air Friction" type="float">How quickly particles will accelerate to the magnitude of the air field.</add>
+        <add name="Inherit Velocity" type="float">How much of the air field velocity will be added to the particle velocity.</add>
+        <add name="Inherit Rotation" type="bool" />
+        <add name="Component Only" type="bool" />
+        <add name="Enable Spread" type="bool" />
+        <add name="Spread" type="float">The angle of the air field cone if Enable Spread is true.</add>
     </niobject>
     
     <niobject name="NiPSysTrailEmitter" abstract="0" inherit="NiPSysEmitter">
@@ -4272,12 +4269,10 @@
 
     <niobject name="NiScreenLODData" abstract="0" inherit="NiLODData">
         NiScreenLODData controls switching LOD levels based on proportion of the screen that a bound would include.
-        <add name="Bound Center" type="Vector3">The center of the bounding sphere?</add>
-        <add name="Bound Radius" type="float">The radius of the bounding sphere?</add>
-        <add name="World Center" type="Vector3">The center of the bounding sphere in world space?</add>
-        <add name="World Radius" type="float">The radius of the bounding sphere in world space?</add>
-        <add name="Proportion Count" type="uint">The number of screen size based LOD levels.</add>
-        <add name="Proportion Levels" type="float" arr1="Proportion Count">The LOD levels based on proportion of screen size?</add>
+        <add name="Bound" type="NiBound" />
+        <add name="World Bound" type="NiBound" />
+        <add name="Num Proportions" type="uint" />
+        <add name="Proportion Levels" type="float" arr1="Num Proportions" />
     </niobject>
 
     <niobject name="NiRotatingParticles" abstract="0" inherit="NiParticles">
@@ -4383,8 +4378,8 @@
 
     <niobject name="NiSpotLight" abstract="0" inherit="NiPointLight">
         A spot.
-        <add name="Cutoff Angle" type="float">The opening angle of the spot.</add>
-        <add name="Unknown Float" type="float" ver1="20.2.0.7">Unknown</add>
+        <add name="Outer Spot Angle" type="float" />
+        <add name="Inner Spot Angle" type="float" ver1="20.2.0.5" />
         <add name="Exponent" type="float">Describes the distribution of light. (see: glLight)</add>
     </niobject>
 
@@ -4442,8 +4437,8 @@
         <add name="Model Projection Matrix" type="Matrix33">Model projection matrix.  Always identity?</add>
         <add name="Model Projection Transform" type="Vector3">Model projection transform.  Always (0,0,0)?</add>
         <add name="Texture Filtering" type="TexFilterMode" default="FILTER_TRILERP">Texture Filtering mode.</add>
+        <add name="Max Anisotropy" type="ushort" ver1="20.5.0.4" />
         <add name="Texture Clamping" type="TexClampMode" default="WRAP_S_WRAP_T">Texture Clamp mode.</add>
-        <add name="Unknown" type="short" ver1="20.6.0.0" />
         <add name="Texture Type" default="EFFECT_ENVIRONMENT_MAP" type="EffectType">The type of effect that the texture is used for.</add>
         <add name="Coordinate Generation Type" default="CG_SPHERE_MAP" type="CoordGenType">The method that will be used to generate UV coordinates for the texture effect.</add>
         <add name="Image" type="Ref" template="NiImage" ver2="3.1">Image index.</add>
@@ -4640,8 +4635,7 @@
     <niobject name="NiVectorExtraData" abstract="0" inherit="NiExtraData">
         DEPRECATED (20.5).
         Extra data in the form of a vector (as x, y, z, w components).
-        <add name="Vector Data" type="Vector3">The vector data.</add>
-        <add name="Unknown Float" type="float">Not sure whether this comes before or after the vector data.</add>
+        <add name="Vector Data" type="Vector4">The vector data.</add>
     </niobject>
 
     <niobject name="NiVertexColorProperty" abstract="0" inherit="NiProperty">
@@ -4714,7 +4708,7 @@
     <niobject name="NiSortAdjustNode" abstract="0" inherit="NiNode">
         Used to turn sorting off for individual subtrees in a scene. Useful if objects must be drawn in a fixed order.
         <add name="Sorting Mode" type="SortingMode" default="SORTING_INHERIT">Sorting</add>
-        <add name="Unknown Int 2" type="int" default="-1" ver2="10.2.0.0">Unknown.</add>
+        <add name="Accumulator" type="Ref" ver2="20.0.0.3" />
     </niobject>
 
     <niobject name="NiSourceCubeMap" abstract="0" inherit="NiSourceTexture">
@@ -5099,15 +5093,15 @@
     <niobject name="NiScreenElementsData" inherit="NiTriShapeData">
         DEPRECATED (20.5), functionality included in NiMeshScreenElements.
         Two dimensional screen elements.
-        <add name="Max Polygons" type="ushort">Maximum number of polygons?</add>
-        <add name="Polygons" type="Polygon" arr1="Max Polygons">Polygons</add>
-        <add name="Polygon Indices" type="ushort" arr1="Max Polygons">Polygon Indices</add>
-        <add name="Unknown UShort 1" type="ushort" default="1">Unknown</add>
-        <add name="Num Polygons" type="ushort">Number of Polygons actually in use</add>
-        <add name="Used Vertices" type="ushort">Number of in-use vertices</add>
-        <add name="Unknown UShort 2" type="ushort" default="1">Unknown</add>
-        <add name="Used Triangle Points" type="ushort">Number of in-use triangles</add>
-        <add name="Unknown UShort 3" type="ushort" default="1">Maximum number of faces</add>
+        <add name="Max Polygons" type="ushort" />
+        <add name="Polygons" type="Polygon" arr1="Max Polygons" />
+        <add name="Polygon Indices" type="ushort" arr1="Max Polygons" />
+        <add name="Polygon Grow By" type="ushort" default="1" />
+        <add name="Num Polygons" type="ushort" />
+        <add name="Max Vertices" type="ushort" />
+        <add name="Vertices Grow By" type="ushort" default="1" />
+        <add name="Max Indices" type="ushort" />
+        <add name="Indices Grow By" type="ushort" default="1" />
     </niobject>
 
     <niobject name="NiScreenElements" inherit="NiTriShape">
@@ -5137,8 +5131,8 @@
     <niobject name="NiPortal" inherit="NiAVObject">
         NiPortal objects are grouping nodes that support aggressive visibility culling.
         They represent flat polygonal regions through which a part of a scene graph can be viewed.
-        <add name="Unknown Flags" type="Flags">Unknown flags.</add>
-        <add name="Unknown Short 2" type="short">Unknown</add>
+        <add name="Portal Flags" type="ushort" />
+        <add name="Plane Count" type="ushort">Unused in 20.x, possibly also 10.x.</add>
         <add name="Num Vertices" type="ushort">Number of vertices in this polygon</add>
         <add name="Vertices" type="Vector3" arr1="Num Vertices">Vertices</add>
         <add name="Target" type="Ptr" template="NiNode">Target portal or room</add>

--- a/nif.xml
+++ b/nif.xml
@@ -2783,19 +2783,21 @@
 
     <niobject name="NiDynamicEffect" abstract="1" inherit="NiAVObject">
         Abstract base class for dynamic effects such as NiLights or projected texture effects.
-        <add name="Switch State" type="bool" ver1="10.1.0.106" vercond="User Version 2 &lt; 130">Turns effect on and off?  Switches list to list of unaffected nodes?</add>
-        <add name="Num Affected Node List Pointers" type="uint" ver2="4.0.0.2" >The number of affected nodes referenced.</add>
-        <add name="Affected Node List Pointers" type="uint" arr1="Num Affected Node List Pointers" ver2="4.0.0.2">This is probably the list of affected nodes. For some reason i do not know the max exporter seems to write pointers instead of links. But it doesn&#039;t matter because at least in version 4.0.0.2 the list is automagically updated by the engine during the load stage.</add>
-        <add name="Num Affected Nodes" type="uint" ver1="10.1.0.0" vercond="User Version 2 &lt; 130">The number of affected nodes referenced.</add>
-        <add name="Affected Nodes" type="Ref" template="NiAVObject" arr1="Num Affected Nodes" ver1="10.1.0.0" vercond="User Version 2 &lt; 130">The list of affected nodes?</add>
+        <add name="Switch State" type="bool" ver1="10.1.0.106" vercond="User Version 2 &lt; 130">If true, then the dynamic effect is applied to affected nodes during rendering.</add>
+        <add name="Num Affected Nodes" type="uint" ver2="4.0.0.2" />
+        <add name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" ver2="3.3.0.13">If a node appears in this list, then its entire subtree will be affected by the effect.</add>
+        <add name="Affected Node Pointers" type="uint" arr1="Num Affected Nodes" ver1="4.0.0.0" ver2="4.0.0.2">As of 4.0 the pointer hash is no longer stored alongside each NiObject on disk, yet this node list still refers to the pointer hashes. Cannot leave the type as Ptr because the link will be invalid.</add>
+        <add name="Num Affected Nodes" type="uint" ver1="10.1.0.0" vercond="User Version 2 &lt; 130" />
+        <add name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" ver1="10.1.0.0" vercond="User Version 2 &lt; 130">If a node appears in this list, then its entire subtree will be affected by the effect.</add>
     </niobject>
 
     <niobject name="NiLight" abstract="1" inherit="NiDynamicEffect">
         Abstract base class that represents light sources in a scene graph.
-        <add name="Dimmer" type="float">Dimmer.</add>
-        <add name="Ambient Color" type="Color3">Ambient color.</add>
-        <add name="Diffuse Color" type="Color3">Diffuse color.</add>
-        <add name="Specular Color" type="Color3">Specular color.</add>
+        For Bethesda Stream 130 (FO4), NiLight now directly inherits from NiAVObject.
+        <add name="Dimmer" type="float">Scales the overall brightness of all light components.</add>
+        <add name="Ambient Color" type="Color3" />
+        <add name="Diffuse Color" type="Color3" />
+        <add name="Specular Color" type="Color3" />
     </niobject>
 
     <niobject name="NiProperty" abstract="1" inherit="NiObjectNET">

--- a/nif.xml
+++ b/nif.xml
@@ -47,44 +47,44 @@
 
     <!--Basic Types-->
 
-    <basic name="bool" count="1" niflibtype="bool">
+    <basic name="bool" count="1">
         A boolean; 32-bit from 4.0.0.2, and 8-bit from 4.1.0.1 on.
     </basic>
 
-    <basic name="byte" count="1" niflibtype="byte">
+    <basic name="byte" count="1">
         An unsigned 8-bit integer.
     </basic>
 
-    <basic name="uint" count="1" niflibtype="unsigned int">
+    <basic name="uint" count="1">
         An unsigned 32-bit integer.
     </basic>
 
-    <basic name="ulittle32" count="1" niflibtype="unsigned int">
+    <basic name="ulittle32" count="1">
         A litte-endian unsigned 32-bit integer.
     </basic>
 
-    <basic name="ushort" count="1" niflibtype="unsigned short">
+    <basic name="ushort" count="1">
         An unsigned 16-bit integer.
     </basic>
 
-    <basic name="int" count="1" niflibtype="int">
+    <basic name="int" count="1">
         A signed 32-bit integer.
     </basic>
 
-    <basic name="short" count="1" niflibtype="short">
+    <basic name="short" count="1">
         A signed 16-bit integer.
     </basic>
 
-    <basic name="BlockTypeIndex" count="0" niflibtype="unsigned short">
+    <basic name="BlockTypeIndex" count="0">
         A 16-bit (signed?) integer, which is used in the header to refer to a particular object type in a object type string array.
         The upper bit appears to be a flag used for PhysX block types.
     </basic>
 
-    <basic name="char" count="0" niflibtype="byte">
+    <basic name="char" count="0">
         An 8-bit character.
     </basic>
 
-    <basic name="FileVersion" count="0" niflibtype="unsigned int">
+    <basic name="FileVersion" count="0">
         A 32-bit integer that stores the version in hexadecimal format with each byte representing a number in the version string.
 
         Some widely-used versions and their hex representation:
@@ -100,42 +100,42 @@
         20.0.0.5:   0x14000005
     </basic>
 
-    <basic name="Flags" count="0" niflibtype="unsigned short">
+    <basic name="Flags" count="0">
         A 16-bit integer, used for bit flags.  Function varies by object type.
     </basic>
 
-    <basic name="float" count="0" niflibtype="float">
+    <basic name="float" count="0">
         A standard 32-bit floating point number.
     </basic>
     
-    <basic name="hfloat" count="0" niflibtype="hfloat">
+    <basic name="hfloat" count="0">
         A 16-bit floating point number.
     </basic>
     
-    <basic name="HeaderString" count="0" niflibtype="HeaderString">
+    <basic name="HeaderString" count="0">
         A variable length string that ends with a newline character (0x0A).  The string starts as follows depending on the version:
 
         Version &lt;= 10.0.1.0:  'NetImmerse File Format'
         Version &gt;= 10.1.0.0:  'Gamebryo File Format'
     </basic>
 
-    <basic name="LineString" count="0" niflibtype="LineString">
+    <basic name="LineString" count="0">
         A variable length string that ends with a newline character (0x0A).
     </basic>
 
-    <basic name="Ptr" count="0" niflibtype="*" istemplate="1">
+    <basic name="Ptr" count="0" istemplate="1">
         A signed 32-bit integer, referring to a object before this one in the hierarchy.  Examples:  Bones, gravity objects.
     </basic>
 
-    <basic name="Ref" count="0" niflibtype="Ref" istemplate="1">
+    <basic name="Ref" count="0" istemplate="1">
         A signed 32-bit integer, used to refer to another object; -1 means no reference. These should always point down the hierarchy. Other types are used for indexes that point to objects higher up.
     </basic>
 
-    <basic name="StringOffset" count="0" niflibtype="unsigned int">
+    <basic name="StringOffset" count="0">
         A 32-bit unsigned integer, used to refer to strings in a NiStringPalette.
     </basic>
 
-    <basic name="StringIndex" count="0" niflibtype="IndexString">
+    <basic name="StringIndex" count="0">
         A 32-bit unsigned integer, used to refer to strings in the header.
     </basic>
     
@@ -1186,13 +1186,13 @@
         These are like C structures and are used as sub-parts of more complex
         classes when there are multiple pieces of data repeated in an array.-->
 
-    <compound name="SizedString" niflibtype="string">
+    <compound name="SizedString">
         A string of given length.
         <add name="Length" type="uint">The string length.</add>
         <add name="Value" type="char" arr1="Length">The string itself.</add>
     </compound>
 
-    <compound name="string" niflibtype="IndexString">
+    <compound name="string">
         A string type.
         <add name="String" type="SizedString" ver2="20.0.0.5">The normal string.</add>
         <add name="Index" type="StringIndex" ver1="20.1.0.3">The string index.</add>
@@ -1211,21 +1211,21 @@
         <add name="Data" type="byte" arr1="Data Size 2" arr2="Data Size 1">The bytes which make up the array</add>
     </compound>
 
-    <compound name="Color3" niflibtype="Color3">
+    <compound name="Color3">
         A color without alpha (red, green, blue).
         <add name="r" type="float">Red color component.</add>
         <add name="g" type="float">Green color component.</add>
         <add name="b" type="float">Blue color component.</add>
     </compound>
 
-    <compound name="ByteColor3"><!-- niflibtype="Color3" -->
+    <compound name="ByteColor3">
         A color without alpha (red, green, blue).
         <add name="r" type="byte">Red color component.</add>
         <add name="g" type="byte">Green color component.</add>
         <add name="b" type="byte">Blue color component.</add>
     </compound>
 
-    <compound name="Color4" niflibtype="Color4">
+    <compound name="Color4">
         A color with alpha (red, green, blue, alpha).
         <add name="r" type="float">Red component.</add>
         <add name="g" type="float">Green component.</add>
@@ -1233,7 +1233,7 @@
         <add name="a" type="float">Alpha.</add>
     </compound>
 
-    <compound name="ByteColor4"><!-- niflibtype="Color4" -->
+    <compound name="ByteColor4">
         A color with alpha (red, green, blue, alpha).
         <add name="r" type="byte">Red color component.</add>
         <add name="g" type="byte">Green color component.</add>
@@ -1241,7 +1241,7 @@
         <add name="a" type="byte">Alpha color component.</add>
     </compound>
 
-    <compound name="FilePath" niflibtype="IndexString">
+    <compound name="FilePath">
         A string that contains the path to a file.
         <add name="String" type="SizedString" ver2="20.0.0.5">The normal string.</add>
         <add name="Index" type="StringIndex" ver1="20.1.0.3">The string index.</add>
@@ -1280,14 +1280,14 @@
         <add name="z" type="hfloat">Third coordinate.</add>
     </compound>
 
-    <compound name="Vector3" niflibtype="Vector3">
+    <compound name="Vector3">
         A vector in 3D space (x,y,z).
         <add name="x" type="float">First coordinate.</add>
         <add name="y" type="float">Second coordinate.</add>
         <add name="z" type="float">Third coordinate.</add>
     </compound>
 
-    <compound name="Vector4" niflibtype="Vector4">
+    <compound name="Vector4">
         A 4-dimensional vector.
         <add name="x" type="float">First coordinate.</add>
         <add name="y" type="float">Second coordinate.</add>
@@ -1295,7 +1295,7 @@
         <add name="w" type="float">Fourth coordinate.</add>
     </compound>
 
-    <compound name="Quaternion" niflibtype="Quaternion">
+    <compound name="Quaternion">
         A quaternion.
         <add name="w" type="float" default="1.0">The w-coordinate.</add>
         <add name="x" type="float" default="0.0">The x-coordinate.</add>
@@ -1311,7 +1311,7 @@
         <add name="w" type="float" default="1.0">The w-coordinate.</add>
     </compound>
 
-    <compound name="Matrix22" niflibtype="Matrix22">
+    <compound name="Matrix22">
         A 2x2 matrix of float values.  Stored in OpenGL column-major format.
         <add name="m11" type="float" default="1.0">Member 1,1 (top left)</add>
         <add name="m21" type="float" default="0.0">Member 2,1 (bottom left)</add>
@@ -1319,7 +1319,7 @@
         <add name="m22" type="float" default="1.0">Member 2,2 (bottom right)</add>
     </compound>
 
-    <compound name="Matrix33" niflibtype="Matrix33">
+    <compound name="Matrix33">
         A 3x3 rotation matrix; M^T M=identity, det(M)=1.    Stored in OpenGL column-major format.
         <add name="m11" type="float" default="1.0">Member 1,1 (top left)</add>
         <add name="m21" type="float" default="0.0">Member 2,1</add>
@@ -1332,7 +1332,7 @@
         <add name="m33" type="float" default="1.0">Member 3,3 (bottom left)</add>
     </compound>
 
-    <compound name="Matrix34" niflibtype="Matrix34">
+    <compound name="Matrix34">
         A 3x4 transformation matrix.
         <add name="m11" type="float" default="1.0">The (1,1) element.</add>
         <add name="m21" type="float" default="0.0">The (2,1) element.</add>
@@ -1348,7 +1348,7 @@
         <add name="m34" type="float" default="0.0">The (3,4) element.</add>
     </compound>
 
-    <compound name="Matrix44" niflibtype="Matrix44">
+    <compound name="Matrix44">
         A 4x4 transformation matrix.
         <add name="m11" type="float" default="1.0">The (1,1) element.</add>
         <add name="m21" type="float" default="0.0">The (2,1) element.</add>
@@ -1368,7 +1368,7 @@
         <add name="m44" type="float" default="1.0">The (4,4) element.</add>
     </compound>
 
-    <compound name="hkMatrix3" niflibtype="InertiaMatrix">
+    <compound name="hkMatrix3">
         A 3x3 Havok matrix stored in 4x3 due to memory alignment.
         <add name="m11" type="float" />
         <add name="m12" type="float" />
@@ -1397,7 +1397,7 @@
         <add name="Nodes" type="Ptr" template="NiNode" arr1="Num Nodes">The list of NiNode references.</add>
     </compound>
 
-    <compound name="ShortString" ver1="10.1.0.0" niflibtype="ShortString">
+    <compound name="ShortString" ver1="10.1.0.0">
         Another string format, for short strings.  Specific to Bethesda-specific header tags.
         <add name="Length" type="byte">The string length.</add>
         <add name="Value" type="char" arr1="Length">The string itself, null terminated (the null terminator is taken into account in the length byte).</add>
@@ -1508,7 +1508,7 @@
         <add name="c" type="float">Continuity.</add>
     </compound>
 
-    <compound name="Key" niflibtype="Key" istemplate="1">
+    <compound name="Key" istemplate="1">
         A generic key with support for interpolation. Type 1 is normal linear interpolation, type 2 has forward and backward tangents, and type 3 has tension, bias and continuity arguments. Note that color4 and byte always seem to be of type 1.
         <add name="Time" type="float">Time of the key.</add>
         <add name="Value" type="TEMPLATE">The key value.</add>
@@ -1524,7 +1524,7 @@
         <add name="Keys" type="Key" arg="Interpolation" template="TEMPLATE" arr1="Num Keys">The keys.</add>
     </compound>
 
-    <compound name="QuatKey" niflibtype="Key" istemplate="1"><!-- TEMPLATE should always be Quaternion -->
+    <compound name="QuatKey" istemplate="1"><!-- TEMPLATE should always be Quaternion -->
         A special version of the key type used for quaternions.  Never has tangents.
         <add name="Time" type="float" ver2="10.1.0.0">Time the key applies.</add>
         <add name="Time" type="float" cond="ARG != 4" ver1="10.1.0.106">Time the key applies.</add>
@@ -1532,7 +1532,7 @@
         <add name="TBC" type="TBC" cond="ARG == 3">The TBC of the key.</add>
     </compound>
 
-    <compound name="TexCoord" niflibtype="TexCoord">
+    <compound name="TexCoord">
         Texture coordinates (u,v). As in OpenGL; image origin is in the lower left corner.
         <add name="u" type="float">First coordinate.</add>
         <add name="v" type="float">Second coordinate.</add>
@@ -1580,7 +1580,7 @@
         <add name="Map ID" type="uint" cond="Has Map">Unique identifier for the Gamebryo shader system.</add>
     </compound>
 
-    <compound name="Triangle" niflibtype="Triangle">
+    <compound name="Triangle">
         List of three vertex indices.
         <add name="v1" type="ushort">First vertex index.</add>
         <add name="v2" type="ushort">Second vertex index.</add>
@@ -1603,7 +1603,7 @@
 		<!-- Last bit unused -->
 	</bitflags>
     
-	<compound name="BSVertexData" niflibtype="BSVertexData">
+	<compound name="BSVertexData">
 		<add name="Vertex" type="HalfVector3" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
 		<add name="Bitangent X" type="hfloat" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 256) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
 		<add name="Unknown Short" type="ushort" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 256) == 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
@@ -1623,7 +1623,7 @@
 		<add name="Eye Data" type="float" cond="(ARG &amp; 4096) != 0" />
 	</compound>
 
-	<compound name="BSVertexDataSSE" niflibtype="BSVertexData">
+	<compound name="BSVertexDataSSE">
 		<add name="Vertex" type="Vector3" cond="((ARG &amp; 16) != 0)" />
 		<add name="Bitangent X" type="float" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 256) != 0)" />
 		<add name="Unknown Int" type="int" cond="((ARG &amp; 16) != 0) &amp;&amp; (ARG &amp; 256) == 0" />

--- a/nif.xml
+++ b/nif.xml
@@ -1070,28 +1070,29 @@
         <option value="13000" name="BP_TORSOSECTION_BRAIN">Torso Section | Brain</option>       
     </enum>
 	
-    <enum name="BSLightingShaderPropertyShaderType" storage="uint">
+    <enum name="BSLightingShaderPropertyShaderType" storage="uint" prefix="ST">
         Values for configuring the shader type in a BSLightingShaderProperty
-        <option value="0" name="Default"></option>
+        <option value="0" name="Default" />
         <option value="1" name="Environment Map">Enables EnvMap Mask(TS6), EnvMap Scale</option>
         <option value="2" name="Glow Shader">Enables Glow(TS3)</option>
-        <option value="3" name="Heightmap">Enables Height(TS4)</option>
-        <option value="4" name="Face Tint">Enables SubSurface(TS3), Detail(TS4), Tint(TS7)</option>
+        <option value="3" name="Parallax">Enables Height(TS4)</option>
+        <option value="4" name="Face Tint">Enables Detail(TS4), Tint(TS7)</option>
         <option value="5" name="Skin Tint">Enables Skin Tint Color</option>
         <option value="6" name="Hair Tint">Enables Hair Tint Color</option>
-        <option value="7" name="Parallax Occ Material">Enables Height(TS4), Max Passes, Scale.  Unused?</option>
-        <option value="8" name="World Multitexture"></option>
-        <option value="9" name="WorldMap1"></option>
-        <option value="10" name="Unknown 10"></option>
+        <option value="7" name="Parallax Occ">Enables Height(TS4), Max Passes, Scale. Unimplemented.</option>
+        <option value="8" name="Multitexture Landscape" />
+        <option value="9" name="LOD Landscape" />
+        <option value="10" name="Snow" />
         <option value="11" name="MultiLayer Parallax">Enables EnvMap Mask(TS6), Layer(TS7), Parallax Layer Thickness, Parallax Refraction Scale, Parallax Inner Layer U Scale, Parallax Inner Layer V Scale, EnvMap Scale</option>
-        <option value="12" name="Unknown 12"></option>
-        <option value="13" name="WorldMap2"></option>
+        <option value="12" name="Tree Anim" />
+        <option value="13" name="LOD Objects" />
         <option value="14" name="Sparkle Snow">Enables SparkleParams</option>
-        <option value="15" name="WorldMap3"></option>
+        <option value="15" name="LOD Objects HD" />
         <option value="16" name="Eye Envmap">Enables EnvMap Mask(TS6), Eye EnvMap Scale</option>
-        <option value="17" name="Unknown 17"></option>
-        <option value="18" name="WorldMap4"></option>
-        <option value="19" name="World LOD Multitexture"></option>
+        <option value="17" name="Cloud" />
+        <option value="18" name="LOD Landscape Noise" />
+        <option value="19" name="Multitexture Landscape LOD Blend" />
+        <option value="20" name="FO4 Dismemberment" />
     </enum>
 
     <enum name="EffectShaderControlledVariable" storage="uint" prefix="ESCV">

--- a/nif.xml
+++ b/nif.xml
@@ -5365,7 +5365,7 @@
         <add name="Type of Controlled Variable" type="EffectShaderControlledVariable">Which float variable in BSEffectShaderProperty to animate:</add>
     </niobject>
 	
-	<niobject name="BSEffectShaderPropertyColorController" inherit="NiFloatInterpController">
+	<niobject name="BSEffectShaderPropertyColorController" inherit="NiPoint3InterpController">
 		This controller is used to animate colors in BSEffectShaderProperty.
 		<add name="Type of Controlled Color" type="EffectShaderControlledColor">Which color in BSEffectShaderProperty to animate:</add>
 	</niobject>
@@ -5375,12 +5375,12 @@
 		<add name="Type of Controlled Variable" type="LightingShaderControlledVariable">Which float variable in BSLightingShaderProperty to animate:</add>
 	</niobject>
 	
-	<niobject name="BSLightingShaderPropertyColorController" abstract="0" inherit="NiFloatInterpController">
+	<niobject name="BSLightingShaderPropertyColorController" abstract="0" inherit="NiPoint3InterpController">
 		This controller is used to animate colors in BSLightingShaderProperty.
 		<add name="Type of Controlled Color" type="LightingShaderControlledColor">Which color in BSLightingShaderProperty to animate:</add>
 	</niobject>	
 	
-	<niobject name="BSNiAlphaPropertyTestRefController" inherit="NiAlphaController" />
+	<niobject name="BSNiAlphaPropertyTestRefController" inherit="NiFloatInterpController" />
 	
 	<niobject name="BSProceduralLightningController" abstract="0" inherit="NiTimeController">
     Skyrim, Paired with dummy TriShapes, this controller generates lightning shapes for special effects.
@@ -6038,9 +6038,8 @@
         <add name="AABB Max" type="Vector4" />
     </niobject>
 
-    <niobject name="BSFrustumFOVController" inherit="NiTimeController">
+    <niobject name="BSFrustumFOVController" inherit="NiFloatInterpController">
         Bethesda-specific time controller.
-        <add name="Interpolator" type="Ref" template="NiFloatInterpolator">Frustrum field of view animation interpolater and data.</add>
     </niobject>
 
     <niobject name="BSDebrisNode" inherit="BSRangeNode">

--- a/nif.xml
+++ b/nif.xml
@@ -6279,11 +6279,34 @@
         <add name="Bone Bounds" type="NiBound" cond="(Flags &amp; 2)!=0" arr1="Num Bones">The bounds of the bones.  Only stored if the RECOMPUTE_BOUNDS bit is set.</add>
     </niobject>
 
-    <niobject name="NiInstancingMeshModifier" inherit="NiMeshModifier">
-        <!-- not yet decoded -->
+    <niobject name="NiMeshHWInstance" inherit="NiAVObject">
+        <add name="Master Mesh" type="Ref" template="NiMesh" />
+        <add name="Mesh Modifier" type="Ref" template="NiInstancingMeshModifier" />
     </niobject>
 
+    <niobject name="NiInstancingMeshModifier" inherit="NiMeshModifier">
+        <add name="Has Instance Nodes" type="bool" />
+        <add name="Per Instance Culling" type="bool" />
+        <add name="Has Static Bounds" type="bool" />
+        <add name="Affected Mesh" type="Ref" template="NiMesh" />
+        <add name="Bound" type="NiBound" cond="Has Static Bounds" />
+        <add name="Num Instance Nodes" type="uint" cond="Has Instance Nodes" />
+        <add name="Instance Nodes" type="Ref" template="NiMeshHWInstance" arr1="Num Instance Nodes" cond="Has Instance Nodes" />
+    </niobject>
+
+    <compound name="LODInfo">
+        <add name="Num Active Skins" type="uint" />
+        <add name="Skin Indices" type="uint" arr1="Num Active Skins" />
+    </compound>
+
     <niobject name="NiSkinningLODController" inherit="NiTimeController">
+        <add name="Current LOD" type="uint" />
+        <add name="Num Bones" type="uint" />
+        <add name="Bones" type="Ref" template="NiNode" arr1="Num Bones" />
+        <add name="Num Skins" type="uint" />
+        <add name="Skins" type="Ref" template="NiMesh" arr1="Num Skins" />
+        <add name="Num LOD Levels" type="uint" />
+        <add name="LODs" type="LODInfo" arr1="Num LOD Levels" />
     </niobject>
 
 
@@ -6612,8 +6635,19 @@
         <!-- not yet decoded -->
     </niobject>
 
-    <niobject name="NiMeshHWInstance" inherit="NiObject">
-        <!-- not yet decoded -->
+    <niobject name="NiShadowGenerator" inherit="NiObject">
+        <add name="Name" type="string" />
+        <add name="Flags" type="ushort" />
+        <add name="Num Shadow Casters" type="uint" />
+        <add name="Shadow Casters" type="Ref" template="NiNode" arr1="Num Shadow Casters" />
+        <add name="Num Shadow Receivers" type="uint" />
+        <add name="Shadow Receivers" type="Ref" template="NiNode" arr1="Num Shadow Receivers" />
+        <add name="Target" type="Ptr" template="NiDynamicEffect" />
+        <add name="Depth Bias" type="float" default="0.98" />
+        <add name="Size Hint" type="ushort" />
+        <add name="Near Clipping Distance" type="float" ver1="20.3.0.7" />
+        <add name="Far Clipping Distance" type="float" ver1="20.3.0.7" />
+        <add name="Directional Light Frustum Width" type="float" ver1="20.3.0.7" />
     </niobject>
 
     <niobject name="NiFurSpringController" inherit="NiTimeController"><!-- BloodBowl -->

--- a/nif.xml
+++ b/nif.xml
@@ -3961,7 +3961,7 @@
         <add name="Type" type="PixelComponent">Component Type</add>
         <add name="Convention" type="PixelRepresentation">Data Storage Convention</add>
         <add name="Bits Per Channel" type="byte">Bits per component</add>
-        <add name="Signed" type="bool" />
+        <add name="Is Signed" type="bool" />
     </compound>
 
     <!--
@@ -4802,11 +4802,13 @@
         <add name="RGB Image Data" type="ByteColor3" arr1="Width" arr2="Height" cond="Image Type == 1" >Image pixel data.</add>
         <add name="RGBA Image Data" type="ByteColor4" arr1="Width" arr2="Height" cond="Image Type == 2" >Image pixel data.</add>
     </niobject>
+    
+    <niobject name="NiAccumulator" abstract="1" inherit="NiObject" />
 
     <niobject name="NiSortAdjustNode" abstract="0" inherit="NiNode">
         Used to turn sorting off for individual subtrees in a scene. Useful if objects must be drawn in a fixed order.
         <add name="Sorting Mode" type="SortingMode" default="SORTING_INHERIT">Sorting</add>
-        <add name="Accumulator" type="Ref" ver2="20.0.0.3" />
+        <add name="Accumulator" type="Ref" template="NiAccumulator" ver2="20.0.0.3" />
     </niobject>
 
     <niobject name="NiSourceCubeMap" abstract="0" inherit="NiSourceTexture">

--- a/nif.xml
+++ b/nif.xml
@@ -3353,11 +3353,11 @@
     
     <niobject name="NiMeshPSysData" abstract="0" inherit="NiPSysData">
         Particle meshes data.
-        <add name="Unknown Int 2" type="uint" ver1="10.2.0.0">Unknown. Possible vertex count but probably not.</add>
-        <add name="Unknown Byte 3" type="byte" default="0" ver1="10.2.0.0">Unknown. 0?</add>
-        <add name="Num Unknown Ints 1" type="uint" ver1="10.2.0.0">Unknown.</add>
-        <add name="Unknown Ints 1" type="uint" ver1="10.2.0.0" arr1="Num Unknown Ints 1">Unknown integers</add>
-        <add name="Unknown Node" type="Ref" template="NiNode">Unknown NiNode.</add>
+        <add name="Default Pool Size" type="uint" ver1="10.2.0.0" />
+        <add name="Fill Pools On Load" type="bool" ver1="10.2.0.0" />
+        <add name="Num Generations" type="uint" ver1="10.2.0.0" />
+        <add name="Generations" type="uint" ver1="10.2.0.0" arr1="Num Generations" />
+        <add name="Particle Meshes" type="Ref" template="NiNode" />
     </niobject>
 
     <niobject name="NiBinaryExtraData" abstract="0" inherit="NiExtraData">

--- a/nif.xml
+++ b/nif.xml
@@ -2269,9 +2269,9 @@
         <add name="Spawn on Collide" type="bool">Spawn particles on impact?</add>
         <add name="Die on Collide" type="bool">Kill particles on impact?</add>
         <add name="Spawn Modifier" type="Ref" template="NiPSysSpawnModifier">Spawner to use for the collider.</add>
-        <add name="Parent" type="Ptr" template="NiObject">Link to parent.</add>
-        <add name="Next Collider" type="Ref" template="NiObject">The next collider.</add>
-        <add name="Collider Object" type="Ptr" template="NiNode">The object whose position and orientation are the basis of the collider.</add>
+        <add name="Parent" type="Ptr" template="NiPSysColliderManager">Link to parent.</add>
+        <add name="Next Collider" type="Ref" template="NiPSysCollider">The next collider.</add>
+        <add name="Collider Object" type="Ptr" template="NiAVObject">The object whose position and orientation are the basis of the collider.</add>
     </niobject>
 
     <enum name="BroadPhaseType" storage="byte">
@@ -2436,10 +2436,10 @@
         <add name="Constraint Force Mixing" type="float" default="1.1920929e-08">Restitution (amount of elasticity) of constraints. Added to the diagonal of the constraint matrix. A value of 0.0 can result in a division by zero with some chain configurations.</add>
         <add name="Max Error Distance" type="float" default="0.1">Maximum distance error in constraints allowed before stabilization algorithm kicks in. A smaller distance causes more resistance.</add>
         <add name="Num Entities A" type="uint">Number of links in the chain</add>
-        <add name="Entities A" type="Ptr" template="NiObject" arr1="Num Entities A" />
+        <add name="Entities A" type="Ptr" template="bhkRigidBody" arr1="Num Entities A" />
         <add name="Num Entities" type="uint" default="2">Hardcoded to 2. Don't change.</add>
-        <add name="Entity A" type="Ptr" template="NiObject" />
-        <add name="Entity B" type="Ptr" template="NiObject" />
+        <add name="Entity A" type="Ptr" template="bhkRigidBody" />
+        <add name="Entity B" type="Ptr" template="bhkRigidBody" />
         <add name="Priority" type="uint" />
     </niobject>
 
@@ -2747,7 +2747,7 @@
         <add name="Flags" type="bhkCOFlags" default="1">
             Set to 1 for most objects, and to 41 for animated objects (ANIM_STATIC). Bits: 0=Active 2=Notify 3=Set Local 6=Reset.
         </add>
-        <add name="Body" type="Ref" template="NiObject" />
+        <add name="Body" type="Ref" template="bhkWorldObject" />
     </niobject>
 
     <niobject name="bhkCollisionObject" abstract="0" inherit="bhkNiCollisionObject">
@@ -3124,7 +3124,7 @@
         <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &lt; 100)" />
         <add name="Dirty Flag" type="bool" ver1="20.2.0.7" vercond="(User Version 2 &gt;= 100)" cond="!NiParticleSystem" />
         <!-- Bethesda -->
-        <add name="Shader Property" type="Ref" template="NiProperty" ver1="20.2.0.7" userver="12" />
+        <add name="Shader Property" type="Ref" template="BSShaderProperty" ver1="20.2.0.7" userver="12" />
         <add name="Alpha Property" type="Ref" template="NiAlphaProperty" ver1="20.2.0.7" userver="12" />
     </niobject>
 
@@ -4089,7 +4089,7 @@
 
     <niobject name="NiPSysDragModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies a linear drag force to particles.
-        <add name="Parent" type="Ptr" template="NiObject">The object whose position and orientation are the basis of the force.</add>
+        <add name="Drag Object" type="Ptr" template="NiAVObject">The object whose position and orientation are the basis of the force.</add>
         <add name="Drag Axis" type="Vector3">The local direction of the force.</add>
         <add name="Percentage" type="float">The amount of drag to apply to particles.</add>
         <add name="Range" type="float">The distance up to which particles are fully affected.</add>
@@ -4105,7 +4105,7 @@
 
     <niobject name="NiPSysGravityModifier" abstract="0" inherit="NiPSysModifier">
         Particle modifier that applies a gravitational force to particles.
-        <add name="Gravity Object" type="Ptr" template="NiNode">The object whose position and orientation are the basis of the force.</add>
+        <add name="Gravity Object" type="Ptr" template="NiAVObject">The object whose position and orientation are the basis of the force.</add>
         <add name="Gravity Axis" type="Vector3">The local direction of the force.</add>
         <add name="Decay" type="float">How the force diminishes by distance.</add>
         <add name="Strength" type="float">The acceleration of the force.</add>
@@ -4379,7 +4379,7 @@
 
     <niobject name="NiShadeProperty" abstract="0" inherit="NiProperty">
         Determines whether flat shading or smooth shading is used on a shape.
-        <add name="Flags" type="Flags">
+        <add name="Flags" type="Flags" default="1" vercond="(User Version 2 &lt;= 34)">
             Bit 0: Enable smooth phong shading on this shape. Otherwise, hard-edged flat shading will be used on this shape.
         </add>
     </niobject>
@@ -5342,15 +5342,11 @@
         <option value="31" name="SF2_Unknown10">Unknown</option>
     </bitflags>
     
-    <niobject name="BSShaderProperty" abstract="0" inherit="NiProperty">
+    <niobject name="BSShaderProperty" abstract="0" inherit="NiShadeProperty">
         Bethesda-specific property.
-        <add name="Smooth" type="Flags" default="1">
-            0: smooth no
-            1: smooth yes
-        </add>
-        <add name="Shader Type" type="BSShaderType" default="SHADER_DEFAULT" />
-        <add name="Shader Flags" type="BSShaderFlags" default="0x82000000" />
-        <add name="Shader Flags 2" type="BSShaderFlags2" default="1" />
+        <add name="Shader Type" type="BSShaderType" default="SHADER_DEFAULT" vercond="(User Version 2 &lt;= 34)" />
+        <add name="Shader Flags" type="BSShaderFlags" default="0x82000000" vercond="(User Version 2 &lt;= 34)" />
+        <add name="Shader Flags 2" type="BSShaderFlags2" default="1" vercond="(User Version 2 &lt;= 34)" />
         <add name="Environment Map Scale" type="float" default="1.0" vercond="(User Version 2 &lt;= 34)">Scales the intensity of the environment/cube map.</add>
     </niobject>
 
@@ -5425,7 +5421,7 @@
         <add name="Fade Main Bolt" type="bool" />
         <add name="Fade Child Bolts" type="bool" />
         <add name="Animate Arc Offset" type="bool" />
-        <add name="Shader Property" type="Ref" template="NiProperty">Reference to a shader property.</add>
+        <add name="Shader Property" type="Ref" template="BSShaderProperty">Reference to a shader property.</add>
 	</niobject>
 
    <niobject name="BSShaderTextureSet" abstract="0" inherit="NiObject">
@@ -5636,7 +5632,7 @@
         <option value="31" name="FSF2_Refraction_Writes_Depth" />
     </bitflags>
 
-    <niobject name="BSLightingShaderProperty"  abstract="0" inherit="NiProperty">
+    <niobject name="BSLightingShaderProperty"  abstract="0" inherit="BSShaderProperty">
         Bethesda shader property for Skyrim and later.
         <add name="Shader Flags 1" suffix="SK" type="SkyrimShaderPropertyFlags1" vercond="(User Version 2 != 130)" default="2185233153">Skyrim Shader Flags for setting render/shader options.</add>
         <add name="Shader Flags 2" suffix="SK" type="SkyrimShaderPropertyFlags2" vercond="(User Version 2 != 130)" default="32801">Skyrim Shader Flags for setting render/shader options.</add>
@@ -5684,12 +5680,12 @@
         <add name="Right Eye Reflection Center" type="Vector3" cond="Skyrim Shader Type == 16">Offset to set center for right eye cubemap</add>
     </niobject>
 
-    <niobject name="BSEffectShaderProperty" abstract="0" inherit="NiProperty">
+    <niobject name="BSEffectShaderProperty" abstract="0" inherit="BSShaderProperty">
         Bethesda effect shader property for Skyrim and later.
-        <add name="Shader Flags 1" suffix="SK" type="SkyrimShaderPropertyFlags1" vercond="(User Version 2 != 130)" />
-        <add name="Shader Flags 2" suffix="SK" type="SkyrimShaderPropertyFlags2" vercond="(User Version 2 != 130)" />
-        <add name="Shader Flags 1" suffix="FO4" type="Fallout4ShaderPropertyFlags1" vercond="(User Version 2 == 130)" />
-        <add name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" vercond="(User Version 2 == 130)" />
+        <add name="Shader Flags 1" suffix="SK" type="SkyrimShaderPropertyFlags1" default="2147483648" vercond="(User Version 2 != 130)" />
+        <add name="Shader Flags 2" suffix="SK" type="SkyrimShaderPropertyFlags2" default="32" vercond="(User Version 2 != 130)" />
+        <add name="Shader Flags 1" suffix="FO4" type="Fallout4ShaderPropertyFlags1" default="2147483648" vercond="(User Version 2 == 130)" />
+        <add name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" default="32" vercond="(User Version 2 == 130)" />
         <add name="UV Offset" type="TexCoord">Offset UVs</add>
         <add name="UV Scale" type="TexCoord" default="1.0, 1.0">Offset UV Scale to repeat tiling textures</add>
         <add name="Source Texture"  type="SizedString">points to an external texture.</add>
@@ -5723,7 +5719,7 @@
         <option value="7" name="SWSF1_Enabled">Water layer on/off</option>
     </bitflags>
     
-    <niobject name="BSWaterShaderProperty" inherit="NiProperty">
+    <niobject name="BSWaterShaderProperty" inherit="BSShaderProperty">
         Skyrim water shader property, different from "WaterShaderProperty" seen in Fallout.
         <add name="Shader Flags 1" type="SkyrimShaderPropertyFlags1"></add>
         <add name="Shader Flags 2" type="SkyrimShaderPropertyFlags2"></add>
@@ -5734,7 +5730,7 @@
         <add name="Unknown Short 3" type="ushort">Unknown, flag?</add>  
     </niobject>
     
-    <niobject name="BSSkyShaderProperty" inherit="NiProperty">
+    <niobject name="BSSkyShaderProperty" inherit="BSShaderProperty">
         Skyrim Sky shader block.
         <add name="Shader Flags 1" type="SkyrimShaderPropertyFlags1"></add>
         <add name="Shader Flags 2" type="SkyrimShaderPropertyFlags2"></add>
@@ -6076,7 +6072,7 @@
 
     <niobject name="bhkOrientHingedBodyAction" abstract="0" inherit="bhkSerializable">
         Bethesda-Specific Havok serializable.
-        <add name="Body" type="Ptr" template="NiObject" />
+        <add name="Body" type="Ptr" template="bhkRigidBody" />
         <add name="Unknown Int 1" type="uint" />
         <add name="Unknown Int 2" type="uint" />
         <add name="Unused 1" type="byte" arr1="8" />
@@ -6362,7 +6358,7 @@
     <niobject name="NiMorphWeightsController" inherit="NiInterpController">
         <add name="Count" type="uint" />
         <add name="Num Interpolators" type="uint" />
-        <add name="Interpolators" type="Ref" template="NiObject" arr1="Num Interpolators" />
+        <add name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" />
         <add name="Num Targets" type="uint" />
         <add name="Target Names" type="string" arr1="Num Targets" />
     </niobject>
@@ -6974,7 +6970,7 @@
         Fallout 4 Tri Shape
         <add name="Bounding Sphere" type="NiBound" />
         <add name="Skin" type="Ref" template="NiObject" />
-        <add name="Shader Property" type="Ref" template="NiProperty" />
+        <add name="Shader Property" type="Ref" template="BSShaderProperty" />
         <add name="Alpha Property" type="Ref" template="NiAlphaProperty" />
         <add name="Vertex Desc" type="BSVertexDesc" />
         <add name="Num Triangles" type="uint" userver2="130" />

--- a/nif.xml
+++ b/nif.xml
@@ -2064,15 +2064,6 @@
         <add name="Weight" type="float" />
     </compound>
 
-    <compound name="ArkTexture">
-        A texture reference used by NiArkTextureExtraData.
-        <add name="Texture Name" type="string" />
-        <add name="Unknown Int 3" type="int" />
-        <add name="Unknown Int 4" type="int" />
-        <add name="Texturing Property" type="Ref" template="NiTexturingProperty" />
-        <add name="Unknown Bytes" type="byte" arr1="9" />
-    </compound>
-
     <compound name="BoneTransform">
         Transformation data for the bone at this index in bhkPoseArray.
         <add name="Translation" type="Vector3" />
@@ -5105,41 +5096,6 @@
 
     <niobject name="NiPhysXDynamicSrc" inherit="NiPhysXRigidBodySrc">
         Sends Gamebryo scene state to a PhysX dynamic actor.
-    </niobject>
-
-    <niobject name="NiArkAnimationExtraData" inherit="NiExtraData">
-        Unknown node.
-        <add name="Unknown Ints" type="int" arr1="4" />
-        <add name="Unknown Bytes" type="byte" arr1="37" ver2="4.1.0.12" />
-    </niobject>
-
-    <niobject name="NiArkImporterExtraData" inherit="NiExtraData">
-        Unknown node.
-        <add name="Unknown Int 1" type="int" />
-        <add name="Unknown Int 2" type="int" ver2="4.1.0.12" />
-        <add name="Importer Name" type="string">Contains a string like &quot;Gamebryo_1_1&quot; or &quot;4.1.0.12&quot;</add>
-        <add name="Unknown Bytes" type="byte" arr1="13" />
-        <add name="Unknown Floats" type="float" arr1="7" />
-    </niobject>
-
-    <niobject name="NiArkTextureExtraData" inherit="NiExtraData">
-        Unknown node.
-        <add name="Unknown Ints 1" type="int" arr1="2" />
-        <add name="Unknown Byte" type="byte" />
-        <add name="Unknown Int 2" type="int" ver2="4.1.0.12" />
-        <add name="Num Textures" type="int" />
-        <add name="Textures" type="ArkTexture" arr1="Num Textures" />
-    </niobject>
-
-    <niobject name="NiArkViewportInfoExtraData" inherit="NiExtraData">
-        Unknown node.
-        <add name="Unknown Bytes" type="byte" arr1="13" />
-    </niobject>
-
-    <niobject name="NiArkShaderExtraData" inherit="NiExtraData">
-        Unknown node.
-        <add name="Unknown Int" type="int" />
-        <add name="Unknown String" type="string" />
     </niobject>
 
     <niobject name="NiLines" inherit="NiTriBasedGeom">

--- a/nif.xml
+++ b/nif.xml
@@ -2126,13 +2126,6 @@
         <add name="Part Flag" type="BSPartFlag" default="257">Flags related to the Body Partition</add>
         <add name="Body Part" type="BSDismemberBodyPartType">Body Part Index</add>
     </compound>
-
-    <compound name="BSGeometrySegmentData">
-        Bethesda-specific node.
-        <add name="Flags" type="byte" />
-        <add name="Index" type="uint">Index = previous Index + previous Num Tris in Segment * 3</add>
-        <add name="Num Tris in Segment" type="uint" >The number of triangles belonging to this segment</add>
-    </compound>
     
     <compound name="BoneLOD">
         Stores Bone Level of Detail info in a BSBoneLODExtraData
@@ -5963,6 +5956,26 @@
         <add name="Radius" type="float" />
     </niobject>
 
+    <compound name="BSGeometrySubSegment">
+        This is only defined because of recursion issues.
+        <add name="Start Index" type="uint" />
+        <add name="Num Primitives" type="uint" />
+        <add name="Parent Array Index" type="uint" />
+        <add name="Unused" type="uint" />
+    </compound>
+
+    <compound name="BSGeometrySegmentData">
+        Bethesda-specific. Describes groups of triangles either segmented in a grid (for LOD) or by body part for skinned FO4 meshes.
+        <add name="Flags" type="byte" vercond="(User Version 2 &lt; 130)" />
+        <add name="Index" type="uint" vercond="(User Version 2 &lt; 130)">Index = previous Index + previous Num Tris in Segment * 3</add>
+        <add name="Num Tris in Segment" type="uint" vercond="(User Version 2 &lt; 130)">The number of triangles belonging to this segment</add>
+        <add name="Start Index" type="uint" userver2="130" />
+        <add name="Num Primitives" type="uint" userver2="130" />
+        <add name="Parent Array Index" type="uint" userver2="130" />
+        <add name="Num Sub Segments" type="uint" userver2="130" />
+        <add name="Sub Segment" type="BSGeometrySubSegment" arr1="Num Sub Segments" userver2="130" />
+    </compound>
+
     <niobject name="BSSegmentedTriShape" inherit="NiTriShape">
         Bethesda-specific AV object.
         <add name="Num Segments" type="int" >Number of segments in the square grid</add>
@@ -6979,33 +6992,18 @@
         <add name="LOD2 Size" type="uint" />
     </niobject>
     
-    <compound name="BSSITSSubSegment">
-        <add name="Start Index" type="uint" />
-        <add name="Num Primitives" type="uint" />
-        <add name="Parent Array Index" type="uint" />
-        <add name="Unknown Int 1" type="uint" />
-    </compound>
-    
-    <compound name="BSSITSSegment">
-        <add name="Start Index" type="uint" />
-        <add name="Num Primitives" type="uint" />
-        <add name="Parent Array Index" type="uint" />
-        <add name="Num Sub Segments" type="uint" />
-        <add name="Sub Segment" type="BSSITSSubSegment" arr1="Num Sub Segments" />
+    <compound name="BSGeometryPerSegmentSharedData">
+        <add name="User Index" type="uint">If Bone ID is 0xffffffff, this value refers to the Segment at the listed index. Otherwise this is the "Biped Object", which is like the body part types in Skyrim and earlier.</add>
+        <add name="Bone ID" type="uint">A hash of the bone name string.</add>
+        <add name="Num Cut Offsets" type="uint">Maximum of 8.</add>
+        <add name="Cut Offsets" type="float" arr1="Num Cut Offsets" />
     </compound>
 
-    <compound name="BSSITSSubSegmentData">
-        <add name="Segment/User" type="uint">If Unknown Int 2 is 0xffffffff, this value refers to the Segment at the listed index.</add>
-        <add name="Unknown Int 2" type="uint" />
-        <add name="Num Data" type="uint" />
-        <add name="Extra Data" type="float" arr1="Num Data" />
-    </compound>
-
-    <compound name="BSSITSSubSegmentRecord">
+    <compound name="BSGeometrySegmentSharedData">
         <add name="Num Segments" type="uint" />
         <add name="Total Segments" type="uint" />
-        <add name="Array Indices" type="uint" arr1="Num Segments" />
-        <add name="Sub Segments" type="BSSITSSubSegmentData" arr1="Total Segments" />
+        <add name="Segment Starts" type="uint" arr1="Num Segments" />
+        <add name="Per Segment Data" type="BSGeometryPerSegmentSharedData" arr1="Total Segments" />
         <!-- TODO: Actual ShortString type (current "ShortString" is actually a byte) -->
         <add name="SSF Length" type="ushort" />
         <add name="SSF File" type="byte" arr1="SSF Length" />
@@ -7016,10 +7014,10 @@
 		<add name="Num Primitives" type="uint" userver2="130" cond="Data Size &gt; 0" />
 		<add name="Num Segments" type="uint" userver2="130" cond="Data Size &gt; 0" />
 		<add name="Total Segments" type="uint" userver2="130" cond="Data Size &gt; 0" />
-		<add name="Segment" suffix="FO4" type="BSSITSSegment" userver2="130" arr1="Num Segments" cond="Data Size &gt; 0" />
-		<add name="Sub Segment Data" type="BSSITSSubSegmentRecord" userver2="130" cond="(Num Segments &lt; Total Segments) &amp;&amp; (Data Size &gt; 0)" />
+		<add name="Segment" type="BSGeometrySegmentData" userver2="130" arr1="Num Segments" cond="Data Size &gt; 0" />
+		<add name="Segment Data" type="BSGeometrySegmentSharedData" userver2="130" cond="(Num Segments &lt; Total Segments) &amp;&amp; (Data Size &gt; 0)" />
 		<add name="Num Segments" type="uint" userver2="100" />
-		<add name="Segment" suffix="SSE" type="BSGeometrySegmentData" userver2="100" arr1="Num Segments" />
+		<add name="Segment" type="BSGeometrySegmentData" userver2="100" arr1="Num Segments" />
     </niobject>
     
     <!-- Fallout 4 Physics -->

--- a/nif.xml
+++ b/nif.xml
@@ -6285,59 +6285,58 @@
 
     <niobject name="NiSkinningLODController" inherit="NiTimeController">
     </niobject>
-    
-    <!-- This and NiPSMeshParticleSystem may inherit from something else -->
-    <niobject name="NiPSParticleSystem" inherit="NiAVObject">
-        <!-- note: Unknonw 1 and 2 already in use by NiAVObject -->
-        <add name="Unknown 3" type="int">0?</add>
-        <add name="Unknown 38" type="int" arr1="Unknown 3"></add>
-        <add name="Unknown 4" type="int">-1?</add>
-        <add name="Unknown 5" type="int">0?</add>
-        <add name="Unknown 39" type="int" arr1="Unknown 3"></add>
-        <add name="Unknown 6" type="int">256?</add>
-        <add name="Unknown 7" type="int">0?</add>
-        <add name="Unknown 8" type="int">0?</add>
-        <add name="Unknown 9" type="int">0?</add>
-        <add name="Unknown 10" type="float">0?</add>
-        <add name="Unknown 11" type="int">0?</add>
-        <add name="Unknown 12" type="int">Counter?</add>
-        <add name="Simulator" type="Ref" template="NiObject">Simulator?</add>
-        <add name="Generator" type="Ref" template="NiObject" cond="Unknown 12 > 1">Generator?</add>
-        <add name="Unknown 15" type="int">Simulator?</add>
-        <add name="Unknown 16" type="int">Updater?</add>
-        <add name="Unknown 17" type="int">1?</add>
-        <add name="Emitter" type="Ref" template="NiObject">Emitter?</add>
-        <add name="Unknown 19" type="int">0?</add>
-        <add name="Unknown 20" type="int">Spawner?</add>
-        <add name="Unknown 21" type="int">Unknown</add>
-        <add name="Unknown 22" type="byte" arr1="4">Unknown</add>
-        <add name="Unknown 27" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 28" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 29" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 30" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 31" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 32" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 33" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 34" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 35" type="byte" ver1="30.0.0.2"></add>
-        <add name="Unknown 36" type="int" ver1="30.0.0.2">-1?</add>
-        <add name="Unknown 37" type="short" ver1="30.0.0.2"></add>
+
+
+    <!-- NiPS Particle System -->
+
+    <compound name="PSSpawnRateKey">
+        <add name="Value" type="float" />
+        <add name="Time" type="float" />
+    </compound>
+
+    <enum name="AlignMethod" storage="uint">
+        <option value="0" name="ALIGN_INVALID" />
+        <option value="1" name="ALIGN_PER_PARTICLE" />
+        <option value="2" name="ALIGN_LOCAL_FIXED" />
+        <option value="5" name="ALIGN_LOCAL_POSITION" />
+        <option value="9" name="ALIGN_LOCAL_VELOCITY" />
+        <option value="16" name="ALIGN_CAMERA" />
+    </enum>
+
+    <niobject name="NiPSParticleSystem" inherit="NiMesh">
+        <add name="Simulator" type="Ref" template="NiPSSimulator" />
+        <add name="Generator" type="Ref" template="NiPSBoundUpdater" />
+        <add name="Num Emitters" type="uint" />
+        <add name="Emitters" type="Ref" template="NiPSEmitter" arr1="Num Emitters" />
+        <add name="Num Spawners" type="uint" />
+        <add name="Spawners" type="Ref" template="NiPSSpawner" arr1="Num Spawners" />
+        <add name="Death Spawner" type="Ref" template="NiPSSpawner" />
+        <add name="Max Num Particles" type="uint" />
+        <add name="Has Colors" type="bool" />
+        <add name="Has Rotations" type="bool" />
+        <add name="Has Rotation Axes" type="bool" />
+        <add name="Has Animated Textures" type="bool" ver1="20.6.1.0" />
+        <add name="World Space" type="bool" />
+        <add name="Normal Method" type="AlignMethod" ver1="20.6.1.0" />
+        <add name="Normal Direction" type="Vector3" ver1="20.6.1.0" />
+        <add name="Up Method" type="AlignMethod" ver1="20.6.1.0" />
+        <add name="Up Direction" type="Vector3" ver1="20.6.1.0" />
+        <add name="Living Spawner" type="Ref" template="NiPSSpawner" ver1="20.6.1.0" />
+        <add name="Num Spawn Rate Keys" type="byte" ver1="20.6.1.0" />
+        <add name="Spawn Rate Keys" type="PSSpawnRateKey" arr1="Num Spawn Rate Keys" ver1="20.6.1.0" />
+        <add name="Pre-RPI" type="bool" ver1="20.6.1.0" />
     </niobject>
 
     <niobject name="NiPSMeshParticleSystem" inherit="NiPSParticleSystem">
-        <add name="Unknown 23" type="int"></add>
-        <add name="Unknown 24" type="int">Unknown - may or may not be emitted mesh?</add>
-        <add name="Unknown 25" type="int"></add>
-        <add name="Unknown 26" type="byte"></add>
+        <add name="Num Generations" type="uint" />
+        <add name="Master Particles" type="Ref" template="NiAVObject" arr1="Num Generations" />
+        <add name="Pool Size" type="uint" />
+        <add name="Auto-Fill Pools" type="bool" />
     </niobject>
 
-    <niobject name="NiPSEmitParticlesCtlr" inherit="NiPSysEmitterCtlr">
-    </niobject>
+    <!-- NiPS Generators -->
 
-    <niobject name="NiPSForceActiveCtlr" inherit="NiTimeController">
-        <add name="Interpolator" type="Ref" template="NiObject"></add>
-        <add name="Unknown 2" type="int"></add>
-    </niobject>
+    <niobject name="NiPSFacingQuadGenerator" inherit="NiMeshModifier" />
 
     <niobject name="NiPSAlignedQuadGenerator" inherit="NiMeshModifier">
         <add name="Scale Amount U" type="float" />
@@ -6360,6 +6359,8 @@
         <add name="Final Time" type="float" />
     </niobject>
 
+    <!-- NiPS Simulators -->
+
     <niobject name="NiPSSimulator" inherit="NiMeshModifier">
         The mesh modifier that performs all particle system simulation.
         <add name="Num Simulation Steps" type="uint">The number of simulation steps in this modifier.</add>
@@ -6380,25 +6381,19 @@
 
     <niobject name="NiPSSimulatorGeneralStep" inherit="NiPSSimulatorStep">
         Encapsulates a floodgate kernel that updates particle size, colors, and rotations.
-        <!-- note: the ver2="30.0.0.2" conditions below are just guesses -->
-        <add name="Num Size Keys" type="byte">The number of size animation keys.</add>
-        <add name="Size Keys" type="Key" template="float" arg="1" arr1="Num Size Keys">The particle size keys.</add>
-        <add name="Size Loop Behavior" type="PSLoopBehavior" ver1="30.0.0.2">The loop behavior for the size keys.</add>
-
-        <add name="Unknown 1" type="float" ver2="20.6.0.0" />
-        <add name="Unknown 2" type="float" ver2="20.6.0.0" />
-        <add name="Unknown 3" type="float" ver2="20.6.0.0" />
-
-        <add name="Num Color Keys" type="byte" ver1="30.0.0.2">The number of color animation keys.</add>
-        <add name="Color Keys" type="Key" template="ByteColor4" arg="1" arr1="Num Color Keys" ver1="30.0.0.2">The particle color keys.</add>
-        <add name="Color Loop Behavior" type="PSLoopBehavior" ver1="30.0.0.2">The loop behavior for the color keys.</add>
-        <add name="Num Rotation Keys" type="byte" ver1="30.0.0.2">The number of rotatoin animation keys.</add>
-        <add name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys" ver1="30.0.0.2">The particle rotation keys.</add>
-        <add name="Rotation Loop Behavior" type="PSLoopBehavior" ver1="30.0.0.2">The loop behavior for the rotation keys.</add>
-        <add name="Grow Time" type="float" ver1="30.0.0.2"> The the amount of time over which a particle's size is ramped from 0.0 to 1.0 in seconds</add>
-        <add name="Shrink Time" type="float" ver1="30.0.0.2">The the amount of time over which a particle's size is ramped from 1.0 to 0.0 in seconds</add>
-        <add name="Grow Generation" type="ushort" ver1="30.0.0.2">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</add>
-        <add name="Shrink Generation" type="ushort" ver1="30.0.0.2">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system, so that particles will shrink immediately before getting killed.</add>
+        <add name="Num Size Keys" type="byte" ver1="20.6.1.0">The number of size animation keys.</add>
+        <add name="Size Keys" type="Key" template="float" arg="1" arr1="Num Size Keys" ver1="20.6.1.0">The particle size keys.</add>
+        <add name="Size Loop Behavior" type="PSLoopBehavior" ver1="20.6.1.0">The loop behavior for the size keys.</add>
+        <add name="Num Color Keys" type="byte">The number of color animation keys.</add>
+        <add name="Color Keys" type="Key" template="ByteColor4" arg="1" arr1="Num Color Keys">The particle color keys.</add>
+        <add name="Color Loop Behavior" type="PSLoopBehavior" ver1="20.6.1.0">The loop behavior for the color keys.</add>
+        <add name="Num Rotation Keys" type="byte" ver1="20.6.1.0">The number of rotation animation keys.</add>
+        <add name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys" ver1="20.6.1.0">The particle rotation keys.</add>
+        <add name="Rotation Loop Behavior" type="PSLoopBehavior" ver1="20.6.1.0">The loop behavior for the rotation keys.</add>
+        <add name="Grow Time" type="float"> The the amount of time over which a particle's size is ramped from 0.0 to 1.0 in seconds</add>
+        <add name="Shrink Time" type="float">The the amount of time over which a particle's size is ramped from 1.0 to 0.0 in seconds</add>
+        <add name="Grow Generation" type="ushort">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</add>
+        <add name="Shrink Generation" type="ushort">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system, so that particles will shrink immediately before getting killed.</add>
     </niobject>
 
     <niobject name="NiPSSimulatorForcesStep" inherit="NiPSSimulatorStep">
@@ -6424,293 +6419,186 @@
         Encapsulates a floodgate kernel that updates particle positions and ages. As indicated by its name, this step should be attached last in the NiPSSimulator mesh modifier.
     </niobject>
 
-    <niobject name="NiPSFacingQuadGenerator" inherit="NiObject">
-        <add name="Unknown 1" type="byte"></add>
-        <add name="Unknown 2" type="byte"></add>
-        <add name="Unknown 3" type="byte"></add>
-        <add name="Unknown 4" type="byte"></add>
-        <add name="Unknown 5" type="byte"></add>
-        <add name="Unknown 6" type="byte"></add>
-        <add name="Unknown 7" type="byte"></add>
-        <add name="Unknown 8" type="byte"></add>
-        <add name="Unknown 9" type="byte"></add>
-        <add name="Unknown 10" type="byte"></add>
-        <add name="Unknown 11" type="byte"></add>
-        <add name="Unknown 12" type="byte"></add>
-    </niobject>
-
-    <!-- from Zorsis demo (Scene.nif) -->
-    <niobject name="NiShadowGenerator" inherit="NiObject">
-        <!-- inheritance? -->
-        <add name="Name" type="string" />
-        <add name="Unknown Flags" type="ushort" />
-        <add name="Num Unknown Links 1" type="uint" />
-        <add name="Unknown Links 1" type="Ref" template="NiNode" arr1="Num Unknown Links 1" />
-        <add name="Unkown Int 2" type="int" default="0" />
-        <add name="Target" type="Ptr" template="NiLight" />
-        <add name="Unkown Float 4" type="float" default="0.98" />
-        <add name="Unkown Byte 5" type="byte" default="0" />
-        <add name="Unkown Int 6" type="int" default="2" />
-        <add name="Unkown Int 7" type="int" default="0" />
-        <add name="Unkown Int 8" type="int" default="0" />
-        <add name="Unkown Byte 9" type="byte" default="0" />
-    </niobject>
-
     <niobject name="NiPSBoundUpdater" inherit="NiObject">
-        <add name="Unknown 1" type="byte"></add>
-        <add name="Unknown 2" type="byte"></add>
+        <add name="Update Skip" type="ushort">Number of particle bounds to skip updating every frame. Higher = more updates each frame.</add>
     </niobject>
 
-    <niobject name="NiPSDragForce" inherit="NiObject">
-        <add name="Unknown 1" type="int"></add>
-        <add name="Unknown 2" type="int"></add>
-        <add name="Unknown 3" type="byte"></add>
-        <add name="Unknown 4" type="float"></add>
-        <add name="Unknown 5" type="float"></add>
-        <add name="Unknown 6" type="float"></add>
-        <add name="Unknown 7" type="float"></add>
-        <add name="Unknown 8" type="float"></add>
-        <add name="Unknown 9" type="float"></add>
-        <add name="Unknown 10" type="int"></add>
-    </niobject>
+    <!-- NiPS Forces -->
 
-    <niobject name="NiPSGravityForce" inherit="NiObject">
-        <add name="Unknown 1" type="byte"></add>
-        <add name="Unknown 2" type="byte"></add>
-        <add name="Unknown 3" type="byte"></add>
-        <add name="Unknown 4" type="byte"></add>
-        <add name="Unknown 5" type="byte"></add>
-        <add name="Unknown 6" type="byte"></add>
-        <add name="Unknown 7" type="byte"></add>
-        <add name="Unknown 8" type="byte"></add>
-        <add name="Unknown 9" type="byte"></add>
-        <add name="Unknown 10" type="byte"></add>
-        <add name="Unknown 11" type="byte"></add>
-        <add name="Unknown 12" type="byte"></add>
-        <add name="Unknown 13" type="byte"></add>
-        <add name="Unknown 14" type="byte"></add>
-        <add name="Unknown 15" type="byte"></add>
-        <add name="Unknown 16" type="byte"></add>
-        <add name="Unknown 17" type="byte"></add>
-        <add name="Unknown 18" type="float"></add>
-        <add name="Unknown 19" type="byte"></add>
-        <add name="Unknown 20" type="byte"></add>
-        <add name="Unknown 21" type="byte"></add>
-        <add name="Unknown 22" type="byte"></add>
-        <add name="Unknown 23" type="byte"></add>
-        <add name="Unknown 24" type="byte"></add>
-        <add name="Unknown 25" type="byte"></add>
-        <add name="Unknown 26" type="byte"></add>
-        <add name="Unknown 27" type="byte"></add>
-        <add name="Unknown 28" type="byte"></add>
-        <add name="Unknown 29" type="byte"></add>
-        <add name="Unknown 30" type="byte"></add>
-        <add name="Unknown 31" type="byte"></add>
-        <add name="Unknown 32" type="byte"></add>
-        <add name="Unknown 33" type="byte"></add>
-        <add name="Unknown 34" type="byte"></add>
-        <add name="Unknown 35" type="float"></add>
-        <add name="Unknown 36" type="Ref" template="NiObject">Gravity node?</add>
-    </niobject>
+    <enum name="PSForceType" storage="uint">
+        <option value="0" name="FORCE_BOMB" />
+        <option value="1" name="FORCE_DRAG" />
+        <option value="2" name="FORCE_AIR_FIELD" />
+        <option value="3" name="FORCE_DRAG_FIELD" />
+        <option value="4" name="FORCE_GRAVITY_FIELD" />
+        <option value="5" name="FORCE_RADIAL_FIELD" />
+        <option value="6" name="FORCE_TURBULENCE_FIELD" />
+        <option value="7" name="FORCE_VORTEX_FIELD" />
+        <option value="8" name="FORCE_GRAVITY" />
+    </enum>
 
-    <niobject name="NiPSBoxEmitter" inherit="NiObject">
-        <add name="Name" type="string"></add>
-        <add name="Unknown 1" type="float"></add>
-        <add name="Unknown 2" type="float"></add>
-        <add name="Unknown 3" type="byte"></add>
-        <add name="Unknown 4" type="byte"></add>
-        <add name="Unknown 5" type="byte"></add>
-        <add name="Unknown 6" type="byte"></add>
-        <add name="Unknown 7" type="float"></add>
-        <add name="Unknown 8" type="byte"></add>
-        <add name="Unknown 9" type="byte"></add>
-        <add name="Unknown 10" type="byte"></add>
-        <add name="Unknown 11" type="byte"></add>
-        <add name="Unknown 12" type="float"></add>
-        <add name="Unknown 13" type="int"></add>
-        <add name="Unknown 14" type="float"></add>
-        <add name="Unknown 15" type="float"></add>
-        <add name="Unknown 16" type="float"></add>
-        <add name="Unknown 17" type="float"></add>
-        <add name="Unknown 18" type="float"></add>
-        <add name="Unknown 19" type="float"></add>
-        <add name="Unknown 20" type="float"></add>
-        <add name="Unknown 21" type="float"></add>
-        <add name="Unknown 22" type="float"></add>
-        <add name="Unknown 23" type="byte"></add>
-        <add name="Unknown 24" type="byte"></add>
-        <add name="Unknown 25" type="byte"></add>
-        <add name="Unknown 26" type="byte"></add>
-        <add name="Unknown 27" type="byte"></add>
-        <add name="Unknown 28" type="byte"></add>
-        <add name="Unknown 29" type="byte"></add>
-        <add name="Unknown 30" type="byte"></add>
-        <add name="Unknown 31" type="byte"></add>
-        <add name="Unknown 32" type="byte"></add>
-        <add name="Unknown 33" type="byte"></add>
-        <add name="Unknown 34" type="byte"></add>
-        <add name="Unknown 35" type="byte"></add>
-        <add name="Unknown 36" type="byte"></add>
-        <add name="Unknown 37" type="byte"></add>
-        <add name="Unknown 38" type="byte"></add>
-        <add name="Unknown 39" type="byte"></add>
-        <add name="Unknown 40" type="byte"></add>
-        <add name="Unknown 41" type="byte"></add>
-        <add name="Unknown 42" type="byte"></add>
-        <add name="Unknown 43" type="byte"></add>
-        <add name="Unknown 44" type="byte"></add>
-        <add name="Unknown 45" type="byte"></add>
-        <add name="Unknown 46" type="byte"></add>
-        <add name="Unknown 47" type="byte"></add>
-        <add name="Unknown 48" type="byte"></add>
-    </niobject>
-
-    <niobject name="NiPSMeshEmitter" inherit="NiObject">
-        <add name="Name" type="string"></add>
-        <add name="Unknown 1" type="int"></add>
-        <add name="Unknown 2" type="int"></add>
-        <add name="Unknown 3" type="int"></add>
-        <add name="Unknown 27" type="int" ver1="30.0.0.2"></add>
-        <add name="Unknown 4" type="float"></add>
-        <add name="Unknown 5" type="float"></add>
-        <add name="Unknown 6" type="float"></add>
-        <add name="Unknown 28" type="float" ver1="30.0.0.2"></add>
-        <add name="Unknown 7" type="int"></add>
-        <add name="Unknown 8" type="float"></add>
-        <add name="Unknown 9" type="float"></add>
-        <add name="Unknown 10" type="float"></add>
-        <add name="Unknown 11" type="float"></add>
-        <add name="Unknown 12" type="float"></add>
-        <add name="Unknown 13" type="int"></add>
-        <add name="Unknown 14" type="float"></add>
-        <add name="Unknown 15" type="float"></add>
-        <add name="Unknown 16" type="float"></add>
-        <add name="Unknown 17" type="int" ver2="20.6.0.0"></add>
-        <add name="Unknown 18" type="int" ver2="20.6.0.0"></add>
-        <add name="Unknown 19" type="short"></add>
-        <add name="Unknown 20" type="int"></add>
-        <add name="Unknown 21" type="int"></add>
-        <add name="Unknown 22" type="float" ver2="20.6.0.0"></add>
-        <add name="Unknown 23" type="int" ver2="20.6.0.0"></add>
-        <add name="Unknown 24" type="int"></add>
-        <add name="Unknown 25" type="int"></add>
-        <add name="Unknown 26" type="int"></add>
-    </niobject>
-
-    <niobject name="NiPSGravityStrengthCtlr" inherit="NiTimeController">
-        <add name="Unknown 2" type="int"></add>
-        <add name="Unknown 3" type="int"></add>
-    </niobject>
-
-    <niobject name="NiPSPlanarCollider" inherit="NiObject">
-        <!-- inheritance? -->
+    <niobject name="NiPSForce" abstract="1" inherit="NiObject">
         <add name="Name" type="string" />
-        <add name="Unknown Int 1" type="int" />
-        <add name="Unknown Int 2" type="int" />
-        <add name="Unknown Short 3" type="short" />
-        <add name="Unknown Byte 4" type="byte" />
-        <add name="Unknown Floats 5" type="float" arr1="8" />
-        <add name="Unknown Link 6" type="Ref" template="NiNode" />
+        <add name="Type" type="PSForceType" />
+        <add name="Active" type="bool" />
     </niobject>
 
-    <niobject name="NiPSEmitterSpeedCtlr" inherit="NiTimeController">
-        <add name="Interpolator" type="Ref" template="NiObject"></add>
-        <add name="Unknown 3" type="int"></add>
+    <niobject name="NiPSDragForce" inherit="NiPSForce">
+        <add name="Drag Axis" type="Vector3" />
+        <add name="Percentage" type="float" />
+        <add name="Range" type="float" />
+        <add name="Range Falloff" type="float" />
+        <add name="Drag Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
-    <!-- from Zorsis demo (hit_effect_meaty.nif) -->
-    <niobject name="NiPSEmitterRadiusCtlr" inherit="NiTimeController">
-        <add name="Interpolator" type="Ref" template="NiObject"></add>
-        <add name="Unknown 2" type="int"></add>
+    <niobject name="NiPSGravityForce" inherit="NiPSForce">
+        <add name="Gravity Axis" type="Vector3" />
+        <add name="Decay" type="float" />
+        <add name="Strength" type="float" />
+        <add name="Force Type" type="ForceType" />
+        <add name="Turbulence" type="float" />
+        <add name="Turbulence Scale" type="float" />
+        <add name="Gravity Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
-    <!-- from Zorsis demo (hit_effect_metal.nif) -->
-    <niobject name="NiPSResetOnLoopCtlr" inherit="NiTimeController">
+    <niobject name="NiPSBombForce" inherit="NiPSForce">
+        <add name="Bomb Axis" type="Vector3" />
+        <add name="Decay" type="float" />
+        <add name="Delta V" type="float" />
+        <add name="Decay Type" type="DecayType" />
+        <add name="Symmetry Type" type="SymmetryType" />
+        <add name="Bomb Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
-    <niobject name="NiPSSphereEmitter" inherit="NiObject">
-        <add name="Name" type="string"></add>
-        <add name="Unknown 2" type="int"></add>
-        <add name="Unknown 3" type="int"></add>
-        <add name="Unknown 4" type="int"></add>
-        <add name="Unknown 5" type="int"></add>
-        <add name="Unknown 6" type="float"></add>
-        <add name="Unknown 7" type="int"></add>
-        <add name="Unknown 8" type="float"></add>
-        <add name="Unknown 9" type="float"></add>
-        <add name="Unknown 10" type="int"></add>
-        <add name="Unknown 11" type="float"></add>
-        <add name="Unknown 12" type="int"></add>
-        <add name="Unknown 13" type="int"></add>
-        <add name="Unknown 14" type="int"></add>
-        <add name="Unknown 15" type="int"></add>
-        <add name="Unknown 16" type="int"></add>
-        <add name="Unknown 17" type="float"></add>
-        <add name="Unknown 18" type="int"></add>
-        <add name="Unknown 19" type="int"></add>
-        <add name="Unknown 20" type="short"></add>
-        <add name="Unknown 21" type="int">Target node?</add>
-        <add name="Unknown 22" type="float"></add>
-    </niobject>
-    
-    <niobject name="NiPSCylinderEmitter" inherit="NiPSSphereEmitter">
-        <add name="Unknown 23" type="float"></add>
-    </niobject>
-    
-    <niobject name="NiPSEmitterDeclinationCtlr" inherit="NiPSysModifierCtlr">
-    </niobject>
-    
-    <niobject name="NiPSEmitterDeclinationVarCtlr" inherit="NiPSEmitterDeclinationCtlr">
-    </niobject>
-    
-    <niobject name="NiPSEmitterPlanarAngleCtlr" inherit="NiPSysModifierCtlr">
-    </niobject>
-    
-    <niobject name="NiPSEmitterPlanarAngleVarCtlr" inherit="NiPSEmitterPlanarAngleCtlr">
-    </niobject>
-    
-    <niobject name="NiPSEmitterRotAngleCtlr" inherit="NiPSysModifierCtlr">
-    </niobject>
-    
-    <niobject name="NiPSEmitterRotAngleVarCtlr" inherit="NiPSEmitterRotAngleCtlr">
-    </niobject>
-    
-    <niobject name="NiPSEmitterRotSpeedCtlr" inherit="NiPSysModifierCtlr">
+    <!-- NiPS Emitters -->
+
+    <niobject name="NiPSEmitter" abstract="1" inherit="NiObject">
+        <add name="Name" type="string" />
+        <add name="Speed" type="float" />
+        <add name="Speed Var" type="float" />
+        <add name="Speed Flip Ratio" type="float" ver1="20.6.1.0" />
+        <add name="Declination" type="float" />
+        <add name="Declination Var" type="float" />
+        <add name="Planar Angle" type="float" />
+        <add name="Planar Angle Var" type="float" />
+        <add name="Color" type="ByteColor4" ver2="20.6.0.0" />
+        <add name="Size" type="float" />
+        <add name="Size Var" type="float" />
+        <add name="Lifespan" type="float" />
+        <add name="Lifespan Var" type="float" />
+        <add name="Rotation Angle" type="float" />
+        <add name="Rotation Angle Var" type="float" />
+        <add name="Rotation Speed" type="float" />
+        <add name="Rotation Speed Var" type="float" />
+        <add name="Rotation Axis" type="Vector3" />
+        <add name="Random Rot Speed Sign" type="bool" />
+        <add name="Random Rot Axis" type="bool" />
+        <add name="Unknown" type="bool" ver1="30.0.0.0" ver2="30.0.0.1" />
     </niobject>
 
-    <niobject name="NiPSEmitterRotSpeedVarCtlr" inherit="NiPSEmitterRotSpeedCtlr">
+    <niobject name="NiPSVolumeEmitter" abstract="1" inherit="NiPSEmitter">
+        <add name="Emitter Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
-    <niobject name="NiPSEmitterLifeSpanCtlr" inherit="NiPSysModifierCtlr">
+    <niobject name="NiPSBoxEmitter" inherit="NiPSVolumeEmitter">
+        <add name="Emitter Width" type="float" />
+        <add name="Emitter Height" type="float" />
+        <add name="Emitter Depth" type="float" />
     </niobject>
 
-    <niobject name="NiPSBombForce" inherit="NiObject">
-        <add name="Name" type="string"></add>
-        <add name="Unknown 1" type="byte"></add>
-        <add name="Unknown 2" type="int"></add>
-        <add name="Unknown 3" type="int"></add>
-        <add name="Unknown 4" type="int"></add>
-        <add name="Unknown 5" type="int"></add>
-        <add name="Unknown 6" type="int"></add>
-        <add name="Unknown 7" type="int"></add>
-        <add name="Unknown 8" type="int"></add>
-        <add name="Unknown 9" type="int"></add>
-        <add name="Unknown 10" type="int"></add>
+    <niobject name="NiPSSphereEmitter" inherit="NiPSVolumeEmitter">
+        <add name="Emitter Radius" type="float" />
     </niobject>
 
-    <niobject name="NiPSSphericalCollider" inherit="NiObject"><!-- possibly inherit="NiPSysSphericalCollider"? -->
-        <add name="Unknown 1" type="int"></add>
-        <add name="Unknown 2" type="int"></add>
-        <add name="Unknown 3" type="byte"></add>
-        <add name="Unknown 4" type="float"></add>
-        <add name="Unknown 5" type="int"></add>
-        <add name="Unknown 6" type="short"></add>
-        <add name="Unknown 7" type="int"></add>
+    <niobject name="NiPSCylinderEmitter" inherit="NiPSVolumeEmitter">
+        <add name="Emitter Radius" type="float" />
+        <add name="Emitter Height" type="float" />
+    </niobject>
+
+    <niobject name="NiPSMeshEmitter" inherit="NiPSEmitter">
+        <add name="Num Mesh Emitters" type="uint" />
+        <add name="Mesh Emitters" type="Ptr" template="NiMesh" arr1="Num Mesh Emitters" />
+        <add name="Emit Axis" type="Vector3" ver2="20.6.0.0" />
+        <add name="Emitter Object" type="Ptr" template="NiAVObject" ver1="20.6.1.0" />
+        <add name="Mesh Emission Type" type="EmitFrom" />
+        <add name="Initial Velocity Type" type="VelocityType" />
+    </niobject>
+
+    <!-- NiPS Controllers -->
+
+    <niobject name="NiPSEmitterCtlr" abstract="1" inherit="NiSingleInterpController">
+        <add name="Emitter Name" type="string" />
+    </niobject>
+
+    <niobject name="NiPSEmitterFloatCtlr" abstract="1" inherit="NiPSEmitterCtlr" />
+
+    <niobject name="NiPSEmitParticlesCtlr" inherit="NiPSEmitterCtlr">
+        <add name="Emitter Active Interpolator" type="Ref" template="NiInterpolator" />
+    </niobject>
+
+    <niobject name="NiPSForceCtlr" abstract="1" inherit="NiSingleInterpController">
+        <add name="Force Name" type="string" />
+    </niobject>
+
+    <niobject name="NiPSForceBoolCtlr" inherit="NiPSForceCtlr" />
+    <niobject name="NiPSForceFloatCtlr" inherit="NiPSForceCtlr" />
+    <niobject name="NiPSForceActiveCtlr" inherit="NiPSForceBoolCtlr" />
+    <niobject name="NiPSGravityStrengthCtlr" inherit="NiPSForceFloatCtlr" />
+    <niobject name="NiPSEmitterSpeedCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterRadiusCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSResetOnLoopCtlr" inherit="NiTimeController" />
+    <niobject name="NiPSEmitterDeclinationCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterDeclinationVarCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterPlanarAngleCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterPlanarAngleVarCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterRotAngleCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterRotAngleVarCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterRotSpeedCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterRotSpeedVarCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSEmitterLifeSpanCtlr" inherit="NiPSEmitterFloatCtlr" />
+
+    <!-- NiPS Colliders -->
+
+    <enum name="ColliderType" storage="uint">
+        <option value="0" name="COLLIDER_PLANAR" />
+        <option value="1" name="COLLIDER_SPHERICAL" />
+    </enum>
+
+    <niobject name="NiPSCollider" inherit="NiObject">
+        <add name="Spawner" type="Ref" template="NiPSSpawner" />
+        <add name="Type" type="ColliderType" />
+        <add name="Active" type="bool" />
+        <add name="Bounce" type="float" />
+        <add name="Spawn on Collide" type="bool" />
+        <add name="Die on Collide" type="bool" />
+    </niobject>
+
+    <niobject name="NiPSPlanarCollider" inherit="NiPSCollider">
+        <add name="Width" type="float" />
+        <add name="Height" type="float" />
+        <add name="X Axis" type="Vector3" />
+        <add name="Y Axis" type="Vector3" />
+        <add name="Collider Object" type="Ptr" template="NiAVObject" />
+    </niobject>
+
+    <niobject name="NiPSSphericalCollider" inherit="NiPSCollider">
+        <add name="Radius" type="float" />
+        <add name="Collider Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
     <niobject name="NiPSSpawner" inherit="NiObject">
-        <!-- not yet decoded -->
+        <add name="Master Particle System" type="Ptr" template="NiPSParticleSystem" ver1="20.6.1.0" />
+        <add name="Percentage Spawned" type="float" />
+        <add name="Spawn Speed Factor" type="float" ver1="20.6.1.0" />
+        <add name="Spawn Speed Factor Var" type="float" />
+        <add name="Spawn Dir Chaos" type="float" />
+        <add name="Life Span" type="float" />
+        <add name="Life Span Var" type="float" />
+        <add name="Num Spawn Generations" type="ushort" />
+        <add name="Min to Spawn" type="uint" />
+        <add name="Max to Spawn" type="uint" />
     </niobject>
+
 
     <niobject name="NiSequenceData" inherit="NiObject">
         <!-- not yet decoded -->

--- a/nif.xml
+++ b/nif.xml
@@ -43,7 +43,8 @@
     <version num="20.6.5.0">Epic Mickey</version>
     <version num="30.0.0.2">Emerge</version>
     <version num="30.1.0.3">Rocksmith, Rocksmith 2014</version>
-    
+    <version num="30.2.0.3"></version>
+
     <!--Basic Types-->
 
     <basic name="bool" count="1" niflibtype="bool">

--- a/nif.xml
+++ b/nif.xml
@@ -4419,6 +4419,13 @@
         A texture.
     </niobject>
 
+    <compound name="FormatPrefs">
+        NiTexture::FormatPrefs. These preferences are a request to the renderer to use a format the most closely matches the settings and may be ignored.
+        <add name="Pixel Layout" type="PixelLayout">Requests the way the image will be stored.</add>
+        <add name="Use Mipmaps" type="MipMapFormat" default="MIP_FMT_DEFAULT">Requests if mipmaps are used or not.</add>
+        <add name="Alpha Format" type="AlphaFormat" default="ALPHA_DEFAULT">Requests no alpha, 1-bit alpha, or </add>
+    </compound>
+
     <niobject name="NiSourceTexture" abstract="0" inherit="NiTexture">
         Describes texture source and properties.
         <add name="Use External" type="byte" default="1">Is the texture external?</add>
@@ -4426,13 +4433,11 @@
         <add name="Unknown Link" type="Ref" template="NiObject" cond="Use External == 1" ver1="10.1.0.0">Unknown.</add>
         <add name="Unknown Byte" type="byte" default="1" cond="Use External == 0" ver2="10.0.1.0">Unknown. Seems to be set if Pixel Data is present?</add>
         <add name="File Name" type="FilePath" cond="Use External == 0" ver1="10.1.0.0">The original source filename of the image embedded by the referred NiPixelData object.</add>
-        <add name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0">Pixel data object index. NiPixelData or NiPersistentSrcTextureRendererData</add>
-        <add name="Pixel Layout" type="PixelLayout" default="PIX_LAY_PALETTISED_4">Specifies the way the image will be stored.</add>
-        <add name="Use Mipmaps" type="MipMapFormat" default="MIP_FMT_DEFAULT">Specifies whether mip maps are used.</add>
-        <add name="Alpha Format" type="AlphaFormat" default="ALPHA_DEFAULT"> Note: the NiTriShape linked to this object must have a NiAlphaProperty in its list of properties to enable material and/or texture transparency.</add>
-        <add name="Is Static" type="byte" default="1">Is Static?</add>
-        <add name="Direct Render" type="bool" default="1" ver1="10.1.0.103">Load direct to renderer</add>
-        <add name="Persist Render Data" type="bool" default="0" ver1="20.2.0.4">Render data is persistant</add>
+        <add name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0">NiPixelData or NiPersistentSrcTextureRendererData</add>
+        <add name="Format Prefs" type="FormatPrefs">A set of preferences for the texture format. They are a request only and the renderer may ignore them.</add>
+        <add name="Is Static" type="byte" default="1">If set, then the application cannot assume that any dynamic changes to the pixel data will show in the rendered image.</add>
+        <add name="Direct Render" type="bool" default="1" ver1="10.1.0.103">A hint to the renderer that the texture can be loaded directly from a texture file into a renderer-specific resource, bypassing the NiPixelData object.</add>
+        <add name="Persist Render Data" type="bool" default="0" ver1="20.2.0.4">Pixel Data is NiPersistentSrcTextureRendererData instead of NiPixelData.</add>
     </niobject>
 
     <niobject name="NiSpecularProperty" abstract="0" inherit="NiProperty">

--- a/nif.xml
+++ b/nif.xml
@@ -4772,7 +4772,7 @@
         <add name="Solver Iteration Count" type="uint" />
         <add name="Sleep Energy Threshold" type="float" ver1="20.3.0.0" />
         <add name="Sleep Damping" type="float" ver1="20.3.0.0" />
-        <add name="Contact Report Threshold" type="float" />
+        <add name="Contact Report Threshold" type="float" ver1="20.4.0.0" />
     </niobject>
 
     <enum name="NxJointType" storage="uint">

--- a/nif.xml
+++ b/nif.xml
@@ -7085,44 +7085,51 @@
 	
     <compound name="BSPackedGeomDataCombined">
         <add name="Grayscale to Palette Scale" type="float" />
-        <add name="Rotation" type="Matrix33" />
-        <add name="Translation" type="Vector3" />
-        <add name="Scale" type="float" />
+        <add name="Transform" type="NiTransform" />
         <add name="Bounding Sphere" type="NiBound" />
     </compound>
-    
-    <compound name="BSPackedGeomDataLOD">
-        <add name="Triangle Count" type="uint" />
-        <add name="Triangle Offset" type="uint" />
-    </compound>
-    
+
     <compound name="BSPackedGeomData">
         <add name="Num Verts" type="uint" />
         <add name="LOD Levels" type="uint" />
-        <add name="LOD" type="BSPackedGeomDataLOD" arr1="LOD Levels" />
+        <add name="Tri Count LOD0" type="uint" />
+        <add name="Tri Offset LOD0" type="uint" />
+        <add name="Tri Count LOD1" type="uint" />
+        <add name="Tri Offset LOD1" type="uint" />
+        <add name="Tri Count LOD2" type="uint" />
+        <add name="Tri Offset LOD2" type="uint" />
         <add name="Num Combined" type="uint" />
         <add name="Combined" type="BSPackedGeomDataCombined" arr1="Num Combined" />
-        <add name="Unk Int 1" type="uint" />
-        <add name="Unk Int 2" type="uint" />
+        <add name="Vertex Desc" type="BSVertexDesc" />
+        <add name="Vertex Data" type="BSVertexData" arr1="Num Verts" arg="Vertex Desc" cond="!BSPackedCombinedSharedGeomDataExtra" />
+        <add name="Triangles" type="Triangle" arr1="Tri Count LOD0 + Tri Count LOD1 + Tri Count LOD2" cond="!BSPackedCombinedSharedGeomDataExtra" />
     </compound>
 	
     <compound name="BSPackedGeomObject">
-        <add name="Unknown Int 1" type="uint" />
-        <add name="Object Hash?" type="uint" />
+        This appears to be a 64-bit hash but nif.xml does not have a 64-bit type.
+        <add name="Shape ID 1" type="uint" />
+        <add name="Shape ID 2" type="uint" />
     </compound>
-    
-    <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData">
-        Fallout 4 Packed Combined Geometry Data
+
+    <niobject name="BSPackedCombinedGeomDataExtra" inherit="NiExtraData">
+        Fallout 4 Packed Combined Geometry Data.
+        Geometry is baked into the file and given a list of transforms to position each copy.
         <add name="Vertex Desc" type="BSVertexDesc" />
         <add name="Num Vertices" type="uint" />
         <add name="Num Triangles" type="uint" />
         <add name="Unknown Flags 1" type="uint" />
         <add name="Unknown Flags 2" type="uint" />
         <add name="Num Data" type="uint" />
-        <add name="Object" type="BSPackedGeomObject" arr1="Num Data" />
+        <add name="Object" type="BSPackedGeomObject" arr1="Num Data" cond="BSPackedCombinedSharedGeomDataExtra" />
         <add name="Object Data" type="BSPackedGeomData" arr1="Num Data" />
     </niobject>
-    
+
+    <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="BSPackedCombinedGeomDataExtra">
+        Fallout 4 Packed Combined Shared Geometry Data.
+        Geometry is NOT baked into the file. It is instead a reference to the shape via a Shape ID (currently undecoded)
+        which loads the geometry via the STAT form for the NIF.
+    </niobject>
+
     <!-- Fallout 4 Animation -->
     
     <niobject name="NiLightRadiusController" inherit="NiFloatInterpController">

--- a/nif.xml
+++ b/nif.xml
@@ -2896,27 +2896,27 @@
     </niobject>
 
     <niobject name="NiPSysEmitterDeclinationCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
-        Unknown.
+        Animates the declination value on an NiPSysEmitter object.
     </niobject>
 
     <niobject name="NiPSysEmitterDeclinationVarCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
-        Unknown.
+        Animates the declination variation value on an NiPSysEmitter object.
     </niobject>
 
     <niobject name="NiPSysEmitterInitialRadiusCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
-        Unknown.
+        Animates the size value on an NiPSysEmitter object.
     </niobject>
 
     <niobject name="NiPSysEmitterLifeSpanCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
-        Unknown.
+        Animates the lifespan value on an NiPSysEmitter object.
     </niobject>
 
     <niobject name="NiPSysEmitterSpeedCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
-        Unknown.
+        Animates the speed value on an NiPSysEmitter object.
     </niobject>
 
     <niobject name="NiPSysGravityStrengthCtlr" abstract="0" inherit="NiPSysModifierFloatCtlr">
-        Unknown.
+        Animates the strength value of an NiPSysGravityModifier.
     </niobject>
 
 
@@ -6352,6 +6352,7 @@
     </enum>
 
     <niobject name="NiPSParticleSystem" inherit="NiMesh">
+        Represents a particle system.
         <add name="Simulator" type="Ref" template="NiPSSimulator" />
         <add name="Generator" type="Ref" template="NiPSBoundUpdater" />
         <add name="Num Emitters" type="uint" />
@@ -6376,6 +6377,7 @@
     </niobject>
 
     <niobject name="NiPSMeshParticleSystem" inherit="NiPSParticleSystem">
+        Represents a particle system that uses mesh particles instead of sprite-based particles.
         <add name="Num Generations" type="uint" />
         <add name="Master Particles" type="Ref" template="NiAVObject" arr1="Num Generations" />
         <add name="Pool Size" type="uint" />
@@ -6384,9 +6386,12 @@
 
     <!-- NiPS Generators -->
 
-    <niobject name="NiPSFacingQuadGenerator" inherit="NiMeshModifier" />
+    <niobject name="NiPSFacingQuadGenerator" inherit="NiMeshModifier">
+        A mesh modifier that uses particle system data to generate camera-facing quads.
+    </niobject>
 
     <niobject name="NiPSAlignedQuadGenerator" inherit="NiMeshModifier">
+        A mesh modifier that uses particle system data to generate aligned quads for each particle.
         <add name="Scale Amount U" type="float" />
         <add name="Scale Limit U" type="float" />
         <add name="Scale Rest U" type="float" />
@@ -6468,6 +6473,7 @@
     </niobject>
 
     <niobject name="NiPSBoundUpdater" inherit="NiObject">
+        Updates the bounding volume for an NiPSParticleSystem object.
         <add name="Update Skip" type="ushort">Number of particle bounds to skip updating every frame. Higher = more updates each frame.</add>
     </niobject>
 
@@ -6486,12 +6492,14 @@
     </enum>
 
     <niobject name="NiPSForce" abstract="1" inherit="NiObject">
+        Abstract base class for all particle forces.
         <add name="Name" type="string" />
         <add name="Type" type="PSForceType" />
         <add name="Active" type="bool" />
     </niobject>
 
     <niobject name="NiPSDragForce" inherit="NiPSForce">
+        Applies a linear drag force to particles.
         <add name="Drag Axis" type="Vector3" />
         <add name="Percentage" type="float" />
         <add name="Range" type="float" />
@@ -6500,6 +6508,7 @@
     </niobject>
 
     <niobject name="NiPSGravityForce" inherit="NiPSForce">
+        Applies a gravitational force to particles.
         <add name="Gravity Axis" type="Vector3" />
         <add name="Decay" type="float" />
         <add name="Strength" type="float" />
@@ -6510,6 +6519,7 @@
     </niobject>
 
     <niobject name="NiPSBombForce" inherit="NiPSForce">
+        Applies an explosive force to particles.
         <add name="Bomb Axis" type="Vector3" />
         <add name="Decay" type="float" />
         <add name="Delta V" type="float" />
@@ -6521,6 +6531,7 @@
     <!-- NiPS Emitters -->
 
     <niobject name="NiPSEmitter" abstract="1" inherit="NiObject">
+        Abstract base class for all particle emitters.
         <add name="Name" type="string" />
         <add name="Speed" type="float" />
         <add name="Speed Var" type="float" />
@@ -6545,25 +6556,30 @@
     </niobject>
 
     <niobject name="NiPSVolumeEmitter" abstract="1" inherit="NiPSEmitter">
+        Abstract base class for particle emitters that emit particles from a volume.
         <add name="Emitter Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
     <niobject name="NiPSBoxEmitter" inherit="NiPSVolumeEmitter">
+        A particle emitter that emits particles from a rectangular volume.
         <add name="Emitter Width" type="float" />
         <add name="Emitter Height" type="float" />
         <add name="Emitter Depth" type="float" />
     </niobject>
 
     <niobject name="NiPSSphereEmitter" inherit="NiPSVolumeEmitter">
+        A particle emitter that emits particles from a spherical volume.
         <add name="Emitter Radius" type="float" />
     </niobject>
 
     <niobject name="NiPSCylinderEmitter" inherit="NiPSVolumeEmitter">
+        A particle emitter that emits particles from a cylindrical volume.
         <add name="Emitter Radius" type="float" />
         <add name="Emitter Height" type="float" />
     </niobject>
 
     <niobject name="NiPSMeshEmitter" inherit="NiPSEmitter">
+        Emits particles from one or more NiMesh objects. A random mesh emitter is selected for each particle emission.
         <add name="Num Mesh Emitters" type="uint" />
         <add name="Mesh Emitters" type="Ptr" template="NiMesh" arr1="Num Mesh Emitters" />
         <add name="Emit Axis" type="Vector3" ver2="20.6.0.0" />
@@ -6575,35 +6591,87 @@
     <!-- NiPS Controllers -->
 
     <niobject name="NiPSEmitterCtlr" abstract="1" inherit="NiSingleInterpController">
+        Abstract base class for all particle emitter time controllers.
         <add name="Emitter Name" type="string" />
     </niobject>
 
-    <niobject name="NiPSEmitterFloatCtlr" abstract="1" inherit="NiPSEmitterCtlr" />
+    <niobject name="NiPSEmitterFloatCtlr" abstract="1" inherit="NiPSEmitterCtlr">
+        Abstract base class for controllers that animate a floating point value on an NiPSEmitter object.
+    </niobject>
 
     <niobject name="NiPSEmitParticlesCtlr" inherit="NiPSEmitterCtlr">
+        Animates particle emission and birth rate.
         <add name="Emitter Active Interpolator" type="Ref" template="NiInterpolator" />
     </niobject>
 
     <niobject name="NiPSForceCtlr" abstract="1" inherit="NiSingleInterpController">
+        Abstract base class for all particle force time controllers.
         <add name="Force Name" type="string" />
     </niobject>
 
-    <niobject name="NiPSForceBoolCtlr" inherit="NiPSForceCtlr" />
-    <niobject name="NiPSForceFloatCtlr" inherit="NiPSForceCtlr" />
-    <niobject name="NiPSForceActiveCtlr" inherit="NiPSForceBoolCtlr" />
-    <niobject name="NiPSGravityStrengthCtlr" inherit="NiPSForceFloatCtlr" />
-    <niobject name="NiPSEmitterSpeedCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterRadiusCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSResetOnLoopCtlr" inherit="NiTimeController" />
-    <niobject name="NiPSEmitterDeclinationCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterDeclinationVarCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterPlanarAngleCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterPlanarAngleVarCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterRotAngleCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterRotAngleVarCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterRotSpeedCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterRotSpeedVarCtlr" inherit="NiPSEmitterFloatCtlr" />
-    <niobject name="NiPSEmitterLifeSpanCtlr" inherit="NiPSEmitterFloatCtlr" />
+    <niobject name="NiPSForceBoolCtlr" abstract="1" inherit="NiPSForceCtlr">
+        Abstract base class for controllers that animate a Boolean value on an NiPSForce object.
+    </niobject>
+
+    <niobject name="NiPSForceFloatCtlr" abstract="1" inherit="NiPSForceCtlr">
+        Abstract base class for controllers that animate a floating point value on an NiPSForce object.
+    </niobject>
+
+    <niobject name="NiPSForceActiveCtlr" inherit="NiPSForceBoolCtlr">
+        Animates whether or not an NiPSForce object is active.
+    </niobject>
+
+    <niobject name="NiPSGravityStrengthCtlr" inherit="NiPSForceFloatCtlr">
+        Animates the strength value of an NiPSGravityForce object.
+    </niobject>
+
+    <niobject name="NiPSEmitterSpeedCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the speed value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterRadiusCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the size value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterDeclinationCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the declination value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterDeclinationVarCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the declination variation value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterPlanarAngleCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the planar angle value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterPlanarAngleVarCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the planar angle variation value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterRotAngleCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the rotation angle value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterRotAngleVarCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the rotation angle variation value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterRotSpeedCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the rotation speed value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterRotSpeedVarCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the rotation speed variation value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSEmitterLifeSpanCtlr" inherit="NiPSEmitterFloatCtlr">
+        Animates the lifespan value on an NiPSEmitter object.
+    </niobject>
+
+    <niobject name="NiPSResetOnLoopCtlr" inherit="NiTimeController">
+        Calls ResetParticleSystem on an NiPSParticleSystem target upon looping.
+    </niobject>
 
     <!-- NiPS Colliders -->
 
@@ -6613,6 +6681,7 @@
     </enum>
 
     <niobject name="NiPSCollider" inherit="NiObject">
+        Abstract base class for all particle colliders.
         <add name="Spawner" type="Ref" template="NiPSSpawner" />
         <add name="Type" type="ColliderType" />
         <add name="Active" type="bool" />
@@ -6622,6 +6691,7 @@
     </niobject>
 
     <niobject name="NiPSPlanarCollider" inherit="NiPSCollider">
+        A planar collider for particles.
         <add name="Width" type="float" />
         <add name="Height" type="float" />
         <add name="X Axis" type="Vector3" />
@@ -6630,11 +6700,13 @@
     </niobject>
 
     <niobject name="NiPSSphericalCollider" inherit="NiPSCollider">
+        A spherical collider for particles.
         <add name="Radius" type="float" />
         <add name="Collider Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
     <niobject name="NiPSSpawner" inherit="NiObject">
+        Creates a new particle whose initial parameters are based on an existing particle.
         <add name="Master Particle System" type="Ptr" template="NiPSParticleSystem" ver1="20.6.1.0" />
         <add name="Percentage Spawned" type="float" />
         <add name="Spawn Speed Factor" type="float" ver1="20.6.1.0" />

--- a/nif.xml
+++ b/nif.xml
@@ -5013,11 +5013,11 @@
         <add name="Shape Name" type="string" />
         <add name="Non-Interacting Compartment Types" type="uint" ver1="20.4.0.0" />
         <add name="Collision Bits" type="uint" arr1="4" />
-        <add name="Shape" type="NxPlane" cond="Shape Type == 0" />
+        <add name="Plane" type="NxPlane" cond="Shape Type == 0" />
         <add name="Sphere Radius" type="float" cond="Shape Type == 1" />
         <add name="Box Half Extents" type="Vector3" cond="Shape Type == 2" />
-        <add name="Shape" type="NxCapsule" cond="Shape Type == 3" />
-        <add name="Shape" type="Ref" template="NiPhysXMeshDesc" cond="(Shape Type == 5) || (Shape Type == 6)" />
+        <add name="Capsule" type="NxCapsule" cond="Shape Type == 3" />
+        <add name="Mesh" type="Ref" template="NiPhysXMeshDesc" cond="(Shape Type == 5) || (Shape Type == 6)" />
     </niobject>
 
     <niobject name="NiPhysXMeshDesc" abstract="0" inherit="NiObject">

--- a/nif.xml
+++ b/nif.xml
@@ -4672,129 +4672,326 @@
     </niobject>
 
     <niobject name="NiPhysXProp" abstract="0" inherit="NiObjectNET">
-        Unknown PhysX node.
-        <add name="Unknown Float 1" type="float">Unknown</add>
-        <add name="Unknown Int 1" type="uint">Unknown</add>
-        <add name="Unknown Refs 1" type="Ref" template="NiObject" arr1="Unknown Int 1">Unknown</add>
-        <add name="Num Dests" type="int">Number of NiPhysXTransformDest references</add>
-        <add name="Transform Dests" type="Ref" template="NiPhysXTransformDest" arr1="Num Dests">Unknown</add>
-        <add name="Unknown Byte" type="byte">Unknown</add>
-        <add name="Unknown Int" type="int" ver1="20.5.0.0">Unknown</add><!-- in Krazy Rain 20.5.0.0 nifs, missing in the copetech 20.3.0.9 nifs -->
-        <add name="Prop Description" type="Ref" template="NiPhysXPropDesc">PhysX Property Description.</add>
+        A PhysX prop which holds information about PhysX actors in a Gamebryo scene
+        <add name="PhysX to World Scale" type="float" />
+        <add name="Num Sources" type="uint" />
+        <add name="Sources" type="Ref" template="NiObject" arr1="Num Sources" />
+        <add name="Num Dests" type="int" />
+        <add name="Dests" type="Ref" template="NiPhysXDest" arr1="Num Dests" />
+        <add name="Num Modified Meshes" type="uint" ver1="20.4.0.0" />
+        <add name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" ver1="20.4.0.0" />
+        <add name="Temp Name" type="string" ver1="30.1.0.2" ver2="30.2.0.2" />
+        <add name="Keep Meshes" type="bool" />
+        <add name="Prop Description" type="Ref" template="NiPhysXPropDesc" />
     </niobject>
 
-    <compound name="physXMaterialRef">
-        <add name="Number" type="byte">Unknown</add>
-        <add name="Unknown Byte 1" type="byte">Unknown</add>
-        <add name="Material Desc" type="Ref" template="NiPhysXMaterialDesc" >PhysX Material Description</add>
+    <compound name="PhysXMaterialRef">
+        <add name="Key" type="ushort" />
+        <add name="Material Desc" type="Ref" template="NiPhysXMaterialDesc" />
+    </compound>
+
+    <compound name="PhysXStateName">
+        <add name="Name" type="string" />
+        <add name="Index" type="uint" />
     </compound>
 
     <niobject name="NiPhysXPropDesc" abstract="0" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Num Dests" type="int">Number of NiPhysXActorDesc references</add>
-        <add name="Actor Descs" type="Ref" template="NiPhysXActorDesc" arr1="Num Dests">Unknown</add>
-        <add name="Num Joints" type="uint">Unknown</add>
-        <add name="Joint Descs" type="Ref" template="NiPhysXD6JointDesc" arr1="Num Joints">PhysX Joint Descriptions</add>
-        <add name="Unknown Int 1" type="int">Unknown</add>
-        <add name="Num Materials" type="uint">Unknown</add>
-        <add name="Material Descs" type="physXMaterialRef"  arr1="Num Materials">PhysX Material Descriptions</add>
-        <add name="Unknown Int 2" type="uint">Unknown</add>
-        <add name="Unknown Int 3" type="uint" ver1="20.5.0.0">Unknown</add><!-- in Krazy Rain 20.5.0.0 nifs, not in copetech nifs -->
-        <add name="Unknown String 4" type="string" ver1="20.5.0.0">Unknown</add><!-- in Krazy Rain 20.5.0.0 nifs, not in copetech nifs -->
-        <add name="Unknown Int 5" type="uint" ver1="20.5.0.0">Unknown</add><!-- in Krazy Rain 20.5.0.0 nifs, not in copetech nifs -->
-        <add name="Unknown Byte 6" type="byte" ver1="20.5.0.0">Unknown</add><!-- in Krazy Rain 20.5.0.0 nifs, not in copetech nifs -->
+        For serialization of PhysX objects and to attach them to the scene.
+        <add name="Num Actors" type="int" />
+        <add name="Actors" type="Ref" template="NiPhysXActorDesc" arr1="Num Actors" />
+        <add name="Num Joints" type="uint" />
+        <add name="Joints" type="Ref" template="NiPhysXJointDesc" arr1="Num Joints" />
+        <add name="Num Clothes" type="uint" ver1="20.3.0.5" />
+        <add name="Clothes" type="Ref" template="NiObject" arr1="Num Clothes" ver1="20.3.0.5" /> <!-- NiPhysXClothDesc -->
+        <add name="Num Materials" type="uint" />
+        <add name="Materials" type="PhysXMaterialRef" arr1="Num Materials" />
+        <add name="Num States" type="uint" />
+        <add name="Num State Names" type="uint" ver1="20.4.0.0" />
+        <add name="State Names" type="PhysXStateName" arr1="Num State Names" ver1="20.4.0.0" />
+        <add name="Flags" type="byte" ver1="20.4.0.0" />
     </niobject>
 
     <niobject name="NiPhysXActorDesc" abstract="0" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Int 1" type="int">Unknown</add>
-        <add name="Unknown Int 2" type="int">Unknown</add>
-        <add name="Unknown Quat 1" type="Quaternion">Unknown</add>
-        <add name="Unknown Quat 2" type="Quaternion">Unknown</add>
-        <add name="Unknown Quat 3" type="Quaternion">Unknown</add>
-        <add name="Unknown Ref 0" type="Ref" template="NiPhysXBodyDesc">Unknown</add>
-        <add name="Unknown Int 4" type="float">Unknown</add>
-        <add name="Unknown Int 5" type="int">Unknown</add>
-        <add name="Unknown Byte 1" type="byte">Unknown</add>
-        <add name="Unknown Byte 2" type="byte">Unknown</add>
-        <add name="Unknown Int 6" type="int">Unknown</add>
-        <add name="Shape Description" type="Ref" template="NiPhysXShapeDesc">PhysX Shape Description</add>
-        <add name="Unknown Ref 1" type="Ref" template="NiObject">Unknown</add>
-        <add name="Unknown Ref 2" type="Ref" template="NiObject">Unknown</add>
-        <add name="Unknown Refs 3" type="Ref" template="NiObject" arr1="Unknown Int 6">Unknown</add>
+        For serializing NxActor objects.
+        <add name="Actor Name" type="string" />
+        <add name="Num Poses" type="uint" />
+        <add name="Poses" type="Matrix34" arr1="Num Poses" />
+        <add name="Body Desc" type="Ref" template="NiPhysXBodyDesc" />
+        <add name="Density" type="float" />
+        <add name="Actor Flags" type="uint" />
+        <add name="Actor Group" type="ushort" />
+        <add name="Dominance Group" type="ushort" ver1="20.4.0.0" />
+        <add name="Contact Report Flags" type="uint" ver1="20.4.0.0" />
+        <add name="Force Field Material" type="ushort" ver1="20.4.0.0" />
+        <add name="Dummy" type="uint" ver1="20.3.0.1" ver2="20.3.0.5" />
+        <add name="Num Shape Descs" type="uint" />
+        <add name="Shape Descriptions" type="Ref" template="NiPhysXShapeDesc" arr1="Num Shape Descs" />
+        <add name="Actor Parent" type="Ref" template="NiPhysXActorDesc" />
+        <add name="Source" type="Ref" template="NiPhysXRigidBodySrc" />
+        <add name="Dest" type="Ref" template="NiPhysXRigidBodyDest" />
     </niobject>
+
+    <compound name="PhysXBodyStoredVels">
+        <add name="Linear Velocity" type="Vector3" />
+        <add name="Angular Velocity" type="Vector3" />
+        <add name="Sleep" type="bool" ver1="30.2.0.3" />
+    </compound>
 
     <niobject name="NiPhysXBodyDesc" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Bytes" type="byte" arr1="136" ver1="20.3.0.6">Unknown</add>
+        For serializing NxBodyDesc objects.
+        <add name="Local Pose" type="Matrix34" />
+        <add name="Space Inertia" type="Vector3" />
+        <add name="Mass" type="float" />
+        <add name="Num Vels" type="uint" />
+        <add name="Vels" type="PhysXBodyStoredVels" arr1="Num Vels" />
+        <add name="Wake Up Counter" type="float" />
+        <add name="Linear Damping" type="float" />
+        <add name="Angular Damping" type="float" />
+        <add name="Max Angular Velocity" type="float" />
+        <add name="CCD Motion Threshold" type="float" />
+        <add name="Flags" type="uint" />
+        <add name="Sleep Linear Velocity" type="float" />
+        <add name="Sleep Angular Velocity" type="float" />
+        <add name="Solver Iteration Count" type="uint" />
+        <add name="Sleep Energy Threshold" type="float" ver1="20.3.0.0" />
+        <add name="Sleep Damping" type="float" ver1="20.3.0.0" />
+        <add name="Contact Report Threshold" type="float" />
     </niobject>
 
-    <niobject name="NiPhysXD6JointDesc" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Bytes" type="byte" arr1="388" ver1="20.3.0.6">Unknown</add>
+    <enum name="NxJointType" storage="uint">
+        <option name="NX_JOINT_PRISMATIC" value="0" />
+        <option name="NX_JOINT_REVOLUTE" value="1" />
+        <option name="NX_JOINT_CYLINDRICAL" value="2" />
+        <option name="NX_JOINT_SPHERICAL" value="3" />
+        <option name="NX_JOINT_POINT_ON_LINE" value="4" />
+        <option name="NX_JOINT_POINT_IN_PLANE" value="5" />
+        <option name="NX_JOINT_DISTANCE" value="6" />
+        <option name="NX_JOINT_PULLEY" value="7" />
+        <option name="NX_JOINT_FIXED" value="8" />
+        <option name="NX_JOINT_D6" value="9" />
+    </enum>
+
+    <enum name="NxD6JointMotion" storage="uint">
+        <option name="NX_D6JOINT_MOTION_LOCKED" value="0" />
+        <option name="NX_D6JOINT_MOTION_LIMITED" value="1" />
+        <option name="NX_D6JOINT_MOTION_FREE" value="2" />
+    </enum>
+
+    <enum name="NxD6JointDriveType" storage="uint">
+        <option name="NX_D6JOINT_DRIVE_POSITION" value="1" />
+        <option name="NX_D6JOINT_DRIVE_VELOCITY" value="2" />
+    </enum>
+
+    <enum name="NxJointProjectionMode" storage="uint">
+        <option name="NX_JPM_NONE" value="0" />
+        <option name="NX_JPM_POINT_MINDIST" value="1" />
+        <option name="NX_JPM_LINEAR_MINDIST" value="2" />
+    </enum>
+
+    <compound name="NiPhysXJointActor">
+        <add name="Actor" type="Ref" template="NiPhysXActorDesc" />
+        <add name="Local Normal" type="Vector3" />
+        <add name="Local Axis" type="Vector3" />
+        <add name="Local Anchor" type="Vector3" />
+    </compound>
+
+    <compound name="NxJointLimitSoftDesc">
+        <add name="Value" type="float" />
+        <add name="Restitution" type="float" />
+        <add name="Spring" type="float" />
+        <add name="Damping" type="float" />
+    </compound>
+
+    <compound name="NxJointDriveDesc">
+        <add name="Drive Type" type="NxD6JointDriveType" />
+        <add name="Restitution" type="float" />
+        <add name="Spring" type="float" />
+        <add name="Damping" type="float" />
+    </compound>
+
+    <compound name="NiPhysXJointLimit">
+        <add name="Limit Plane Normal" type="Vector3" />
+        <add name="Limit Plane D" type="float" />
+        <add name="Limit Plane R" type="float" ver1="20.4.0.0" />
+    </compound>
+
+    <niobject name="NiPhysXJointDesc" inherit="NiObject" abstract="1">
+        A PhysX Joint abstract base class.
+        <add name="Joint Type" type="NxJointType" />
+        <add name="Joint Name" type="string" />
+        <add name="Actors" type="NiPhysXJointActor" arr1="2" />
+        <add name="Max Force" type="float" />
+        <add name="Max Torque" type="float" />
+        <add name="Solver Extrapolation Factor" type="float" ver1="20.5.0.3" />
+        <add name="Use Acceleration Spring" type="uint" ver1="20.5.0.3" />
+        <add name="Joint Flags" type="uint" />
+        <add name="Limit Point" type="Vector3" />
+        <add name="Num Limits" type="uint" />
+        <add name="Limits" type="NiPhysXJointLimit" arr1="Num Limits" />
     </niobject>
+
+    <niobject name="NiPhysXD6JointDesc" inherit="NiPhysXJointDesc">
+        A 6DOF (6 degrees of freedom) joint.
+        <add name="X Motion" type="NxD6JointMotion" />
+        <add name="Y Motion" type="NxD6JointMotion" />
+        <add name="Z Motion" type="NxD6JointMotion" />
+        <add name="Swing 1 Motion" type="NxD6JointMotion" />
+        <add name="Swing 2 Motion" type="NxD6JointMotion" />
+        <add name="Twist Motion" type="NxD6JointMotion" />
+        <add name="Linear Limit" type="NxJointLimitSoftDesc" />
+        <add name="Swing 1 Limit" type="NxJointLimitSoftDesc" />
+        <add name="Swing 2 Limit" type="NxJointLimitSoftDesc" />
+        <add name="Twist Low Limit" type="NxJointLimitSoftDesc" />
+        <add name="Twist High Limit" type="NxJointLimitSoftDesc" />
+        <add name="X Drive" type="NxJointDriveDesc" />
+        <add name="Y Drive" type="NxJointDriveDesc" />
+        <add name="Z Drive" type="NxJointDriveDesc" />
+        <add name="Swing Drive" type="NxJointDriveDesc" />
+        <add name="Twist Drive" type="NxJointDriveDesc" />
+        <add name="Slerp Drive" type="NxJointDriveDesc" />
+        <add name="Drive Position" type="Vector3" />
+        <add name="Drive Orientation" type="Quaternion" />
+        <add name="Drive Linear Velocity" type="Vector3" />
+        <add name="Drive Angular Velocity" type="Vector3" />
+        <add name="Projection Mode" type="NxJointProjectionMode" />
+        <add name="Projection Distance" type="float" />
+        <add name="Projection Angle" type="float" />
+        <add name="Gear Ratio" type="float" />
+        <add name="Flags" type="uint" />
+    </niobject>
+
+    <enum name="NxShapeType" storage="uint">
+        <option name="NX_SHAPE_PLANE" value="0" />
+        <option name="NX_SHAPE_SPHERE" value="1" />
+        <option name="NX_SHAPE_BOX" value="2" />
+        <option name="NX_SHAPE_CAPSULE" value="3" />
+        <option name="NX_SHAPE_WHEEL" value="4" />
+        <option name="NX_SHAPE_CONVEX" value="5" />
+        <option name="NX_SHAPE_MESH" value="6" />
+        <option name="NX_SHAPE_HEIGHTFIELD" value="7" />
+        <option name="NX_SHAPE_RAW_MESH" value="8" />
+        <option name="NX_SHAPE_COMPOUND" value="9" />
+    </enum>
+
+    <compound name="NxPlane">
+        <add name="Val 1" type="float" />
+        <add name="Point 1" type="Vector3" />
+    </compound>
+
+    <compound name="NxCapsule">
+        <add name="Val 1" type="float" />
+        <add name="Val 2" type="float" />
+        <add name="Capsule Flags" type="uint" />
+    </compound>
 
     <niobject name="NiPhysXShapeDesc" abstract="0" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Int 1" type="int">Unknown</add>
-        <add name="Unknown Quat 1" type="Quaternion">Unknown</add>
-        <add name="Unknown Quat 2" type="Quaternion">Unknown</add>
-        <add name="Unknown Quat 3" type="Quaternion">Unknown</add>
-        <add name="Unknown Short 1" type="short">Unknown</add>
-        <add name="Unknown Int 2" type="int">Unknown</add>
-        <add name="Unknown Short 2" type="short">Unknown</add>
-        <add name="Unknown Float 1" type="float">Unknown</add>
-        <add name="Unknown Float 2" type="float">Unknown</add>
-        <add name="Unknown Float 3" type="float">Unknown</add>
-        <add name="Unknown Int 3" type="int">Unknown</add>
-        <add name="Unknown Int 4" type="int">Unknown</add>
-        <add name="Unknown Int 5" type="int">Unknown</add>
-        <add name="Unknown Int 7" type="int">Unknown</add>
-        <add name="Unknown Int 8" type="int">Unknown</add>
-        <!--<add name="Unknown Bytes 1" type="byte" arr1="8" ver1="20.3.0.6">Unknown. Wrong, but better than nothing.</add>-->
-        <add name="Mesh Description" type="Ref" template="NiPhysXMeshDesc">PhysX Mesh Description</add>
-        <!-- todo: fix invalid link failure on Ficus.nif from the emerge demo -->
+        For serializing NxShapeDesc objects
+        <add name="Shape Type" type="NxShapeType" />
+        <add name="Local Pose" type="Matrix34" />
+        <add name="Shape Flags" type="uint" />
+        <add name="Collision Group" type="ushort" />
+        <add name="Material Index" type="ushort" />
+        <add name="Density" type="float" />
+        <add name="Mass" type="float" />
+        <add name="Skin Width" type="float" />
+        <add name="Shape Name" type="string" />
+        <add name="Non-Interacting Compartment Types" type="uint" ver1="20.4.0.0" />
+        <add name="Collision Bits" type="uint" arr1="4" />
+        <add name="Shape" type="NxPlane" cond="Shape Type == 0" />
+        <add name="Sphere Radius" type="float" cond="Shape Type == 1" />
+        <add name="Box Half Extents" type="Vector3" cond="Shape Type == 2" />
+        <add name="Shape" type="NxCapsule" cond="Shape Type == 3" />
+        <add name="Shape" type="Ref" template="NiPhysXMeshDesc" cond="(Shape Type == 5) || (Shape Type == 6)" />
     </niobject>
 
     <niobject name="NiPhysXMeshDesc" abstract="0" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Short 1" type="short">Unknown</add>
-        <add name="Unknown Float 1" type="float">Unknown</add>
-        <add name="Unknown Short 2" type="short">Unknown</add>
-        <add name="Unknown Bytes 0" type="byte" arr1="3">NXS</add>
-        <add name="Unknown Byte 1" type="byte">Unknown</add>
-        <add name="Unknown Bytes 1" type="byte" arr1="4">MESH</add>
-        <add name="Unknown Bytes 2" type="byte" arr1="8">Unknown</add>
-        <add name="Unknown Float 2" type="float">Unknown</add>
-        <add name="Unknown Int 1" type="int">Unknown</add>
-        <add name="Unknown Int 2" type="int">Unknown</add>
-        <add name="Num Vertices" type="int">Number of mesh vertices</add>
-        <add name="Unknown Int 4" type="int">Unknown</add>
-        <add name="Vertices" type="Vector3" arr1="Num Vertices">Vertices</add>
-        <add name="Unknown Bytes 3" type="byte" arr1="982">Unknown</add>
-        <add name="Unknown Shorts 1" type="short" arr1="368">Unknown</add>
-        <add name="Unknown Ints 1" type="uint" arr1="3328">Unknown</add>
-        <add name="Unknown Byte 2" type="byte">Unknown</add>
+        Holds mesh data for streaming.
+        <add name="Is Convex" type="bool" ver2="20.3.0.4" />
+        <add name="Mesh Name" type="string" />
+        <add name="Mesh Data" type="ByteArray" />
+        <add name="Mesh Size" type="ushort" ver1="20.3.0.5" ver2="30.2.0.2" />
+        <add name="Mesh Data" type="ushort" arr1="Mesh Size" ver1="20.3.0.5" ver2="30.2.0.2" />
+        <add name="Mesh Flags" type="uint" />
+        <add name="Mesh Paging Mode" type="uint" ver1="20.3.0.1" />
+        <add name="Is Hardware" type="bool" ver1="20.3.0.2" ver2="20.3.0.4" />
+        <add name="Flags" type="byte" ver1="20.3.0.5" />
     </niobject>
+
+    <bitflags name="NxMaterialFlag" storage="uint">
+        <option name="NX_MF_ANISOTROPIC" value="1" />
+        <option name="NX_MF_DUMMY1" value="2" />
+        <option name="NX_MF_DUMMY2" value="3" />
+        <option name="NX_MF_DUMMY3" value="4" />
+        <option name="NX_MF_DISABLE_FRICTION" value="5" />
+        <option name="NX_MF_DISABLE_STRONG_FRICTION" value="6" />
+    </bitflags>
+
+    <compound name="NxSpringDesc">
+        <add name="Spring" type="float" />
+        <add name="Damper" type="float" />
+        <add name="Target Value" type="float" />
+    </compound>
+
+    <enum name="NxCombineMode" storage="uint">
+        <option name="NX_CM_AVERAGE" value="0" />
+        <option name="NX_CM_MIN" value="1" />
+        <option name="NX_CM_MULTIPLY" value="2" />
+        <option name="NX_CM_MAX" value="3" />
+    </enum>
+
+    <compound name="NxMaterialDesc">
+        <add name="Dynamic Friction" type="float" />
+        <add name="Static Friction" type="float" />
+        <add name="Restitution" type="float" />
+        <add name="Dynamic Friction V" type="float" />
+        <add name="Static Friction V" type="float" />
+        <add name="Direction of Anisotropy" type="Vector3" />
+        <add name="Flags" type="NxMaterialFlag" />
+        <add name="Friction Combine Mode" type="NxCombineMode" />
+        <add name="Restitution Combine Mode" type="NxCombineMode" />
+        <add name="Has Spring" type="bool" ver2="20.2.3.0" />
+        <add name="Spring" type="NxSpringDesc" ver2="20.2.3.0" cond="Has Spring" />
+    </compound>
 
     <niobject name="NiPhysXMaterialDesc" abstract="0" inherit="NiObject">
-        Unknown node.
-        <add name="Unknown Int" type="uint" arr1="12">Unknown</add>
-        <add name="Unknown Byte 1" type="byte">Unknown</add>
-        <add name="Unknown Byte 2" type="byte">Unknown</add>
+        For serializing NxMaterialDesc objects.
+        <add name="Index" type="ushort" />
+        <add name="Num States" type="uint" />
+        <add name="Material Descs" type="NxMaterialDesc" arr1="Num States" />
     </niobject>
 
-    <niobject name="NiPhysXKinematicSrc" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Bytes" type="byte" arr1="6" ver1="20.3.0.6">Unknown</add>
+    <niobject name="NiPhysXDest" inherit="NiObject" abstract="1">
+        A destination is a link between a PhysX actor and a Gamebryo object being driven by the physics.
+        <add name="Active" type="bool" />
+        <add name="Interpolate" type="bool" />
     </niobject>
 
-    <niobject name="NiPhysXTransformDest" inherit="NiObject">
-        Unknown PhysX node.
-        <add name="Unknown Byte 1" type="byte">Unknown. =1?</add>
-        <add name="Unknown Byte 2" type="byte">Unknown. =0</add>
-        <add name="Node" type="Ptr" template="NiNode" >Affected node?</add>
+    <niobject name="NiPhysXRigidBodyDest" inherit="NiPhysXDest" abstract="1">
+        Base for destinations that set a rigid body state.
+    </niobject>
 
+    <niobject name="NiPhysXTransformDest" inherit="NiPhysXRigidBodyDest">
+        Connects PhysX rigid body actors to a scene node.
+        <add name="Target" type="Ptr" template="NiAVObject" />
+    </niobject>
+
+    <niobject name="NiPhysXSrc" inherit="NiObject" abstract="1">
+        A source is a link between a Gamebryo object and a PhysX actor.
+        <add name="Active" type="bool" />
+        <add name="Interpolate" type="bool" />
+    </niobject>
+
+    <niobject name="NiPhysXRigidBodySrc" inherit="NiPhysXSrc" abstract="1">
+        Sets state of a rigid body PhysX actor.
+        <add name="Source" type="Ptr" template="NiAVObject" />
+    </niobject>
+
+    <niobject name="NiPhysXKinematicSrc" inherit="NiPhysXRigidBodySrc">
+        Sets state of kinematic PhysX actor.
+    </niobject>
+
+    <niobject name="NiPhysXDynamicSrc" inherit="NiPhysXRigidBodySrc">
+        Sends Gamebryo scene state to a PhysX dynamic actor.
     </niobject>
 
     <niobject name="NiArkAnimationExtraData" inherit="NiExtraData">

--- a/nif.xml
+++ b/nif.xml
@@ -816,14 +816,13 @@
         <option value="7" name="ZCOMP_NEVER">Always false. Ref value is ignored.</option>
     </enum>
 
-    <enum name="MotionSystem" storage="byte">
-        Bethesda Havok.
-        The motion system. 4 (Box) is used for everything movable. 7 (Keyframed) is used on statics and animated stuff.
+    <enum name="hkMotionType" storage="byte">
+        Bethesda Havok, based on hkpMotion::MotionType. Motion type of a rigid body determines what happens when it is simulated.
         <option value="0" name="MO_SYS_INVALID">Invalid</option>
         <option value="1" name="MO_SYS_DYNAMIC">A fully-simulated, movable rigid body. At construction time the engine checks the input inertia and selects MO_SYS_SPHERE_INERTIA or MO_SYS_BOX_INERTIA as appropriate.</option>
-        <option value="2" name="MO_SYS_SPHERE">Simulation is performed using a sphere inertia tensor.</option>
-        <option value="3" name="MO_SYS_SPHERE_INERTIA">This is the same as MO_SYS_SPHERE_INERTIA, except that simulation of the rigid body is "softened".</option>
-        <option value="4" name="MO_SYS_BOX">Simulation is performed using a box inertia tensor.</option>
+        <option value="2" name="MO_SYS_SPHERE_INERTIA">Simulation is performed using a sphere inertia tensor.</option>
+        <option value="3" name="MO_SYS_SPHERE_STABILIZED">This is the same as MO_SYS_SPHERE_INERTIA, except that simulation of the rigid body is "softened".</option>
+        <option value="4" name="MO_SYS_BOX_INERTIA">Simulation is performed using a box inertia tensor.</option>
         <option value="5" name="MO_SYS_BOX_STABILIZED">This is the same as MO_SYS_BOX_INERTIA, except that simulation of the rigid body is "softened".</option>
         <option value="6" name="MO_SYS_KEYFRAMED">Simulation is not performed as a normal rigid body. The keyframed rigid body has an infinite mass when viewed by the rest of the system. (used for creatures)</option>
         <option value="7" name="MO_SYS_FIXED">This motion type is used for the static elements of a game scene, e.g. the landscape. Faster than MO_SYS_KEYFRAMED at velocity 0. (used for weapons)</option>
@@ -838,34 +837,38 @@
         <option value="2" name="DEACTIVATOR_SPATIAL">Tells Havok to use a spatial deactivation scheme. This makes use of high and low frequencies of positional motion to determine when deactivation should occur.</option>
     </enum>
 
-    <enum name="SolverDeactivation" storage="byte">
-        Bethesda Havok.
-        A list of possible solver deactivation settings. This value defines how the
-        solver deactivates objects. The solver works on a per object basis.
-        Note: Solver deactivation does not save CPU, but reduces creeping of
-        movable objects in a pile quite dramatically.
+    <enum name="hkSolverDeactivation" storage="byte">
+        Bethesda Havok, based on hkpRigidBodyCinfo::SolverDeactivation.
+        A list of possible solver deactivation settings. This value defines how aggressively the solver deactivates objects.
+        Note: Solver deactivation does not save CPU, but reduces creeping of movable objects in a pile quite dramatically.
         <option value="0" name="SOLVER_DEACTIVATION_INVALID">Invalid</option>
-        <option value="1" name="SOLVER_DEACTIVATION_OFF">No solver deactivation</option>
+        <option value="1" name="SOLVER_DEACTIVATION_OFF">No solver deactivation.</option>
         <option value="2" name="SOLVER_DEACTIVATION_LOW">Very conservative deactivation, typically no visible artifacts.</option>
-        <option value="3" name="SOLVER_DEACTIVATION_MEDIUM">Normal deactivation, no serious visible artifacts in most cases</option>
-        <option value="4" name="SOLVER_DEACTIVATION_HIGH">Fast deactivation, visible artifacts</option>
-        <option value="5" name="SOLVER_DEACTIVATION_MAX">Very fast deactivation, visible artifacts</option>
+        <option value="3" name="SOLVER_DEACTIVATION_MEDIUM">Normal deactivation, no serious visible artifacts in most cases.</option>
+        <option value="4" name="SOLVER_DEACTIVATION_HIGH">Fast deactivation, visible artifacts.</option>
+        <option value="5" name="SOLVER_DEACTIVATION_MAX">Very fast deactivation, visible artifacts.</option>
     </enum>
 
-    <enum name="MotionQuality" storage="byte">
-        Bethesda Havok.
-        The motion type. Determines quality of motion?
+    <enum name="hkQualityType" storage="byte">
+        Bethesda Havok, based on hkpCollidableQualityType. Describes the priority and quality of collisions for a body,
+            e.g. you may expect critical game play objects to have solid high-priority collisions so that they never sink into ground,
+            or may allow penetrations for visual debris objects.
+        Notes:
+            - Fixed and keyframed objects cannot interact with each other.
+            - Debris can interpenetrate but still responds to Bullet hits.
+            - Critical objects are forced to not interpenetrate.
+            - Moving objects can interpenetrate slightly with other Moving or Debris objects but nothing else.
         <option value="0" name="MO_QUAL_INVALID">Automatically assigned to MO_QUAL_FIXED, MO_QUAL_KEYFRAMED or MO_QUAL_DEBRIS</option>
-        <option value="1" name="MO_QUAL_FIXED">Use this for fixed bodies. </option>
-        <option value="2" name="MO_QUAL_KEYFRAMED">Use this for moving objects with infinite mass.</option>
-        <option value="3" name="MO_QUAL_DEBRIS">Use this for all your debris objects</option>
-        <option value="4" name="MO_QUAL_MOVING">Use this for moving bodies, which should not leave the world.</option>
-        <option value="5" name="MO_QUAL_CRITICAL">Use this for all objects, which you cannot afford to tunnel through the world at all</option>
-        <option value="6" name="MO_QUAL_BULLET">Use this for very fast objects </option>
+        <option value="1" name="MO_QUAL_FIXED">Static body.</option>
+        <option value="2" name="MO_QUAL_KEYFRAMED">Animated body with infinite mass.</option>
+        <option value="3" name="MO_QUAL_DEBRIS">Low importance bodies adding visual detail.</option>
+        <option value="4" name="MO_QUAL_MOVING">Moving bodies which should not penetrate or leave the world, but can.</option>
+        <option value="5" name="MO_QUAL_CRITICAL">Gameplay critical bodies which cannot penetrate or leave the world under any circumstance.</option>
+        <option value="6" name="MO_QUAL_BULLET">Fast-moving bodies, such as projectiles.</option>
         <option value="7" name="MO_QUAL_USER">For user.</option>
-        <option value="8" name="MO_QUAL_CHARACTER">Use this for rigid body character controllers</option>
+        <option value="8" name="MO_QUAL_CHARACTER">For use with rigid body character controllers.</option>
         <option value="9" name="MO_QUAL_KEYFRAMED_REPORT">
-            Use this for moving objects with infinite mass which should report contact points and Toi-collisions against all other bodies, including other fixed and keyframed bodies.
+            Moving bodies with infinite mass which should report contact points and TOI collisions against all other bodies.
         </option>
     </enum>
 
@@ -1299,7 +1302,7 @@
         <add name="z" type="float" default="0.0">The z-coordinate.</add>
     </compound>
 
-    <compound name="QuaternionXYZW">
+    <compound name="hkQuaternion">
         A quaternion as it appears in the havok objects.
         <add name="x" type="float" default="0.0">The x-coordinate.</add>
         <add name="y" type="float" default="0.0">The y-coordinate.</add>
@@ -1746,7 +1749,7 @@
         <add name="Entry Properties" type="FurnitureEntryPoints" vercond="((Version >= 20.2.0.7) &amp;&amp; (User Version >= 12))">Unknown/unused in nif?</add>
     </compound>
 
-    <compound name="hkTriangle">
+    <compound name="TriangleData">
         Bethesda Havok. A triangle with extra data used for physics.
         <add name="Triangle" type="Triangle">The triangle.</add>
         <add name="Welding Info" type="ushort">Additional havok information on how triangles are welded.</add>
@@ -2089,7 +2092,7 @@
     <compound name="BoneTransform">
         Transformation data for the bone at this index in bhkPoseArray.
         <add name="Translation" type="Vector3" />
-        <add name="Rotation" type="QuaternionXYZW" />
+        <add name="Rotation" type="hkQuaternion" />
         <add name="Scale" type="Vector3" />
     </compound>
 
@@ -2149,7 +2152,7 @@
     <compound name="bhkCMSDTransform">
         A set of transformation data: translation and rotation
         <add name="Translation" type="Vector4">A vector that moves the chunk by the specified amount. W is not used.</add>
-        <add name="Rotation" type="QuaternionXYZW">Rotation. Reference point for rotation is bhkRigidBody translation.</add>
+        <add name="Rotation" type="hkQuaternion">Rotation. Reference point for rotation is bhkRigidBody translation.</add>
     </compound>
     
     <compound name="bhkCMSDChunk">
@@ -2334,7 +2337,7 @@
         <add name="Process Contact Callback Delay 2" type="ushort" default="0xffff" />
         <add name="Unknown Int 2" type="uint" vercond="User Version 2 &lt;= 34" />
         <add name="Translation" type="Vector4"> A vector that moves the body by the specified amount. Only enabled in bhkRigidBodyT objects.</add>
-        <add name="Rotation" type="QuaternionXYZW">The rotation Yaw/Pitch/Roll to apply to the body. Only enabled in bhkRigidBodyT objects.</add>
+        <add name="Rotation" type="hkQuaternion">The rotation Yaw/Pitch/Roll to apply to the body. Only enabled in bhkRigidBodyT objects.</add>
         <add name="Linear Velocity" type="Vector4">Linear velocity.</add>
         <add name="Angular Velocity" type="Vector4">Angular velocity.</add>
         <add name="Inertia Tensor" type="hkMatrix3">Defines how the mass is distributed among the body.</add>
@@ -2358,11 +2361,11 @@
             This is a hint to the engine to see how much CPU the engine should invest to keep this object from penetrating.
             A good choice is 5% - 20% of the smallest diameter of the object.
         </add>
-        <add name="Motion System" type="MotionSystem" default="MO_SYS_DYNAMIC">Motion system? Overrides Quality when on Keyframed?</add>
-        <add name="Deactivator Type" type="DeactivatorType" default="DEACTIVATOR_NEVER" vercond="(User Version 2 &lt;= 34)">The initial deactivator type of the body.</add>
+        <add name="Motion System" type="hkMotionType" default="MO_SYS_DYNAMIC">Motion system? Overrides Quality when on Keyframed?</add>
+        <add name="Deactivator Type" type="hkDeactivatorType" default="DEACTIVATOR_NEVER" vercond="(User Version 2 &lt;= 34)">The initial deactivator type of the body.</add>
         <add name="Enable Deactivation" type="bool" default="1" vercond="(User Version 2 &gt; 34)" />
-        <add name="Solver Deactivation" type="SolverDeactivation" default="SOLVER_DEACTIVATION_OFF">Usually set to 1 for fixed objects, or set to 2 for moving ones.  Seems to always be same as Unknown Byte 1.</add>
-        <add name="Quality Type" type="MotionQuality" default="MO_QUAL_FIXED">The motion type. Determines quality of motion?</add>
+        <add name="Solver Deactivation" type="hkSolverDeactivation" default="SOLVER_DEACTIVATION_OFF">How aggressively the engine will try to zero the velocity for slow objects. This does not save CPU.</add>
+        <add name="Quality Type" type="hkQualityType" default="MO_QUAL_FIXED">The type of interaction with other objects.</add>
         <add name="Unknown Bytes 1" type="byte" arr1="12">Unknown.</add>
         <add name="Unknown Bytes 2" type="byte" arr1="4" vercond="(User Version 2 &gt; 34)">Unknown. Skyrim only.</add>
         <add name="Num Constraints" type="uint"> The number of constraints this object is bound to.</add>
@@ -3235,9 +3238,9 @@
 
     <niobject name="hkPackedNiTriStripsData" abstract="0" inherit="bhkShapeCollection">
         NiTriStripsData for havok data?
-        <add name="Num Triangles" type="uint">Number of triangles?</add>
-        <add name="Triangles" type="hkTriangle" arr1="Num Triangles">The physics triangles?</add>
-        <add name="Num Vertices" type="uint">Number of vertices.</add>
+        <add name="Num Triangles" type="uint" />
+        <add name="Triangles" type="TriangleData" arr1="Num Triangles" />
+        <add name="Num Vertices" type="uint" />
         <add name="Unknown Byte 1" type="byte" ver1="20.2.0.7">Unknown.</add>
         <add name="Vertices" type="Vector3" arr1="Num Vertices">The vertices?</add>
         <add name="Num Sub Shapes" type="ushort" ver1="20.2.0.7">Number of subparts.</add>


### PR DESCRIPTION
_Changelog WIP_

- Header compound overhaul.  Wider version support, correct versioning, unknown decoding.
- Removal of `niflibtype` - generators must map this internally.
- NiPhysX block decoding
- NiPS* block decoding
- NiEvaluator (20.5+ KF) decoding
- NiMesh skinning block decoding
- Added 30.2.0.3 support to `<version>`
- Major documentation changes at block and row level
- Type narrowing for Ref and Ptr where possible
- Major structural changes to:
    - NiBSpline* blocks
    - NiControllerSequence
    - NiSourceTexture
    - NiPixelData and NiPersistentSrcTextureRendererData
    - NiMesh/NiGeometry - moved shared data into a compound

## New Attributes
- `prefix` for `enum`/`bitflags`.  It is used for prepending to each enum option name where necessary. 
- `suffix` for `add`.  It is appended to the name of the `add` where necessary.

## Required Parser Changes
- [ALL PARSERS] For `arg` attribute, you must support `\` to mean compound member accessor.  For example `Vertex Desc\Vertex Attributes` for the compound `BSVertexDesc`. 
- If using C-style enums that need unique enumerator names, you must combine the prefix and the name on `enum`/`bitflags`.
- If generating class variables in a strongly typed language, you must append the suffix to the variable name.  The suffix is provided when multiple `<add>` use the same name but the type differs per version.  They are always exclusive by version but sometimes the type changes.

## Upcoming Commits

- ~~A major reorganization is planned that will basically rearrange every line of the file.  This will group objects logically and make the file easier to navigate.~~ **Deferred for 0.9.5**
- ~~A major overhaul of the use of `User Version` vs `User Version 2`.  The latter has been confirmed to be Bethesda-only and there are many improper uses of `User Version` in verconds when `User Version 2` suffices.  Improper `User Version` use can cause support for other games' NIFs to break, such as Divinity 2 which has user versions of `0x20000` and `0x30000`.~~  **Completed**
- ~~Commits which widen NIF version support and lower the number of files which load with error.~~
