### PR TITLE
Add additional Skyrim collision layer information

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -761,14 +761,7 @@
         <option value="44" name="SKYL_CUSTOMPICK2">Custom Pick 2</option>
         <option value="45" name="SKYL_SPELLEXPLOSION">Spell Explosion</option>
         <option value="46" name="SKYL_DROPPINGPICK">Dropping Pick</option>
-        <option value="47" name="SKYL_DEADACTORZONE">Dead Actor Zone</option>
-        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Trigger Falling Trap</option>
-        <option value="49" name="SKYL_NAVCUT">Nav Cut</option>
-        <option value="50" name="SKYL_CRITTER">Critter</option>
-        <option value="51" name="SKYL_SPELLTRIGGER">Spell Trigger</option>
-        <option value="52" name="SKYL_LIVING_AND_DEAD_ACTORS">Living And Dead Actors</option>
-        <option value="53" name="SKYL_DETECTION">Detection</option>
-        <option value="54" name="SKYL_TRAP_TRIGGER">Trap Trigger</option>
+        <option value="47" name="SKYL_NULL">Null</option>
     </enum>
 
     <enum name="BipedPart" storage="byte">

--- a/nif.xml
+++ b/nif.xml
@@ -761,7 +761,14 @@
         <option value="44" name="SKYL_CUSTOMPICK2">Custom Pick 2</option>
         <option value="45" name="SKYL_SPELLEXPLOSION">Spell Explosion</option>
         <option value="46" name="SKYL_DROPPINGPICK">Dropping Pick</option>
-        <option value="47" name="SKYL_NULL">Null</option>
+        <option value="47" name="SKYL_DEADACTORZONE">Dead Actor Zone</option>
+        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Trigger Falling Trap</option>
+        <option value="49" name="SKYL_NAVCUT">Nav Cut</option>
+        <option value="50" name="SKYL_CRITTER">Critter</option>
+        <option value="51" name="SKYL_SPELLTRIGGER">Spell Trigger</option>
+        <option value="52" name="SKYL_LIVING_AND_DEAD_ACTORS">Living And Dead Actors</option>
+        <option value="53" name="SKYL_DETECTION">Detection</option>
+        <option value="54" name="SKYL_TRAP_TRIGGER">Trap Trigger</option>
     </enum>
 
     <enum name="BipedPart" storage="byte">

--- a/nif.xml
+++ b/nif.xml
@@ -762,7 +762,7 @@
         <option value="45" name="SKYL_SPELLEXPLOSION">Spell Explosion</option>
         <option value="46" name="SKYL_DROPPINGPICK">Dropping Pick</option>
         <option value="47" name="SKYL_DEADACTORZONE">Dead Actor Zone</option>
-        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Falling Trap Trigger</option>
+        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Trigger Falling Trap</option>
         <option value="49" name="SKYL_NAVCUT">Nav Cut</option>
         <option value="50" name="SKYL_CRITTER">Critter</option>
         <option value="51" name="SKYL_SPELLTRIGGER">Spell Trigger</option>

--- a/nif.xml
+++ b/nif.xml
@@ -761,7 +761,14 @@
         <option value="44" name="SKYL_CUSTOMPICK2">Custom Pick 2</option>
         <option value="45" name="SKYL_SPELLEXPLOSION">Spell Explosion</option>
         <option value="46" name="SKYL_DROPPINGPICK">Dropping Pick</option>
-        <option value="47" name="SKYL_NULL">Null</option>
+        <option value="47" name="SKYL_DEADACTORZONE">Dead Actor Zone</option>
+        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Falling Trap Trigger</option>
+        <option value="49" name="SKYL_NAVCUT">Nav Cut</option>
+        <option value="50" name="SKYL_CRITTER">Critter</option>
+        <option value="51" name="SKYL_SPELLTRIGGER">Spell Trigger</option>
+        <option value="52" name="SKYL_LIVING_AND_DEAD_ACTORS">Living And Dead Actors</option>
+        <option value="53" name="SKYL_DETECTION">Detection</option>
+        <option value="54" name="SKYL_TRAP_TRIGGER">Trap Trigger</option>
     </enum>
 
     <enum name="BipedPart" storage="byte">

--- a/nif.xml
+++ b/nif.xml
@@ -762,7 +762,7 @@
         <option value="45" name="SKYL_SPELLEXPLOSION">Spell Explosion</option>
         <option value="46" name="SKYL_DROPPINGPICK">Dropping Pick</option>
         <option value="47" name="SKYL_DEADACTORZONE">Dead Actor Zone</option>
-        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Trigger Falling Trap</option>
+        <option value="48" name="SKYL_TRIGGER_FALLINGTRAP">Falling Trap Trigger</option>
         <option value="49" name="SKYL_NAVCUT">Nav Cut</option>
         <option value="50" name="SKYL_CRITTER">Critter</option>
         <option value="51" name="SKYL_SPELLTRIGGER">Spell Trigger</option>


### PR DESCRIPTION
Added additional enum options to SkyrimLayer corresponding to previously undefined or improperly defined Skyrim collision layers

How I obtained the information to make these changes, and confirmed the information to be correct:

While figuring out how the falling oil lamp traps work I made a discovery. The oil lamps use destruction data to switch to a havok-enabled gavity-affected nif at a certain item health. This nif contains two bhkCollisionObject blocks, one collides with the world as a physics object, the other acts as a trigger volume. The trigger volume can detect when another collider enters, stays, and leaves it's volume. The oil lamp trap uses this trigger volume to trigger an event in it's attached script, replacing the falling lamp with an havok explosion, visual effects, and a nif with the lamp broken into smaller havok-enabled pieces. 

What colliders are detected by the trigger volume is defined by it's own collision layer, the collision layer of the other collider, and what collision layers can interact with each other, as defined by the collision layers objects in the Skyrim Creation Kit. 

When investigating all of this, I found that the collision layer of the trigger volume, when viewed in nifskope, is specified as the integer 48, with no name. I cross-referenced the collision layer objects in the CK with the Skyrim collision layers defined in the nif.xml, included with nifskope (2.0 dev 7), to find the what layers where unaccounted for. From that point, I made the assumption that the L_TRIGGER_FALLINGTRAP layer was a likely candidate for my unknown layer 48. In the CK, I removed L_ANIMSTATIC from L_TRIGGER_FALLINGTRAP's mutually interactable layers. I then placed an item with a collider in the L_ANIMSTATIC layer under the oil lamp trap in Bleak Falls Barrow. Triggering the trap caused the havok-model to fall, hit, then roll off my anim static item, then hit the ground and explode. I then added the layer back and tried again, this time the lamp exploded on the anim static item. 

With now only 7 collision layers unaccounted for, I decided to try to experiment to figure out the corresponding integers for the rest. I set the collision layer in my anim static nif to the next unknown int, and changed the collision layer settings of L_TRIGGER_FALLINGTRAP in the CK to only collide with the next unaccounted layer. I would load into Skyrim, fire an arrow at the lamp and if it exploded on my nif, I would note that down and move on to the next integer. If it didn't explode, I went back into the CK, went to the next accounted layer, and tried again until I found the right layer.

If I need to provide proof in the form of an esp and nifs, I can do that. Also, I wasn't sure what the pre-set standards are for version increment so I did not change it.