### PR TITLE
Release 0.9.0

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -1478,7 +1478,7 @@
 		<option value="15" name="VF_Unknown_8" />      <!-- & 32768 -->
 	</bitflags>
     
-	<compound name="BSVertexData">
+	<compound name="BSVertexData" niflibtype="BSVertexData">
 		<add name="Vertex" type="HalfVector3" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
 		<add name="Bitangent X" type="hfloat" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 256) != 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />
 		<add name="Unknown Short" type="ushort" cond="((ARG &amp; 16) != 0) &amp;&amp; ((ARG &amp; 256) == 0) &amp;&amp; ((ARG &amp; 16384) == 0)" />

--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.8.5.0">
+<niftoolsxml version="0.8.6.0">
     <!--These are the version numbers marked as supported by NifSkope.
         The num argument is the numeric representation created by storing
         each part of the version in a byte.  For example, 4.0.0.2 is

--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.8.4.0">
+<niftoolsxml version="0.8.5.0">
     <!--These are the version numbers marked as supported by NifSkope.
         The num argument is the numeric representation created by storing
         each part of the version in a byte.  For example, 4.0.0.2 is

--- a/nif.xml
+++ b/nif.xml
@@ -1698,9 +1698,9 @@
 
     <compound name="HavokColFilter">
         ColFilter property for Havok. It contains Layer, Flags and Part Number
-        <add name="Layer" type="OblivionLayer" default="STATIC" vercond="(Version != 20.2.0.7) || ((Version == 20.2.0.7) &amp;&amp; (User Version != 11) &amp;&amp; (User Version != 12) &amp;&amp; (User Version 2 != 34) &amp;&amp; (User Version 2 != 83))">Sets mesh color in Oblivion Construction Set.</add><!--condition: all except Fallout 3 and Skyrim -->
-        <add name="Layer" type="Fallout3Layer" default="STATIC" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version == 11) &amp;&amp; (User Version 2 == 34)">Sets mesh color in Fallout 3 GECK.</add>
-        <add name="Layer" type="SkyrimLayer" default="STATIC" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version == 12) &amp;&amp; (User Version 2 &gt;= 83)">Physical purpose of collision object? The setting affects object's havok behavior in game.</add>
+        <add name="Layer" type="OblivionLayer" default="OL_STATIC" ver1="20.0.0.4" ver2="20.0.0.5">The layer the collision belongs to.</add>
+        <add name="Layer" type="Fallout3Layer" default="FOL_STATIC" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &lt;= 34)">The layer the collision belongs to.</add>
+        <add name="Layer" type="SkyrimLayer" default="SKYL_STATIC" vercond="(Version == 20.2.0.7) &amp;&amp; (User Version 2 &gt; 34)">The layer the collision belongs to.</add>
 
         <add name="Flags and Part Number" type="byte" default="0">FLAGS are stored in highest 3 bits:
         	Bit 7: sets the LINK property and controls whether this body is physically linked to others.


### PR DESCRIPTION
Release version 0.9.0

- Header compound overhaul.  Wider version support, correct versioning, unknown decoding.
- Removal of `niflibtype` - generators must map this internally.
- NiPhysX block decoding
- NiPS* block decoding
- NiEvaluator (20.5+ KF) decoding
- NiMesh skinning block decoding
- Added 30.2.0.3 support to `<version>`
- Major documentation changes at block and row level
- Type narrowing for Ref and Ptr where possible
- Major structural changes to:
    - NiBSpline* blocks
    - NiControllerSequence
    - NiSourceTexture
    - NiPixelData and NiPersistentSrcTextureRendererData
    - NiMesh/NiGeometry - moved shared data into a compound

## New Attributes
- `prefix` for `enum`/`bitflags`.  It is used for prepending to each enum option name where necessary. 
- `suffix` for `add`.  It is appended to the name of the `add` where necessary.

## Required Parser Changes
- [ALL PARSERS] For `arg` attribute, you must support `\` to mean compound member accessor.  For example `Vertex Desc\Vertex Attributes` for the compound `BSVertexDesc`. 
- If using C-style enums that need unique enumerator names, you must combine the prefix and the name on `enum`/`bitflags`.
- If generating class variables in a strongly typed language, you must append the suffix to the variable name.  The suffix is provided when multiple `<add>` use the same name but the type differs per version.  They are always exclusive by version but sometimes the type changes.