### PR TITLE
Updates to nif.xml based on NifSkope dev8 nif.xml

### DIFF
--- a/doc/nifdoc.css
+++ b/doc/nifdoc.css
@@ -27,6 +27,6 @@ tr.even       { background: #EEEEEE; color: black; }
 td.aname { white-space: nowrap; }
 td.atype { white-space: nowrap; }
 td.aarg  { font-size: small; font-family: 'Courier New', Courier, monospace; }
-td.aarr1 { font-size: small; font-family: 'Courier New', Courier, monospace; }
-td.aarr2 { font-size: small; font-family: 'Courier New', Courier, monospace; }
+td.alength { font-size: small; font-family: 'Courier New', Courier, monospace; }
+td.awidth { font-size: small; font-family: 'Courier New', Courier, monospace; }
 td.acond { font-size: small; font-family: 'Courier New', Courier, monospace; }

--- a/nif.xml
+++ b/nif.xml
@@ -2587,7 +2587,7 @@
         <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
         <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
         <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
-        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false">
+        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false" />
     </bitfield>
 
     <struct name="bhkCMSChunk" module="BSHavok" versions="#SKY_AND_LATER#">

--- a/nif.xml
+++ b/nif.xml
@@ -551,6 +551,8 @@
         Bethesda Havok. Material descriptor for a Havok shape in Skyrim.
         <option value="0" name="SKY_HAV_MAT_NONE">Invalid Material</option>
         <option value="131151687" name="SKY_HAV_MAT_BROKEN_STONE">Broken Stone</option>
+        <option value="322207473" name="SKY_HAV_MAT_MATERIAL_CARRIAGE_WHEEL">Material Carriage Wheel</option>
+        <option value="346811165" name="SKY_HAV_MAT_MATERIAL_METAL_LIGHT">Material Metal Light</option>
         <option value="365420259" name="SKY_HAV_MAT_LIGHT_WOOD">Light Wood</option>
         <option value="398949039" name="SKY_HAV_MAT_SNOW">Snow</option>
         <option value="428587608" name="SKY_HAV_MAT_GRAVEL">Gravel</option>
@@ -563,6 +565,7 @@
         <option value="781661019" name="SKY_HAV_MAT_MATERIAL_CERAMIC_MEDIUM">Material Ceramic Medium</option>
         <option value="790784366" name="SKY_HAV_MAT_MATERIAL_BASKET">Material Basket</option>
         <option value="873356572" name="SKY_HAV_MAT_ICE">Ice</option>
+        <option value="880200008" name="SKY_HAV_MAT_STAIRS_GLASS">Stairs Glass</option>
         <option value="899511101" name="SKY_HAV_MAT_STAIRS_STONE">Stairs Stone</option>
         <option value="1024582599" name="SKY_HAV_MAT_WATER">Water</option>
         <option value="1028101969" name="SKY_HAV_MAT_UNKNOWN_1028101969">Unknown in Creation Kit v1.6.89.0. Found in actors\draugr\character assets\skeletons.nif.</option>
@@ -592,6 +595,7 @@
         <option value="2518321175" name="SKY_HAV_MAT_DRAGON">Dragon</option>
         <option value="2617944780" name="SKY_HAV_MAT_MATERIAL_BLADE_1HAND_SMALL">Material Blade 1Hand Small</option>
         <option value="2632367422" name="SKY_HAV_MAT_MATERIAL_SKIN_SMALL">Material Skin Small</option>
+        <option value="2742858142" name="SKY_HAV_MAT_MATERIAL_POTS_PANS">Material Pots Pans</option>
         <option value="2892392795" name="SKY_HAV_MAT_STAIRS_BROKEN_STONE">Stairs Broken Stone</option>
         <option value="2965929619" name="SKY_HAV_MAT_MATERIAL_SKIN_LARGE">Material Skin Large</option>
         <option value="2974920155" name="SKY_HAV_MAT_ORGANIC">Organic</option>
@@ -599,6 +603,7 @@
         <option value="3070783559" name="SKY_HAV_MAT_HEAVY_WOOD">Heavy Wood</option>
         <option value="3074114406" name="SKY_HAV_MAT_MATERIAL_CHAIN">Material Chain</option>
         <option value="3106094762" name="SKY_HAV_MAT_DIRT">Dirt</option>
+        <option value="3387452107" name="SKY_HAV_MAT_MATERIAL_SKIN_METAL_LARGE">Material Skin Metal Large</option>
         <option value="3424720541" name="SKY_HAV_MAT_MATERIAL_ARMOR_LIGHT">Material Armor Light</option>
         <option value="3448167928" name="SKY_HAV_MAT_MATERIAL_SHIELD_LIGHT">Material Shield Light</option>
         <option value="3589100606" name="SKY_HAV_MAT_MATERIAL_COIN">Material Coin</option>
@@ -607,24 +612,19 @@
         <option value="3725505938" name="SKY_HAV_MAT_MATERIAL_ARROW">Material Arrow</option>
         <option value="3739830338" name="SKY_HAV_MAT_GLASS">Glass</option>
         <option value="3741512247" name="SKY_HAV_MAT_STONE">Stone</option>
+        <option value="3764646153" name="SKY_HAV_MAT_MATERIAL_WATER_PUDDLE">Material Water Puddle</option>
         <option value="3839073443" name="SKY_HAV_MAT_CLOTH">Cloth</option>
+        <option value="3855001958" name="SKY_HAV_MAT_MATERIAL_SKIN_METAL_SMALL">Material Skin Metal Small</option>
+        <option value="3895166727" name="SKY_HAV_MAT_WARD">Ward</option>
+        <option value="3934839107" name="SKY_HAV_MAT_WEB">Web</option>
         <option value="3969592277" name="SKY_HAV_MAT_MATERIAL_BLUNT_2HAND">Material Blunt 2Hand</option>
         <option value="4239621792" name="SKY_HAV_MAT_UNKNOWN_4239621792">Unknown in Creation Kit v1.9.32.0. Found in Dawnguard DLC in meshes\dlc01\prototype\dlc1protoswingingbridge.nif.</option>
         <option value="4283869410" name="SKY_HAV_MAT_MATERIAL_BOULDER_MEDIUM">Material Boulder Medium</option>
-        <option value="3855001958" name="SKY_HAV_MAT_UNKNOWN_3855001958" />
-        <option value="3387452107" name="SKY_HAV_MAT_UNKNOWN_3387452107" />
-        <option value="2742858142" name="SKY_HAV_MAT_UNKNOWN_2742858142" />
         <option value="2794252627" name="SKY_HAV_MAT_UNKNOWN_2794252627" />
-        <option value="346811165" name="SKY_HAV_MAT_UNKNOWN_346811165" />
         <option value="1668849266" name="SKY_HAV_MAT_UNKNOWN_1668849266" />
         <option value="1734341287" name="SKY_HAV_MAT_UNKNOWN_1734341287" />
         <option value="3974071006" name="SKY_HAV_MAT_UNKNOWN_3974071006" />
-        <option value="3895166727" name="SKY_HAV_MAT_UNKNOWN_3895166727">dlc1shadowshieldfx</option>
-        <option value="880200008" name="SKY_HAV_MAT_UNKNOWN_880200008">azurafloorhex01</option>
-        <option value="3934839107" name="SKY_HAV_MAT_UNKNOWN_3934839107">fxspiderwebhitstrip01</option>
         <option value="3941234649" name="SKY_HAV_MAT_UNKNOWN_3941234649">tfxsteelswordbloody</option>
-        <option value="322207473" name="SKY_HAV_MAT_UNKNOWN_322207473">prisonercarriage01</option>
-        <option value="3764646153" name="SKY_HAV_MAT_UNKNOWN_3764646153">tundrastreambend01watera</option>
         <option value="1820198263" name="SKY_HAV_MAT_UNKNOWN_1820198263">steelgreatsword</option>
     </enum>
 

--- a/nif.xml
+++ b/nif.xml
@@ -197,7 +197,7 @@
         <global token="#BSVER#" string="BS Header\BS Version" />
     </token>
 
-    <token name="operator" attrs="cond vercond arr1 arr2 arg">
+    <token name="operator" attrs="cond vercond length width arg">
         All Operators except for unary not (!), parentheses, and member of (\)
         NOTE: These can be ignored entirely by string substitution and dealt with directly.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
@@ -1575,13 +1575,13 @@
     <struct name="SizedString">
         A string of given length.
         <field name="Length" type="uint">The string length.</field>
-        <field name="Value" type="char" arr1="Length">The string itself.</field>
+        <field name="Value" type="char" length="Length">The string itself.</field>
     </struct>
 
     <struct name="SizedString16">
         A string of given length, using a ushort to store string length.
         <field name="Length" type="ushort">The string length.</field>
-        <field name="Value" type="char" arr1="Length">The string itself.</field>
+        <field name="Value" type="char" length="Length">The string itself.</field>
     </struct>
 
     <struct name="string">
@@ -1600,20 +1600,20 @@
         A mapping or hash table between NiFixedString keys and a generic value.
         Currently, #T# must be a basic type due to nif.xml restrictions.
         <field name="Num Strings" type="uint" />
-        <field name="Strings" type="NiTFixedStringMapItem" template="#T#" arr1="Num Strings" />
+        <field name="Strings" type="NiTFixedStringMapItem" template="#T#" length="Num Strings" />
     </struct>
 
     <struct name="ByteArray">
         An array of bytes.
         <field name="Data Size" type="uint">The number of bytes in this array</field>
-        <field name="Data" type="byte" arr1="Data Size">The bytes which make up the array</field>
+        <field name="Data" type="byte" length="Data Size">The bytes which make up the array</field>
     </struct>
 
     <struct name="ByteMatrix">
         An array of bytes.
         <field name="Data Size 1" type="uint">The number of bytes in this array</field>
         <field name="Data Size 2" type="uint">The number of bytes in this array</field>
-        <field name="Data" type="byte" arr1="Data Size 2" arr2="Data Size 1">The bytes which make up the array</field>
+        <field name="Data" type="byte" length="Data Size 2" width="Data Size 1">The bytes which make up the array</field>
     </struct>
 
     <struct name="Color3" size="12">
@@ -1655,20 +1655,20 @@
     <struct name="Footer">
         The NIF file footer.
         <field name="Num Roots" type="uint" since="3.3.0.13">The number of root references.</field>
-        <field name="Roots" type="Ref" template="NiObject" arr1="Num Roots" since="3.3.0.13">List of root NIF objects. If there is a camera, for 1st person view, then this NIF object is referred to as well in this list, even if it is not a root object (usually we want the camera to be attached to the Bip Head node).</field>
+        <field name="Roots" type="Ref" template="NiObject" length="Num Roots" since="3.3.0.13">List of root NIF objects. If there is a camera, for 1st person view, then this NIF object is referred to as well in this list, even if it is not a root object (usually we want the camera to be attached to the Bip Head node).</field>
     </struct>
 
     <struct name="LODRange">
         The distance range where a specific level of detail applies.
         <field name="Near Extent" type="float">Begining of range.</field>
         <field name="Far Extent" type="float">End of Range.</field>
-        <field name="Unknown Ints" type="uint" arr1="3" until="3.1" />
+        <field name="Unknown Ints" type="uint" length="3" until="3.1" />
     </struct>
 
     <struct name="MatchGroup">
         Group of vertex indices of vertices that match.
         <field name="Num Vertices" type="ushort">Number of vertices in this group.</field>
-        <field name="Vertex Indices" type="ushort" arr1="Num Vertices">The vertex indices.</field>
+        <field name="Vertex Indices" type="ushort" length="Num Vertices">The vertex indices.</field>
     </struct>
     
     <struct name="Vector3" size="12">
@@ -1799,13 +1799,13 @@
     <struct name="NodeSet">
         A set of NiNode references.
         <field name="Num Nodes" type="uint">Number of node references that follow.</field>
-        <field name="Nodes" type="Ptr" template="NiNode" arr1="Num Nodes">The list of NiNode references.</field>
+        <field name="Nodes" type="Ptr" template="NiNode" length="Num Nodes">The list of NiNode references.</field>
     </struct>
 
     <struct name="ExportString">
         Specific to Bethesda-specific header export strings.
         <field name="Length" type="byte">The string length.</field>
-        <field name="Value" type="char" arr1="Length">The string itself, null terminated (the null terminator is taken into account in the length byte).</field>
+        <field name="Value" type="char" length="Length">The string itself, null terminated (the null terminator is taken into account in the length byte).</field>
     </struct>
 
     <struct name="SkinInfo" size="8" since="V4_2_2_0">
@@ -1817,7 +1817,7 @@
     <struct name="SkinInfoSet" since="V4_2_2_0">
         A set of NiBoneLODController::SkinInfo.
         <field name="Num Skin Info" type="uint" />
-        <field name="Skin Info" type="SkinInfo" arr1="Num Skin Info" />
+        <field name="Skin Info" type="SkinInfo" length="Num Skin Info" />
     </struct>
 
     <struct name="BoneVertData" size="6">
@@ -1879,7 +1879,7 @@
     <struct name="Header">
         The NIF file header.
         <field name="Header String" type="HeaderString">'NetImmerse File Format x.x.x.x' (versions &lt;= 10.0.1.2) or 'Gamebryo File Format x.x.x.x' (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</field>
-        <field name="Copyright" type="LineString" arr1="3" until="3.1.0.0" />
+        <field name="Copyright" type="LineString" length="3" until="3.1.0.0" />
         <field name="Version" type="FileVersion" default="0x04000002" since="3.1.0.1">The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002, 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...</field>
         <field name="Endian Type" type="EndianType" default="ENDIAN_LITTLE" since="20.0.0.3">Determines the endianness of the data in the file.</field>
         <field name="User Version" type="ulittle32" since="10.0.1.8">An extra version number, for companies that decide to modify the file format.</field>
@@ -1887,15 +1887,15 @@
         <field name="BS Header" type="BSStreamHeader" cond="#BSSTREAMHEADER#" />
         <field name="Metadata" type="ByteArray" since="30.0.0.0" />
         <field name="Num Block Types" type="ushort" since="5.0.0.1">Number of object types in this NIF file.</field>
-        <field name="Block Types" type="SizedString" arr1="Num Block Types" since="5.0.0.1" cond="Version != 20.3.1.2">List of all object types used in this NIF file.</field>
-        <field name="Block Type Hashes" type="uint" arr1="Num Block Types" since="20.3.1.2" until="20.3.1.2">List of all object types used in this NIF file.</field>
-        <field name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" since="5.0.0.1">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</field>
-        <field name="Block Size" type="uint" arr1="Num Blocks" since="20.2.0.5">Array of block sizes</field>
+        <field name="Block Types" type="SizedString" length="Num Block Types" since="5.0.0.1" cond="Version != 20.3.1.2">List of all object types used in this NIF file.</field>
+        <field name="Block Type Hashes" type="uint" length="Num Block Types" since="20.3.1.2" until="20.3.1.2">List of all object types used in this NIF file.</field>
+        <field name="Block Type Index" type="BlockTypeIndex" length="Num Blocks" since="5.0.0.1">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</field>
+        <field name="Block Size" type="uint" length="Num Blocks" since="20.2.0.5">Array of block sizes</field>
         <field name="Num Strings" type="uint" since="20.1.0.1">Number of strings.</field>
         <field name="Max String Length" type="uint" since="20.1.0.1">Maximum string length.</field>
-        <field name="Strings" type="SizedString" arr1="Num Strings" since="20.1.0.1">Strings.</field>
+        <field name="Strings" type="SizedString" length="Num Strings" since="20.1.0.1">Strings.</field>
         <field name="Num Groups" type="uint" default="0" since="5.0.0.6" />
-        <field name="Groups" type="uint" arr1="Num Groups" since="5.0.0.6" />
+        <field name="Groups" type="uint" length="Num Groups" since="5.0.0.6" />
     </struct>
 
     <struct name="StringPalette">
@@ -1924,7 +1924,7 @@
         Array of vector keys (anything that can be interpolated, except rotations).
         <field name="Num Keys" type="uint">Number of keys in the array.</field>
         <field name="Interpolation" type="KeyType" cond="Num Keys != 0">The key type.</field>
-        <field name="Keys" type="Key" arg="Interpolation" template="#T#" arr1="Num Keys">The keys.</field>
+        <field name="Keys" type="Key" arg="Interpolation" template="#T#" length="Num Keys">The keys.</field>
     </struct>
 
     <struct name="QuatKey" generic="true">
@@ -2035,8 +2035,8 @@
 		<field name="Tangent" type="ByteVector3" cond="(#ARG# #BITAND# 0x18) == 0x18" />
 		<field name="Bitangent Z" type="byte" cond="(#ARG# #BITAND# 0x18) == 0x18" />
 		<field name="Vertex Colors" type="ByteColor4" cond="#ARG# #BITAND# 0x20" />
-		<field name="Bone Weights" type="hfloat" arr1="4" cond="#ARG# #BITAND# 0x40" />
-		<field name="Bone Indices" type="byte" arr1="4" cond="#ARG# #BITAND# 0x40" />
+		<field name="Bone Weights" type="hfloat" length="4" cond="#ARG# #BITAND# 0x40" />
+		<field name="Bone Indices" type="byte" length="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Eye Data" type="float" cond="#ARG# #BITAND# 0x100" />
 	</struct>
 
@@ -2050,8 +2050,8 @@
 		<field name="Tangent" type="ByteVector3" cond="(#ARG# #BITAND# 0x18) == 0x18" />
 		<field name="Bitangent Z" type="byte" cond="(#ARG# #BITAND# 0x18) == 0x18" />
 		<field name="Vertex Colors" type="ByteColor4" cond="#ARG# #BITAND# 0x20" />
-		<field name="Bone Weights" type="hfloat" arr1="4" cond="#ARG# #BITAND# 0x40" />
-		<field name="Bone Indices" type="byte" arr1="4" cond="#ARG# #BITAND# 0x40" />
+		<field name="Bone Weights" type="hfloat" length="4" cond="#ARG# #BITAND# 0x40" />
+		<field name="Bone Indices" type="byte" length="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Eye Data" type="float" cond="#ARG# #BITAND# 0x100" />
 	</struct>
 
@@ -2062,25 +2062,25 @@
         <field name="Num Bones" type="ushort">Number of bones influencing this submesh.</field>
         <field name="Num Strips" type="ushort">Number of strips in this submesh (zero if not stripped).</field>
         <field name="Num Weights Per Vertex" type="ushort" default="4">Number of weight coefficients per vertex. The Gamebryo engine seems to work well only if this number is equal to 4, even if there are less than 4 influences per vertex.</field>
-        <field name="Bones" type="ushort" arr1="Num Bones">List of bones.</field>
+        <field name="Bones" type="ushort" length="Num Bones">List of bones.</field>
         <field name="Has Vertex Map" type="bool" since="10.1.0.0">Do we have a vertex map?</field>
-        <field name="Vertex Map" type="ushort" arr1="Num Vertices" until="10.0.1.2">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
-        <field name="Vertex Map" type="ushort" arr1="Num Vertices" cond="Has Vertex Map" since="10.1.0.0">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
+        <field name="Vertex Map" type="ushort" length="Num Vertices" until="10.0.1.2">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
+        <field name="Vertex Map" type="ushort" length="Num Vertices" cond="Has Vertex Map" since="10.1.0.0">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
         <field name="Has Vertex Weights" type="bool" since="10.1.0.0">Do we have vertex weights?</field>
-        <field name="Vertex Weights" type="float" arr1="Num Vertices" arr2="Num Weights Per Vertex" until="10.0.1.2">The vertex weights.</field>
-        <field name="Vertex Weights" type="float" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Vertex Weights" since="10.1.0.0">The vertex weights.</field>
-        <field name="Strip Lengths" type="ushort" arr1="Num Strips">The strip lengths.</field>
+        <field name="Vertex Weights" type="float" length="Num Vertices" width="Num Weights Per Vertex" until="10.0.1.2">The vertex weights.</field>
+        <field name="Vertex Weights" type="float" length="Num Vertices" width="Num Weights Per Vertex" cond="Has Vertex Weights" since="10.1.0.0">The vertex weights.</field>
+        <field name="Strip Lengths" type="ushort" length="Num Strips">The strip lengths.</field>
         <field name="Has Faces" type="bool" calc="(#LEN[Strips]# #ADD# #LEN[Triangles]# #GT# 0) #THEN# 1 #ELSE# 0" since="10.1.0.0">Do we have triangle or strip data?</field>
-        <field name="Strips" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="Num Strips != 0" until="10.0.1.2">The strips.</field>
-        <field name="Strips" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="(Has Faces) #AND# (Num Strips != 0)" since="10.1.0.0">The strips.</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Num Strips == 0" until="10.0.1.2">The triangles.</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="(Has Faces) #AND# (Num Strips == 0)" since="10.1.0.0">The triangles.</field>
+        <field name="Strips" type="ushort" length="Num Strips" width="Strip Lengths" cond="Num Strips != 0" until="10.0.1.2">The strips.</field>
+        <field name="Strips" type="ushort" length="Num Strips" width="Strip Lengths" cond="(Has Faces) #AND# (Num Strips != 0)" since="10.1.0.0">The strips.</field>
+        <field name="Triangles" type="Triangle" length="Num Triangles" cond="Num Strips == 0" until="10.0.1.2">The triangles.</field>
+        <field name="Triangles" type="Triangle" length="Num Triangles" cond="(Has Faces) #AND# (Num Strips == 0)" since="10.1.0.0">The triangles.</field>
         <field name="Has Bone Indices" type="bool">Do we have bone indices?</field>
-        <field name="Bone Indices" type="byte" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into 'Bones'.</field>
+        <field name="Bone Indices" type="byte" length="Num Vertices" width="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into 'Bones'.</field>
         <field name="LOD Level" type="byte" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
         <field name="Global VB" type="bool" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
 		<field name="Vertex Desc" type="BSVertexDesc" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Triangles Copy" type="Triangle" arr1="Num Triangles" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Triangles Copy" type="Triangle" length="Num Triangles" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
     </struct>
 
     <struct name="NiPlane" size="16">
@@ -2092,7 +2092,7 @@
     <struct name="NiBoundAABB" size="26">
         Divinity 2 specific NiBound extension.
         <field name="Num Corners" type="ushort" default="2" />
-        <field name="Corners" type="Vector3" arr1="2">Corners are only non-zero if Num Corners is 2. Hardcoded to 2.</field>
+        <field name="Corners" type="Vector3" length="2">Corners are only non-zero if Num Corners is 2. Hardcoded to 2.</field>
     </struct>
 
     <struct name="NiBound">
@@ -2106,16 +2106,16 @@
         A 3D curve made up of control points and knots.
         <field name="Degree" type="uint" />
         <field name="Num Control Points" type="uint" />
-        <field name="Control Points" type="Vector3" arr1="Num Control Points" />
+        <field name="Control Points" type="Vector3" length="Num Control Points" />
         <field name="Num Knots" type="uint" />
-        <field name="Knots" type="float" arr1="Num Knots" />
+        <field name="Knots" type="float" length="Num Knots" />
     </struct>
 
     <struct name="NiQuatTransform">
         <field name="Translation" type="Vector3" />
         <field name="Rotation" type="Quaternion" />
         <field name="Scale" type="float" default="1.0" />
-        <field name="TRS Valid" type="bool" arr1="3" until="10.1.0.109">Whether each transform component is valid.</field>
+        <field name="TRS Valid" type="bool" length="3" until="10.1.0.109">Whether each transform component is valid.</field>
     </struct>
 
     <struct name="NiTransform" size="52">
@@ -2163,9 +2163,9 @@
         <field name="Frame Name" type="string" since="10.1.0.106">Name of the frame.</field>
         <field name="Num Keys" type="uint" until="10.1.0.0">The number of morph keys that follow.</field>
         <field name="Interpolation" type="KeyType" until="10.1.0.0">Unlike most objects, the presense of this value is not conditional on there being keys.</field>
-        <field name="Keys" type="Key" arg="Interpolation" template="float" arr1="Num Keys" until="10.1.0.0">The morph key frames.</field>
+        <field name="Keys" type="Key" arg="Interpolation" template="float" length="Num Keys" until="10.1.0.0">The morph key frames.</field>
         <field name="Legacy Weight" type="float" since="10.1.0.104" until="20.1.0.2" vercond="#BSVER# #LT# 10" />
-        <field name="Vectors" type="Vector3" arr1="#ARG#">Morph vectors.</field>
+        <field name="Vectors" type="Vector3" length="#ARG#">Morph vectors.</field>
     </struct>
 
     <struct name="NiParticleInfo" size="40">
@@ -2185,8 +2185,8 @@
         <field name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</field>
         <field name="Bounding Sphere" type="NiBound">Note that its a Sphere Containing Axis Aligned Box not a minimum volume Sphere</field>
         <field name="Num Vertices" type="ushort">Number of weighted vertices.</field>
-        <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" until="4.2.1.0">The vertex weights.</field>
-        <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" since="4.2.2.0" cond="#ARG# != 0">The vertex weights.</field>
+        <field name="Vertex Weights" type="BoneVertData" length="Num Vertices" until="4.2.1.0">The vertex weights.</field>
+        <field name="Vertex Weights" type="BoneVertData" length="Num Vertices" since="4.2.2.0" cond="#ARG# != 0">The vertex weights.</field>
     </struct>
 
     <struct name="HavokFilter" size="4" versions="#BETHESDA#">
@@ -2238,7 +2238,7 @@
     <struct name="bhkConstraintChainCInfo" versions="#BETHESDA#">
         Bethesda extension of hkpConstraintChainInstance.
         <field name="Num Chained Entities" type="uint" />
-        <field name="Chained Entities" type="Ptr" template="bhkRigidBody" arr1="Num Chained Entities" />
+        <field name="Chained Entities" type="Ptr" template="bhkRigidBody" length="Num Chained Entities" />
         <field name="Constraint Info" type="bhkConstraintCInfo" />
     </struct>
 
@@ -2434,7 +2434,7 @@
     <struct name="BoxBV" size="60">
         Box Bounding Volume
         <field name="Center" type="Vector3" />
-        <field name="Axis" type="Vector3" arr1="3" />
+        <field name="Axis" type="Vector3" length="3" />
         <field name="Extent" type="Vector3" />
     </struct>
 
@@ -2462,7 +2462,7 @@
 
     <struct name="UnionBV">
         <field name="Num BV" type="uint" />
-        <field name="Bounding Volumes" type="BoundingVolume" arr1="Num BV" />
+        <field name="Bounding Volumes" type="BoundingVolume" length="Num BV" />
     </struct>
 
     <struct name="MorphWeight" size="8">
@@ -2480,14 +2480,14 @@
     <struct name="BonePose" versions="#FO3_AND_LATER#">
         A list of transforms for each bone in bhkPoseArray.
         <field name="Num Transforms" type="uint" />
-        <field name="Transforms" type="BoneTransform" arr1="Num Transforms" />
+        <field name="Transforms" type="BoneTransform" length="Num Transforms" />
     </struct>
 
     <struct name="DecalVectorArray" versions="#FO3_AND_LATER#">
         Array of Vectors for Decal placement in BSDecalPlacementVectorExtraData.
         <field name="Num Vectors" type="ushort" />
-        <field name="Points" type="Vector3" arr1="Num Vectors">Vector XYZ coords</field>
-        <field name="Normals" type="Vector3" arr1="Num Vectors">Vector Normals</field>
+        <field name="Points" type="Vector3" length="Num Vectors">Vector XYZ coords</field>
+        <field name="Normals" type="Vector3" length="Num Vectors">Vector Normals</field>
     </struct>
 
     <bitflags name="BSPartFlag" storage="ushort" versions="#BETHESDA#">
@@ -2534,13 +2534,13 @@
         <field name="Reference" type="ushort" default="#USHRT_MAX#">Index of another chunk in the chunks list.</field>
         <field name="Transform Index" type="ushort">Index of transformation in bhkCompressedMeshShapeData::Chunk Transforms</field>
         <field name="Num Vertices" type="uint" />
-        <field name="Vertices" type="ushort" arr1="Num Vertices" />
+        <field name="Vertices" type="ushort" length="Num Vertices" />
         <field name="Num Indices" type="uint" />
-        <field name="Indices" type="ushort" arr1="Num Indices" />
+        <field name="Indices" type="ushort" length="Num Indices" />
         <field name="Num Strips" type="uint" />
-        <field name="Strips" type="ushort" arr1="Num Strips" />
+        <field name="Strips" type="ushort" length="Num Strips" />
         <field name="Num Welding Info" type="uint" />
-        <field name="Welding Info" type="ushort" arr1="Num Welding Info" />
+        <field name="Welding Info" type="ushort" length="Num Welding Info" />
     </struct>
 
     <struct name="bhkMalleableConstraintCInfo" versions="#BETHESDA#">
@@ -2584,43 +2584,43 @@
 
     <niobject name="Ni3dsAlphaAnimator" inherit="NiObject" module="NiLegacy" versions="V2_3">
         Unknown.
-        <field name="Unknown 1" type="byte" arr1="40" />
+        <field name="Unknown 1" type="byte" length="40" />
         <field name="Parent" type="Ref" template="NiObject" />
         <field name="Num 1" type="uint" />
         <field name="Num 2" type="uint" />
-        <field name="Unknown 2" type="uint" arr1="Num 1 * Num 2" arr2="2" />
+        <field name="Unknown 2" type="uint" length="Num 1 * Num 2" width="2" />
     </niobject>
 
     <niobject name="Ni3dsAnimationNode" inherit="NiObject" module="NiLegacy" versions="V2_3">
         Unknown. Only found in 2.3 nifs.
         <field name="Name" type="SizedString">Name of this object.</field>
         <field name="Has Data" type="bool" />
-        <field name="Unknown Floats 1" type="float" arr1="21" cond="Has Data" />
+        <field name="Unknown Floats 1" type="float" length="21" cond="Has Data" />
         <field name="Unknown Short" type="ushort" cond="Has Data" />
         <field name="Child" type="Ref" template="NiObject" cond="Has Data" />
-        <field name="Unknown Floats 2" type="float" arr1="12" cond="Has Data" />
+        <field name="Unknown Floats 2" type="float" length="12" cond="Has Data" />
         <field name="Count" type="uint" cond="Has Data">A count.</field>
-        <field name="Unknown Array" type="byte" arr1="Count" arr2="5" cond="Has Data" />
+        <field name="Unknown Array" type="byte" length="Count" width="5" cond="Has Data" />
     </niobject>
 
     <niobject name="Ni3dsColorAnimator" inherit="NiObject" module="NiLegacy" versions="V2_3">
         Unknown!
-        <field name="Unknown 1" type="byte" arr1="184" />
+        <field name="Unknown 1" type="byte" length="184" />
     </niobject>
 
     <niobject name="Ni3dsMorphShape" inherit="NiObject" module="NiLegacy" versions="V2_3">
         Unknown!
-        <field name="Unknown 1" type="byte" arr1="14" />
+        <field name="Unknown 1" type="byte" length="14" />
     </niobject>
 
     <niobject name="Ni3dsParticleSystem" inherit="NiObject" module="NiLegacy" versions="V2_3">
         Unknown!
-        <field name="Unknown 1" type="byte" arr1="14" />
+        <field name="Unknown 1" type="byte" length="14" />
     </niobject>
 
     <niobject name="Ni3dsPathController" inherit="NiObject" module="NiLegacy" versions="V2_3">
         Unknown!
-        <field name="Unknown 1" type="byte" arr1="20" />
+        <field name="Unknown 1" type="byte" length="20" />
     </niobject>
 
 
@@ -2664,9 +2664,9 @@
     </struct>
 
     <struct name="bhkWorldObjectCInfo">
-        <field name="Unused 01" type="byte" arr1="4" binary="true" />
+        <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Broad Phase Type" type="BroadPhaseType" default="BROAD_PHASE_ENTITY" />
-        <field name="Unused 02" type="byte" arr1="3" binary="true" />
+        <field name="Unused 02" type="byte" length="3" binary="true" />
         <field name="Property" type="bhkWorldObjCInfoProperty" />
     </struct>
 
@@ -2687,7 +2687,7 @@
         Bethesda extension of hkpAabbPhantom. A non-physical object made up of only an AABB.
             - Very fast as they use only broadphase collision detection.
             - Used for triggers/regions where a shape is not necessary.
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="AABB" type="hkAabb" />
     </niobject>
 
@@ -2698,7 +2698,7 @@
     <niobject name="bhkSimpleShapePhantom" inherit="bhkShapePhantom" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpSimpleShapePhantom. A Phantom with arbitrary shape and transform.
         Does not do any narrowphase caching, in contrast to hkpCachingShapePhantom.
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="Transform" type="Matrix44" />
     </niobject>
 
@@ -2714,13 +2714,13 @@
     </niobject>
 
     <struct name="bhkRigidBodyCInfo550_660">
-        <field name="Unused 01" type="byte" arr1="4" binary="true" since="10.1.0.0" />
+        <field name="Unused 01" type="byte" length="4" binary="true" since="10.1.0.0" />
         <field name="Havok Filter" type="HavokFilter" since="10.1.0.0" />
-        <field name="Unused 02" type="byte" arr1="4" binary="true" since="10.1.0.0" />
+        <field name="Unused 02" type="byte" length="4" binary="true" since="10.1.0.0" />
         <field name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT" since="10.1.0.0" />
         <field name="Unused 03" type="byte" since="10.1.0.0" />
         <field name="Process Contact Callback Delay" type="ushort" default="0xffff" since="10.1.0.0" />
-        <field name="Unused 04" type="byte" arr1="4" binary="true" />
+        <field name="Unused 04" type="byte" length="4" binary="true" />
         <field name="Translation" type="Vector4"> A vector that moves the body by the specified amount. Only enabled in bhkRigidBodyT objects.</field>
         <field name="Rotation" type="hkQuaternion">The rotation Yaw/Pitch/Roll to apply to the body. Only enabled in bhkRigidBodyT objects.</field>
         <field name="Linear Velocity" type="Vector4">Linear velocity.</field>
@@ -2746,13 +2746,13 @@
         <field name="Deactivator Type" type="hkDeactivatorType" default="DEACTIVATOR_NEVER">The initial deactivator type of the body.</field>
         <field name="Solver Deactivation" type="hkSolverDeactivation" default="SOLVER_DEACTIVATION_OFF">How aggressively the engine will try to zero the velocity for slow objects. This does not save CPU.</field>
         <field name="Quality Type" type="hkQualityType" default="MO_QUAL_FIXED">The type of interaction with other objects.</field>
-        <field name="Unused 05" type="byte" arr1="12" binary="true" />
+        <field name="Unused 05" type="byte" length="12" binary="true" />
     </struct>
 
     <struct name="bhkRigidBodyCInfo2010">
-        <field name="Unused 01" type="byte" arr1="4" binary="true" />
+        <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Havok Filter" type="HavokFilter" />
-        <field name="Unused 02" type="byte" arr1="4" binary="true" />
+        <field name="Unused 02" type="byte" length="4" binary="true" />
         <field name="Unknown Int 1" type="uint" />
         <field name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT" />
         <field name="Unused 03" type="byte" />
@@ -2789,13 +2789,13 @@
         <field name="Response Modifier Flags" type="byte" />
         <field name="Num Shape Keys in Contact Point" type="byte" default="3" />
         <field name="Force Collided Onto PPU" type="bool" />
-        <field name="Unused 04" type="byte" arr1="12" binary="true" />
+        <field name="Unused 04" type="byte" length="12" binary="true" />
     </struct>
 
     <struct name="bhkRigidBodyCInfo2014">
-        <field name="Unused 01" type="byte" arr1="4" binary="true" />
+        <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Havok Filter" type="HavokFilter" />
-        <field name="Unused 02" type="byte" arr1="12" binary="true" />
+        <field name="Unused 02" type="byte" length="12" binary="true" />
         <field name="Translation" type="Vector4"> A vector that moves the body by the specified amount. Only enabled in bhkRigidBodyT objects.</field>
         <field name="Rotation" type="hkQuaternion">The rotation Yaw/Pitch/Roll to apply to the body. Only enabled in bhkRigidBodyT objects.</field>
         <field name="Linear Velocity" type="Vector4">Linear velocity.</field>
@@ -2824,7 +2824,7 @@
             A good choice is 5% - 20% of the smallest diameter of the object.
         </field>
         <field name="Time Factor" type="float" />
-        <field name="Unused 04" type="byte" arr1="4" />
+        <field name="Unused 04" type="byte" length="4" />
         <field name="Collision Response" type="hkResponseType" />
         <field name="Unused 05" type="byte" />
         <field name="Process Contact Callback Delay 3" type="ushort" default="0xffff" />
@@ -2833,7 +2833,7 @@
         <field name="Response Modifier Flags" type="byte" />
         <field name="Num Shape Keys in Contact Point" type="byte" default="3" />
         <field name="Force Collided Onto PPU" type="bool" />
-        <field name="Unused 06" type="byte" arr1="3" binary="true" />
+        <field name="Unused 06" type="byte" length="3" binary="true" />
     </struct>
 
     <niobject name="bhkRigidBody" inherit="bhkEntity" module="BSHavok" versions="#BETHESDA#">
@@ -2844,7 +2844,7 @@
         <field name="Rigid Body Info" suffix="2010" type="bhkRigidBodyCInfo2010" vercond="#BS_GTE_SKY# #AND# (!#BS_FO4#)" />
         <field name="Rigid Body Info" suffix="2014" type="bhkRigidBodyCInfo2014" vercond="#BS_FO4#" />
         <field name="Num Constraints" type="uint" />
-        <field name="Constraints" type="Ref" template="bhkSerializable" arr1="Num Constraints" />
+        <field name="Constraints" type="Ref" template="bhkSerializable" length="Num Constraints" />
         <field name="Body Flags" type="uint" vercond="#BSVER# #LT# 76">1 = respond to wind</field>
         <field name="Body Flags" type="ushort" vercond="#BSVER# #GTE# 76">1 = respond to wind</field>
     </niobject>
@@ -2861,14 +2861,14 @@
     <niobject name="bhkUnaryAction" abstract="true" inherit="bhkAction" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpUnaryAction. hkpUnaryAction performs an action on one body.
         <field name="Entity" type="Ptr" template="bhkRigidBody" />
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
     </niobject>
 
     <niobject name="bhkBinaryAction" abstract="true" inherit="bhkAction" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpBinaryAction. hkpBinaryAction performs an action on two bodies.
         <field name="Entity A" type="Ptr" template="bhkRigidBody" />
         <field name="Entity B" type="Ptr" template="bhkRigidBody" />
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
     </niobject>
 
     <niobject name="bhkConstraint" abstract="true" inherit="bhkSerializable" module="BSHavok" versions="#BETHESDA#">
@@ -2921,7 +2921,7 @@
     <niobject name="bhkBallSocketConstraintChain" inherit="bhkSerializable" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpBallSocketChainData. A chain of ball and socket constraints.
         <field name="Num Pivots" type="uint" calc="#LEN[Pivots]# * 2">Should equal (Num Chained Entities - 1) * 2</field>
-        <field name="Pivots" type="bhkBallAndSocketConstraintCInfo" arr1="Num Pivots / 2">Two pivot points A and B for each constraint.</field>
+        <field name="Pivots" type="bhkBallAndSocketConstraintCInfo" length="Num Pivots / 2">Two pivot points A and B for each constraint.</field>
         <field name="Tau" type="float" default="1.0">High values are harder and more reactive, lower values are smoother.</field>
         <field name="Damping" type="float" default="0.6">Defines damping strength for the current velocity.</field>
         <field name="Constraint Force Mixing" type="float" default="1.1920929e-08">Restitution (amount of elasticity) of constraints. Added to the diagonal of the constraint matrix. A value of 0.0 can result in a division by zero with some chain configurations.</field>
@@ -2939,7 +2939,7 @@
         <field name="Shape" type="Ref" template="bhkShape">The shape that this object transforms.</field>
         <field name="Material" type="HavokMaterial">The material of the shape.</field>
         <field name="Radius" type="float" />
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="Transform" type="Matrix44">A transform matrix.</field>
     </niobject>
 
@@ -2964,7 +2964,7 @@
 
     <niobject name="bhkPlaneShape" inherit="bhkHeightFieldShape" module="BSHavok" versions="#BETHESDA#">
         Contains a normal and distance from the origin, bounded by a given AABB.
-        <field name="Unused 01" type="byte" arr1="12" binary="true" />
+        <field name="Unused 01" type="byte" length="12" binary="true" />
         <field name="Plane Normal" type="Vector3" />
         <field name="Plane Constant" type="float">Distance from the origin to the plane.</field>
         <field name="AABB Half Extents" type="Vector4" />
@@ -2977,16 +2977,16 @@
 
     <niobject name="bhkCylinderShape" inherit="bhkConvexShape" module="BSHavok" versions="#BETHESDA#">
         A cylinder.
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="Vertex A" type="Vector4" />
         <field name="Vertex B" type="Vector4" />
         <field name="Cylinder Radius" type="float" />
-        <field name="Unused 02" type="byte" arr1="12" binary="true" />
+        <field name="Unused 02" type="byte" length="12" binary="true" />
     </niobject>
 
     <niobject name="bhkCapsuleShape" inherit="bhkConvexShape" module="BSHavok" versions="#BETHESDA#">
         A capsule.
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="First Point" type="Vector3">First point on the capsule's axis.</field>
         <field name="Radius 1" type="float">Matches first capsule radius.</field>
         <field name="Second Point" type="Vector3">Second point on the capsule's axis.</field>
@@ -2995,7 +2995,7 @@
 
     <niobject name="bhkBoxShape" inherit="bhkConvexShape" module="BSHavok" versions="#BETHESDA#">
         A box.
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="Dimensions" type="Vector3">A cube stored in Half Extents. A unit cube (1.0, 1.0, 1.0) would be stored as 0.5, 0.5, 0.5.</field>
         <field name="Unused Float" type="float">Unused as Havok stores the Half Extents as hkVector4 with the W component unused.</field>
     </niobject>
@@ -3007,9 +3007,9 @@
         <field name="Vertices Property" type="bhkWorldObjCInfoProperty" />
         <field name="Normals Property" type="bhkWorldObjCInfoProperty" />
         <field name="Num Vertices" type="uint">Number of vertices.</field>
-        <field name="Vertices" type="Vector4" arr1="Num Vertices">Vertices. Fourth component is 0. Lexicographically sorted.</field>
+        <field name="Vertices" type="Vector4" length="Num Vertices">Vertices. Fourth component is 0. Lexicographically sorted.</field>
         <field name="Num Normals" type="uint">The number of half spaces.</field>
-        <field name="Normals" type="Vector4" arr1="Num Normals">Half spaces as determined by the set of vertices above. First three components define the normal pointing to the exterior, fourth component is the signed distance of the separating plane to the origin: it is minus the dot product of v and n, where v is any vertex on the separating plane, and n is the normal. Lexicographically sorted.</field>
+        <field name="Normals" type="Vector4" length="Num Normals">Half spaces as determined by the set of vertices above. First three components define the normal pointing to the exterior, fourth component is the signed distance of the separating plane to the origin: it is minus the dot product of v and n, where v is any vertex on the separating plane, and n is the normal. Lexicographically sorted.</field>
     </niobject>
 
     <niobject name="bhkConvexTransformShape" inherit="bhkConvexShapeBase" module="BSHavok" versions="#BETHESDA#">
@@ -3018,7 +3018,7 @@
         <field name="Shape" type="Ref" template="bhkConvexShape">The shape that this object transforms.</field>
         <field name="Material" type="HavokMaterial">The material of the shape.</field>
         <field name="Radius" type="float" />
-        <field name="Unused 01" type="byte" arr1="8" binary="true" />
+        <field name="Unused 01" type="byte" length="8" binary="true" />
         <field name="Transform" type="Matrix44">A transform matrix.</field>
     </niobject>
 
@@ -3036,7 +3036,7 @@
             Therefore shapes like bhkCapsuleShape or bhkConvexVerticesShape should be preferred.
         <field name="Shape Property" type="bhkWorldObjCInfoProperty" />
         <field name="Num Spheres" type="uint" default="2" range="1:8" />
-        <field name="Spheres" type="NiBound" arr1="Num Spheres">The spheres which make up the multi sphere shape. Max of 8.</field>
+        <field name="Spheres" type="NiBound" length="Num Spheres">The spheres which make up the multi sphere shape. Max of 8.</field>
     </niobject>
 
     <niobject name="bhkBvTreeShape" abstract="true" inherit="bhkShape" module="BSHavok" versions="#BETHESDA#">
@@ -3053,12 +3053,12 @@
                In Oblivion files, scale is taken equal to 256*256*254 / (size + 0.2) where size is the largest dimension of the bounding box of the packed shape.
         </field>
         <field name="Build Type" type="hkMoppCodeBuildType" vercond="#BS_GT_FO3#">Tells if MOPP Data was organized into smaller chunks (PS3) or not (PC)</field>
-        <field name="Data" type="byte" binary="true" arr1="Data Size">The tree of bounding volume data.</field>
+        <field name="Data" type="byte" binary="true" length="Data Size">The tree of bounding volume data.</field>
     </struct>
 
     <niobject name="bhkMoppBvTreeShape" inherit="bhkBvTreeShape" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpMoppBvTreeShape. hkpMoppBvTreeShape is a bounding volume tree using Havok-proprietary MOPP code.
-        <field name="Unused 01" type="byte" arr1="12" binary="true" />
+        <field name="Unused 01" type="byte" length="12" binary="true" />
         <field name="Scale" type="float" default="1.0" />
         <field name="MOPP Code" type="hkpMoppCode" />
     </niobject>
@@ -3074,36 +3074,36 @@
         Shapes collected in a bhkListShape may not have the correct collision sound/FX due to HavokMaterial issues.
         Do not put a bhkPackedNiTriStripsShape in the Sub Shapes. Use a separate collision nodes without a list shape for those.
         <field name="Num Sub Shapes" type="uint" default="1" range="1:256" />
-        <field name="Sub Shapes" type="Ref" template="bhkShape" arr1="Num Sub Shapes">List of shapes. Max of 256.</field>
+        <field name="Sub Shapes" type="Ref" template="bhkShape" length="Num Sub Shapes">List of shapes. Max of 256.</field>
         <field name="Material" type="HavokMaterial">The material of the shape.</field>
         <field name="Child Shape Property" type="bhkWorldObjCInfoProperty" />
         <field name="Child Filter Property" type="bhkWorldObjCInfoProperty" />
         <field name="Num Filters" type="uint" calc="#LEN[Sub Shapes]#" />
-        <field name="Filters" type="HavokFilter" arr1="Num Filters">Always zeroed. Seemingly unused, or 0 for all values means no override.</field>
+        <field name="Filters" type="HavokFilter" length="Num Filters">Always zeroed. Seemingly unused, or 0 for all values means no override.</field>
     </niobject>
 
     <niobject name="bhkMeshShape" inherit="bhkShape" module="BSHavok" versions="V10_0_1_0">
         Bethesda extension of hkpMeshShape, but using NiTriStripsData instead of Havok storage.
         Appears in one old Oblivion NIF, but only in certain distributions. NIF version 10.0.1.0 only.
-        <field name="Unknown 01" type="uint" arr1="2" />
+        <field name="Unknown 01" type="uint" length="2" />
         <field name="Radius" type="float" />
-        <field name="Unknown 02" type="uint" arr1="2" />
+        <field name="Unknown 02" type="uint" length="2" />
         <field name="Scale" type="Vector4" />
         <field name="Num Shape Properties" type="uint" />
-        <field name="Shape Properties" type="bhkWorldObjCInfoProperty" arr1="Num Shape Properties" />
-        <field name="Unknown 03" type="uint" arr1="3" />
+        <field name="Shape Properties" type="bhkWorldObjCInfoProperty" length="Num Shape Properties" />
+        <field name="Unknown 03" type="uint" length="3" />
         <field name="Num Strips Data" type="uint" until="10.0.1.0" />
-        <field name="Strips Data" type="Ref" template="NiTriStripsData" arr1="Num Strips Data" until="10.0.1.0" />
+        <field name="Strips Data" type="Ref" template="NiTriStripsData" length="Num Strips Data" until="10.0.1.0" />
     </niobject>
 
     <niobject name="bhkPackedNiTriStripsShape" inherit="bhkShapeCollection" module="BSHavok" versions="#BETHESDA#">
         Bethesda custom hkpShapeCollection using custom packed tri strips data.
         <field name="Num Sub Shapes" type="ushort" until="20.0.0.5" />
-        <field name="Sub Shapes" type="hkSubPartData" arr1="Num Sub Shapes" until="20.0.0.5" />
+        <field name="Sub Shapes" type="hkSubPartData" length="Num Sub Shapes" until="20.0.0.5" />
         <field name="User Data" type="uint" default="0" />
-        <field name="Unused 01" type="byte" arr1="4" binary="true" />
+        <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Radius" type="float" default="0.1" />
-        <field name="Unused 02" type="byte" arr1="4" binary="true" />
+        <field name="Unused 02" type="byte" length="4" binary="true" />
         <field name="Scale" type="Vector4" default="#VEC4_1110#" />
         <field name="Radius Copy" type="float" default="0.1">Same as radius</field>
         <field name="Scale Copy" type="Vector4" default="#VEC4_1110#">Same as scale.</field>
@@ -3114,13 +3114,13 @@
         Bethesda custom hkpShapeCollection using NiTriStripsData for geometry storage.
         <field name="Material" type="HavokMaterial">The material of the shape.</field>
         <field name="Radius" type="float" default="0.1" />
-        <field name="Unused 01" type="byte" arr1="20" binary="true" />
+        <field name="Unused 01" type="byte" length="20" binary="true" />
         <field name="Grow By" type="uint" default="1" />
         <field name="Scale" type="Vector4" default="#VEC4_1110#" since="10.1.0.0" />
         <field name="Num Strips Data" type="uint" default="1" />
-        <field name="Strips Data" type="Ref" template="NiTriStripsData" arr1="Num Strips Data" />
+        <field name="Strips Data" type="Ref" template="NiTriStripsData" length="Num Strips Data" />
         <field name="Num Filters" type="uint" default="1" calc="#LEN[Strips Data]#" />
-        <field name="Filters" type="HavokFilter" arr1="Num Filters" />
+        <field name="Filters" type="HavokFilter" length="Num Filters" />
     </niobject>
 
     <niobject name="NiExtraData" inherit="NiObject" module="NiMain">
@@ -3225,9 +3225,9 @@
         <field name="High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <field name="Next High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <field name="High Ease Spinner" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
-        <field name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Interp Array Items" type="InterpBlendItem" length="Array Size" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <!-- /Flags conds -->
-        <field name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" until="10.1.0.111" />
+        <field name="Interp Array Items" type="InterpBlendItem" length="Array Size" until="10.1.0.111" />
         <field name="Manager Controlled" type="bool" until="10.1.0.111" />
         <field name="Weight Threshold" type="float" until="10.1.0.111" />
         <field name="Only Use Highest Weight" type="bool" until="10.1.0.111" />
@@ -3267,7 +3267,7 @@
         <field name="Legacy Extra Data" type="LegacyExtraData" until="2.3" />
         <field name="Extra Data" type="Ref" template="NiExtraData" since="3.0" until="4.2.2.0">Extra data object index. (The first in a chain)</field>
         <field name="Num Extra Data List" type="uint" since="10.0.1.0">The number of Extra Data objects referenced through the list.</field>
-        <field name="Extra Data List" type="Ref" template="NiExtraData" arr1="Num Extra Data List" since="10.0.1.0">List of extra data indices.</field>
+        <field name="Extra Data List" type="Ref" template="NiExtraData" length="Num Extra Data List" since="10.0.1.0">List of extra data indices.</field>
         <field name="Controller" type="Ref" template="NiTimeController" since="3.0">Controller object index. (The first in a chain)</field>
     </niobject>
 
@@ -3390,8 +3390,8 @@
         <field name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</field>
         <field name="Velocity" type="Vector3" until="4.2.2.0">Unknown function. Always seems to be (0, 0, 0)</field>
         <field name="Num Properties" type="uint" vercond="#NI_BS_LTE_FO3#" />
-        <field name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="#NI_BS_LTE_FO3#">All rendering properties attached to this object.</field>
-        <field name="Unknown 1" type="uint" arr1="4" until="2.3" />
+        <field name="Properties" type="Ref" template="NiProperty" length="Num Properties" vercond="#NI_BS_LTE_FO3#">All rendering properties attached to this object.</field>
+        <field name="Unknown 1" type="uint" length="4" until="2.3" />
         <field name="Unknown 2" type="byte" until="2.3" />
         <field name="Has Bounding Volume" type="bool" since="3.0" until="4.2.2.0" />
         <field name="Bounding Volume" type="BoundingVolume" cond="Has Bounding Volume" since="3.0" until="4.2.2.0" />
@@ -3402,10 +3402,10 @@
         Abstract base class for dynamic effects such as NiLights or projected texture effects.
         <field name="Switch State" type="bool" default="1" since="10.1.0.106" vercond="#NI_BS_LT_FO4#">If true, then the dynamic effect is applied to affected nodes during rendering.</field>
         <field name="Num Affected Nodes" type="uint" until="4.0.0.2" />
-        <field name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" until="3.3.0.13">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
-        <field name="Affected Node Pointers" type="uint" arr1="Num Affected Nodes" since="4.0.0.0" until="4.0.0.2">As of 4.0 the pointer hash is no longer stored alongside each NiObject on disk, yet this node list still refers to the pointer hashes. Cannot leave the type as Ptr because the link will be invalid.</field>
+        <field name="Affected Nodes" type="Ptr" template="NiNode" length="Num Affected Nodes" until="3.3.0.13">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
+        <field name="Affected Node Pointers" type="uint" length="Num Affected Nodes" since="4.0.0.0" until="4.0.0.2">As of 4.0 the pointer hash is no longer stored alongside each NiObject on disk, yet this node list still refers to the pointer hashes. Cannot leave the type as Ptr because the link will be invalid.</field>
         <field name="Num Affected Nodes" type="uint" since="10.1.0.0" vercond="#NI_BS_LT_FO4#" />
-        <field name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" since="10.1.0.0" vercond="#NI_BS_LT_FO4#">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
+        <field name="Affected Nodes" type="Ptr" template="NiNode" length="Num Affected Nodes" since="10.1.0.0" vercond="#NI_BS_LT_FO4#">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
     </niobject>
 
     <niobject name="NiLight" abstract="true" inherit="NiDynamicEffect" module="NiMain">
@@ -3423,7 +3423,7 @@
 
     <niobject name="NiTransparentProperty" inherit="NiProperty" module="NiLegacy">
         Unknown
-        <field name="Unknown" type="byte" arr1="6" />
+        <field name="Unknown" type="byte" length="6" />
     </niobject>
 
     <enum name="NiPSysModifierOrder" storage="uint">
@@ -3521,7 +3521,7 @@
     <niobject name="NiMultiTargetTransformController" inherit="NiInterpController" module="NiAnimation">
         DEPRECATED (20.6)
         <field name="Num Extra Targets" type="ushort">The number of target pointers that follow.</field>
-        <field name="Extra Targets" type="Ptr" template="NiAVObject" arr1="Num Extra Targets">NiNode Targets to be controlled.</field>
+        <field name="Extra Targets" type="Ptr" template="NiAVObject" length="Num Extra Targets">NiNode Targets to be controlled.</field>
     </niobject>
 
     <niobject name="NiGeomMorpherController" inherit="NiInterpController" module="NiAnimation">
@@ -3531,10 +3531,10 @@
         <field name="Data" type="Ref" template="NiMorphData">Geometry morphing data index.</field>
         <field name="Always Update" type="byte" since="4.0.0.2" />
         <field name="Num Interpolators" type="uint" since="10.1.0.106" />
-        <field name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" since="10.1.0.106" until="20.0.0.5" />
-        <field name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" since="20.1.0.3" />
+        <field name="Interpolators" type="Ref" template="NiInterpolator" length="Num Interpolators" since="10.1.0.106" until="20.0.0.5" />
+        <field name="Interpolator Weights" type="MorphWeight" length="Num Interpolators" since="20.1.0.3" />
         <field name="Num Unknown Ints" type="uint" since="10.2.0.0" until="20.0.0.5" vercond="#BSVER# #GT# 9" />
-        <field name="Unknown Ints" type="uint" arr1="Num Unknown Ints" since="10.2.0.0" until="20.0.0.5" vercond="#BSVER# #GT# 9" />
+        <field name="Unknown Ints" type="uint" length="Num Unknown Ints" since="10.2.0.0" until="20.0.0.5" vercond="#BSVER# #GT# 9" />
     </niobject>
 
     <niobject name="NiMorphController" inherit="NiInterpController" module="NiLegacy" until="V10_0_1_0">
@@ -3630,8 +3630,8 @@
             delta = (start_time - stop_time) / sources.num_indices
         </field>
         <field name="Num Sources" type="uint" />
-        <field name="Sources" type="Ref" template="NiSourceTexture" arr1="Num Sources" since="3.3.0.13">The texture sources.</field>
-        <field name="Images" type="Ref" template="NiImage" arr1="Num Sources" until="3.1">The image sources</field>
+        <field name="Sources" type="Ref" template="NiSourceTexture" length="Num Sources" since="3.3.0.13">The texture sources.</field>
+        <field name="Images" type="Ref" template="NiImage" length="Num Sources" until="3.1">The image sources</field>
     </niobject>
 
     <niobject name="NiAlphaController" inherit="NiFloatInterpController" module="NiAnimation">
@@ -3701,8 +3701,8 @@
         Animates an NiFloatExtraData object attached to an NiAVObject.
         NiInterpController::GetCtlrID() string format is same as parent.
         <field name="Num Extra Bytes" type="byte" until="10.1.0.0">Number of extra bytes.</field>
-        <field name="Unknown Bytes" type="byte" arr1="7" until="10.1.0.0" />
-        <field name="Unknown Extra Bytes" type="byte" arr1="Num Extra Bytes" until="10.1.0.0" />
+        <field name="Unknown Bytes" type="byte" length="7" until="10.1.0.0" />
+        <field name="Unknown Extra Bytes" type="byte" length="Num Extra Bytes" until="10.1.0.0" />
         <field name="Data" type="Ref" template="NiFloatData" until="10.1.0.103" />
     </niobject>
 
@@ -3729,11 +3729,11 @@
         <field name="LOD" type="uint" />
         <field name="Num LODs" type="uint">Number of LODs.</field>
         <field name="Num Node Groups" type="uint">Number of node arrays.</field>
-        <field name="Node Groups" type="NodeSet" arr1="Num LODs">A list of node sets (each set a sequence of bones).</field>
+        <field name="Node Groups" type="NodeSet" length="Num LODs">A list of node sets (each set a sequence of bones).</field>
         <field name="Num Shape Groups" type="uint" since="4.2.2.0" vercond="#NISTREAM#">Number of shape groups.</field>
-        <field name="Shape Groups 1" type="SkinInfoSet" arr1="Num Shape Groups" since="4.2.2.0" vercond="#NISTREAM#">List of shape groups.</field>
+        <field name="Shape Groups 1" type="SkinInfoSet" length="Num Shape Groups" since="4.2.2.0" vercond="#NISTREAM#">List of shape groups.</field>
         <field name="Num Shape Groups 2" type="uint" since="4.2.2.0" vercond="#NISTREAM#">The size of the second list of shape groups.</field>
-        <field name="Shape Groups 2" type="Ref" template="NiTriBasedGeom" arr1="Num Shape Groups 2" since="4.2.2.0" vercond="#NISTREAM#">Group of NiTriShape indices.</field>
+        <field name="Shape Groups 2" type="Ref" template="NiTriBasedGeom" length="Num Shape Groups 2" since="4.2.2.0" vercond="#NISTREAM#">Group of NiTriShape indices.</field>
     </niobject>
 
     <niobject name="NiBSBoneLODController" inherit="NiBoneLODController" module="BSAnimation">
@@ -3745,8 +3745,8 @@
         <field name="Shader Name" type="string" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">The shader name.</field>
         <field name="Shader Extra Data" type="int" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">Extra data associated with the shader. A value of -1 means the shader is the default implementation.</field>
         <field name="Num Materials" type="uint" since="20.2.0.5" />
-        <field name="Material Name" type="NiFixedString" arr1="Num Materials" since="20.2.0.5">The name of the material.</field>
-        <field name="Material Extra Data" type="int" arr1="Num Materials" since="20.2.0.5">Extra data associated with the material. A value of -1 means the material is the default implementation.</field>
+        <field name="Material Name" type="NiFixedString" length="Num Materials" since="20.2.0.5">The name of the material.</field>
+        <field name="Material Extra Data" type="int" length="Num Materials" since="20.2.0.5">Extra data associated with the material. A value of -1 means the material is the default implementation.</field>
         <field name="Active Material" type="int" default="-1" since="20.2.0.5">The index of the currently active material.</field>
         <field name="Cyanide Unknown" type="byte" default="255" since="10.2.0.0" until="10.2.0.0" vercond="#USER# == 1">Cyanide extension (Blood Bowl).</field>
         <field name="WorldShift Unknown" type="int" since="10.3.0.1" until="10.4.0.1" />
@@ -3760,7 +3760,7 @@
             This causes massive inheritance problems so the rows below are doubled up to exclude NiParticleSystem for Bethesda Stream 100+
             and to add data exclusive to BSGeometry.
         <field name="Bounding Sphere" type="NiBound" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" onlyT="NiParticleSystem" />
-        <field name="Bound Min Max" type="float" arr1="6" since="20.2.0.7" until="20.2.0.7" vercond="#BS_F76#" onlyT="NiParticleSystem" />
+        <field name="Bound Min Max" type="float" length="6" since="20.2.0.7" until="20.2.0.7" vercond="#BS_F76#" onlyT="NiParticleSystem" />
         <field name="Skin" type="Ref" template="NiObject" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" onlyT="NiParticleSystem" />
         <field name="Data" type="Ref" template="NiGeometryData" vercond="#NI_BS_LT_SSE#">Data index (NiTriShapeData/NiTriStripData).</field>
         <field name="Data" type="Ref" template="NiGeometryData" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</field>
@@ -3789,16 +3789,16 @@
         <field name="Keep Flags" type="byte" since="10.1.0.0">Used with NiCollision objects when OBB or TRI is set.</field>
         <field name="Compress Flags" type="byte" since="10.1.0.0" />
         <field name="Has Vertices" type="bool" default="1">Is the vertex array present? (Always non-zero.)</field>
-        <field name="Vertices" type="Vector3" arr1="Num Vertices" cond="Has Vertices">The mesh vertices.</field>
+        <field name="Vertices" type="Vector3" length="Num Vertices" cond="Has Vertices">The mesh vertices.</field>
         <field name="Data Flags" type="NiGeometryDataFlags" since="10.0.1.0" vercond="!#BS202#" />
         <field name="BS Data Flags" type="BSGeometryDataFlags" vercond="#BS202#" />
         <field name="Material CRC" type="uint" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
         <field name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</field>
-        <field name="Normals" type="Vector3" arr1="Num Vertices" cond="Has Normals">The lighting normals.</field>
-        <field name="Tangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Tangent vectors.</field>
-        <field name="Bitangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Bitangent vectors.</field>
+        <field name="Normals" type="Vector3" length="Num Vertices" cond="Has Normals">The lighting normals.</field>
+        <field name="Tangents" type="Vector3" length="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Tangent vectors.</field>
+        <field name="Bitangents" type="Vector3" length="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Bitangent vectors.</field>
         <field name="Has DIV2 Floats" type="bool" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
-        <field name="DIV2 Floats" type="float" arr1="Num Vertices" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" cond="Has DIV2 Floats" />
+        <field name="DIV2 Floats" type="float" length="Num Vertices" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" cond="Has DIV2 Floats" />
         <field name="Bounding Sphere" type="NiBound" />
         <field name="Has Vertex Colors" type="bool">
             Do we have vertex colors? These are usually used to fine-tune the lighting of the model.
@@ -3807,14 +3807,14 @@
 
             Note 2: set to either 0 or 0xFFFFFFFF for NifTexture compatibility.
         </field>
-        <field name="Vertex Colors" type="Color4" default="#VEC4_ONE#" arr1="Num Vertices" cond="Has Vertex Colors">The vertex colors.</field>
+        <field name="Vertex Colors" type="Color4" default="#VEC4_ONE#" length="Num Vertices" cond="Has Vertex Colors">The vertex colors.</field>
         <field name="Data Flags" type="NiGeometryDataFlags" until="4.2.2.0">The lower 6 bits of this field represent the number of UV texture sets. The rest is unused.</field>
         <field name="Has UV" type="bool" until="4.0.0.2">
             Do we have UV coordinates?
 
             Note: for compatibility with NifTexture, set this value to either 0x00000000 or 0xFFFFFFFF.
         </field>
-        <field name="UV Sets" type="TexCoord" arr1="((Data Flags #BITAND# 63) | (BS Data Flags #BITAND# 1))" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</field>
+        <field name="UV Sets" type="TexCoord" length="((Data Flags #BITAND# 63) | (BS Data Flags #BITAND# 1))" width="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</field>
         <field name="Consistency Flags" type="ConsistencyType" since="10.0.1.0" default="CT_MUTABLE">Consistency Flags</field>
         <field name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" since="20.0.0.4" />
     </niobject>
@@ -3841,7 +3841,7 @@
     <niobject name="BSFurnitureMarker" inherit="NiExtraData" module="BSMain" versions="#BETHESDA#">
         Unknown. Marks furniture sitting positions?
         <field name="Num Positions" type="uint" />
-        <field name="Positions" type="FurniturePosition" arr1="Num Positions" />
+        <field name="Positions" type="FurniturePosition" length="Num Positions" />
     </niobject>
 
     <niobject name="BSParentVelocityModifier" inherit="NiPSysModifier" module="BSParticle" versions="#BETHESDA#">
@@ -3861,15 +3861,15 @@
     <niobject name="hkPackedNiTriStripsData" inherit="bhkShapeCollection" module="BSHavok" versions="#BETHESDA#">
         Bethesda custom tri strips data block for bhkPackedNiTriStripsShape.
         <field name="Num Triangles" type="uint" />
-        <field name="Triangles" type="TriangleData" arr1="Num Triangles" />
+        <field name="Triangles" type="TriangleData" length="Num Triangles" />
         <field name="Num Vertices" type="uint" />
         <field name="Compressed" type="bool" since="20.2.0.7" />
-        <field name="Vertices" type="Vector3" arr1="Num Vertices" cond="Compressed == 0" />
-        <field name="Compressed Vertices" type="HalfVector3" arr1="Num Vertices" cond="Compressed != 0">
+        <field name="Vertices" type="Vector3" length="Num Vertices" cond="Compressed == 0" />
+        <field name="Compressed Vertices" type="HalfVector3" length="Num Vertices" cond="Compressed != 0">
             Compression on read may not be supported. Vertices may be packed in ushort that are not IEEE standard half-precision.
         </field>
         <field name="Num Sub Shapes" type="ushort" since="20.2.0.7" />
-        <field name="Sub Shapes" type="hkSubPartData" arr1="Num Sub Shapes" since="20.2.0.7" />
+        <field name="Sub Shapes" type="hkSubPartData" length="Num Sub Shapes" since="20.2.0.7" />
     </niobject>
 
     <niobject name="NiAlphaProperty" inherit="NiProperty" module="NiMain">
@@ -3896,21 +3896,21 @@
         <field name="Num Particles" type="ushort" until="4.0.0.2">The maximum number of particles (matches the number of vertices).</field>
         <field name="Particle Radius" type="float" until="10.0.1.0">The particles' size.</field>
         <field name="Has Radii" type="bool" since="10.1.0.0">Is the particle size array present?</field>
-        <field name="Radii" type="float" arr1="Num Vertices" cond="Has Radii" since="10.1.0.0" vercond="!#BS202#">The individual particle sizes.</field>
+        <field name="Radii" type="float" length="Num Vertices" cond="Has Radii" since="10.1.0.0" vercond="!#BS202#">The individual particle sizes.</field>
         <field name="Num Active" type="ushort">The number of active particles at the time the system was saved. This is also the number of valid entries in the following arrays.</field>
         <field name="Has Sizes" type="bool">Is the particle size array present?</field>
-        <field name="Sizes" type="float" arr1="Num Vertices" cond="Has Sizes" vercond="!#BS202#">The individual particle sizes.</field>
+        <field name="Sizes" type="float" length="Num Vertices" cond="Has Sizes" vercond="!#BS202#">The individual particle sizes.</field>
         <field name="Has Rotations" type="bool" since="10.0.1.0">Is the particle rotation array present?</field>
-        <field name="Rotations" type="Quaternion" arr1="Num Vertices" cond="Has Rotations" since="10.0.1.0" vercond="!#BS202#">The individual particle rotations.</field>
+        <field name="Rotations" type="Quaternion" length="Num Vertices" cond="Has Rotations" since="10.0.1.0" vercond="!#BS202#">The individual particle rotations.</field>
         <field name="Has Rotation Angles" type="bool" since="20.0.0.4">Are the angles of rotation present?</field>
-        <field name="Rotation Angles" type="float" arr1="Num Vertices" cond="Has Rotation Angles" vercond="!#BS202#">Angles of rotation</field>
+        <field name="Rotation Angles" type="float" length="Num Vertices" cond="Has Rotation Angles" vercond="!#BS202#">Angles of rotation</field>
         <field name="Has Rotation Axes" type="bool" since="20.0.0.4">Are axes of rotation present?</field>
-        <field name="Rotation Axes" type="Vector3" arr1="Num Vertices" cond="Has Rotation Axes" since="20.0.0.4" vercond="!#BS202#">Axes of rotation.</field>
+        <field name="Rotation Axes" type="Vector3" length="Num Vertices" cond="Has Rotation Axes" since="20.0.0.4" vercond="!#BS202#">Axes of rotation.</field>
 
         <field name="Has Texture Indices" type="bool" vercond="#BS202#" />
         <field name="Num Subtexture Offsets" type="uint" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#">How many quads to use in BSPSysSubTexModifier for texture atlasing</field>
         <field name="Num Subtexture Offsets" type="byte" since="20.2.0.7" until="20.2.0.7" vercond="#BSSTREAM# #AND# #NI_BS_LTE_FO3#">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</field>
-        <field name="Subtexture Offsets" type="Vector4" arr1="Num Subtexture Offsets" vercond="#BS202#">Defines UV offsets</field>
+        <field name="Subtexture Offsets" type="Vector4" length="Num Subtexture Offsets" vercond="#BS202#">Defines UV offsets</field>
         <field name="Aspect Ratio" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#">Sets aspect ratio for Subtexture Offset UV quads</field>
         <field name="Aspect Flags" type="AspectFlags" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
         <field name="Speed to Aspect Aspect 2" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
@@ -3921,7 +3921,7 @@
     <niobject name="NiRotatingParticlesData" inherit="NiParticlesData" module="NiLegacy" until="V10_0_1_0">
         Rotating particles data object.
         <field name="Has Rotations 2" type="bool" until="4.2.2.0">Is the particle rotation array present?</field>
-        <field name="Rotations 2" type="Quaternion" arr1="Num Vertices" cond="Has Rotations 2" until="4.2.2.0">The individual particle rotations.</field>
+        <field name="Rotations 2" type="Quaternion" length="Num Vertices" cond="Has Rotations 2" until="4.2.2.0">The individual particle rotations.</field>
     </niobject>
 
     <niobject name="NiAutoNormalParticlesData" inherit="NiParticlesData" module="NiLegacy" until="V10_0_1_0">
@@ -3930,10 +3930,10 @@
 
     <niobject name="NiPSysData" inherit="NiParticlesData" module="NiParticle">
         Particle system data.
-        <field name="Particle Info" type="NiParticleInfo" arr1="Num Vertices" vercond="!#BS202#" />
+        <field name="Particle Info" type="NiParticleInfo" length="Num Vertices" vercond="!#BS202#" />
         <field name="Unknown Vector" type="Vector3" vercond="#BS_F76#" />
         <field name="Has Rotation Speeds" type="bool" since="20.0.0.2" />
-        <field name="Rotation Speeds" type="float" arr1="Num Vertices" cond="Has Rotation Speeds" since="20.0.0.2" vercond="!#BS202#" />
+        <field name="Rotation Speeds" type="float" length="Num Vertices" cond="Has Rotation Speeds" since="20.0.0.2" vercond="!#BS202#" />
         <field name="Num Added Particles" type="ushort" vercond="!#BS202#" />
         <field name="Added Particles Base" type="ushort" vercond="!#BS202#" />
     </niobject>
@@ -3943,7 +3943,7 @@
         <field name="Default Pool Size" type="uint" since="10.2.0.0" />
         <field name="Fill Pools On Load" type="bool" since="10.2.0.0" />
         <field name="Num Generations" type="uint" since="10.2.0.0" />
-        <field name="Generations" type="uint" since="10.2.0.0" arr1="Num Generations" />
+        <field name="Generations" type="uint" since="10.2.0.0" length="Num Generations" />
         <field name="Particle Meshes" type="Ref" template="NiNode" />
     </niobject>
 
@@ -3962,13 +3962,13 @@
         <field name="Unknown Short 1" type="ushort" />
         <field name="Unknown Short 2" type="ushort" />
         <field name="Unknown Short 3" type="ushort" />
-        <field name="Unknown 7 Floats" type="float" arr1="7" />
-        <field name="Unknown Bytes 1" type="byte" arr1="7" arr2="12" />
+        <field name="Unknown 7 Floats" type="float" length="7" />
+        <field name="Unknown Bytes 1" type="byte" length="7" width="12" />
         <field name="Num Unknown Vectors" type="uint" />
-        <field name="Unknown Vectors" type="Vector4" arr1="Num Unknown Vectors" />
+        <field name="Unknown Vectors" type="Vector4" length="Num Unknown Vectors" />
         <field name="Num Unknown Bytes 2" type="uint" />
-        <field name="Unknown Bytes 2" type="byte" arr1="Num Unknown Bytes 2" />
-        <field name="Unknown 5 Ints" type="uint" arr1="5" />
+        <field name="Unknown Bytes 2" type="byte" length="Num Unknown Bytes 2" />
+        <field name="Unknown 5 Ints" type="uint" length="5" />
     </niobject>
 
     <niobject name="NiBlendBoolInterpolator" inherit="NiBlendInterpolator" module="NiAnimation">
@@ -4055,9 +4055,9 @@
     <niobject name="NiBSplineData" inherit="NiObject" module="NiAnimation">
         Contains one or more sets of control points for use in interpolation of open, uniform B-Splines, stored as either float or compact.
         <field name="Num Float Control Points" type="uint" />
-        <field name="Float Control Points" type="float" arr1="Num Float Control Points">Float values representing the control data.</field>
+        <field name="Float Control Points" type="float" length="Num Float Control Points">Float values representing the control data.</field>
         <field name="Num Compact Control Points" type="uint" />
-        <field name="Compact Control Points" type="short" arr1="Num Compact Control Points">Signed shorts representing the data from 0 to 1 (scaled by SHRT_MAX).</field>
+        <field name="Compact Control Points" type="short" length="Num Compact Control Points">Signed shorts representing the data from 0 to 1 (scaled by SHRT_MAX).</field>
     </niobject>
 
     <niobject name="NiCamera" inherit="NiAVObject" module="NiMain">
@@ -4095,7 +4095,7 @@
         Controls animation sequences on a specific branch of the scene graph.
         <field name="Cumulative" type="bool">Whether transformation accumulation is enabled. If accumulation is not enabled, the manager will treat all sequence data on the accumulation root as absolute data instead of relative delta values.</field>
         <field name="Num Controller Sequences" type="uint" />
-        <field name="Controller Sequences" type="Ref" template="NiControllerSequence" arr1="Num Controller Sequences" />
+        <field name="Controller Sequences" type="Ref" template="NiControllerSequence" length="Num Controller Sequences" />
         <field name="Object Palette" type="Ref" template="NiDefaultAVObjectPalette" />
     </niobject>
 
@@ -4105,11 +4105,11 @@
         <field name="Accum Root Name" type="string" until="10.1.0.103">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
         <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" until="10.1.0.103" />
         <field name="Num DIV2 Ints" type="uint" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
-        <field name="DIV2 Ints" type="int" arr1="Num DIV2 Ints" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
+        <field name="DIV2 Ints" type="int" length="Num DIV2 Ints" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
         <field name="DIV2 Ref" type="Ref" template="NiObject" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
         <field name="Num Controlled Blocks" type="uint" />
         <field name="Array Grow By" type="uint" default="1" since="10.1.0.106" />
-        <field name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" />
+        <field name="Controlled Blocks" type="ControlledBlock" length="Num Controlled Blocks" />
     </niobject>
 
     <niobject name="NiControllerSequence" inherit="NiSequence" module="NiAnimation">
@@ -4129,7 +4129,7 @@
         <field name="String Palette" type="Ref" template="NiStringPalette" since="10.1.0.113" until="20.1.0.0" />
         <field name="Anim Notes" type="Ref" template="BSAnimNotes" since="20.2.0.7" vercond="(#BSVER# #GTE# 24) #AND# (#BSVER# #LTE# 28)" />
         <field name="Num Anim Note Arrays" type="ushort" since="20.2.0.7" vercond="#BSVER# #GT# 28" />
-        <field name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" since="20.2.0.7" vercond="#BSVER# #GT# 28" />
+        <field name="Anim Note Arrays" type="Ref" template="BSAnimNotes" length="Num Anim Note Arrays" since="20.2.0.7" vercond="#BSVER# #GT# 28" />
     </niobject>
 
     <niobject name="NiAVObjectPalette" abstract="true" inherit="NiObject" module="NiMain">
@@ -4140,7 +4140,7 @@
         NiAVObjectPalette implementation. Used to quickly look up objects by name.
         <field name="Scene" type="Ptr" template="NiAVObject">Scene root of the object palette.</field>
         <field name="Num Objs" type="uint">Number of objects.</field>
-        <field name="Objs" type="AVObject" arr1="Num Objs">The objects.</field>
+        <field name="Objs" type="AVObject" length="Num Objs">The objects.</field>
     </niobject>
 
     <niobject name="NiDirectionalLight" inherit="NiLight" module="NiMain">
@@ -4170,7 +4170,7 @@
     <niobject name="NiFloatsExtraData" inherit="NiExtraData" module="NiMain">
         Extra float array data.
         <field name="Num Floats" type="uint">Number of floats in the next field.</field>
-        <field name="Data" type="float" arr1="Num Floats">Float data.</field>
+        <field name="Data" type="float" length="Num Floats">Float data.</field>
     </niobject>
 
     <niobject name="NiFogProperty" inherit="NiProperty" module="NiMain">
@@ -4217,7 +4217,7 @@
     <niobject name="NiIntegersExtraData" inherit="NiExtraData" module="NiMain">
         Extra integer array data.
         <field name="Num Integers" type="uint">Number of integers.</field>
-        <field name="Data" type="uint" arr1="Num Integers">Integers.</field>
+        <field name="Data" type="uint" length="Num Integers">Integers.</field>
     </niobject>
 
     <niobject name="BSKeyframeController" inherit="NiKeyframeController" module="BSAnimation" versions="#BETHESDA#">
@@ -4230,9 +4230,9 @@
         Wrapper for transformation animation keys.
         <field name="Num Rotation Keys" type="uint">The number of quaternion rotation keys. If the rotation type is XYZ (type 4) then this *must* be set to 1, and in this case the actual number of keys is stored in the XYZ Rotations field.</field>
         <field name="Rotation Type" type="KeyType" cond="Num Rotation Keys != 0">The type of interpolation to use for rotation.  Can also be 4 to indicate that separate X, Y, and Z values are used for the rotation instead of Quaternions.</field>
-        <field name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" arr1="Num Rotation Keys" cond="Rotation Type != 4">The rotation keys if Quaternion rotation is used.</field>
+        <field name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" length="Num Rotation Keys" cond="Rotation Type != 4">The rotation keys if Quaternion rotation is used.</field>
         <field name="Order" type="float" cond="Rotation Type == 4" until="10.1.0.0" />
-        <field name="XYZ Rotations" type="KeyGroup" template="float" arr1="3" cond="Rotation Type == 4">Individual arrays of keys for rotating X, Y, and Z individually.</field>
+        <field name="XYZ Rotations" type="KeyGroup" template="float" length="3" cond="Rotation Type == 4">Individual arrays of keys for rotating X, Y, and Z individually.</field>
         <field name="Translations" type="KeyGroup" template="Vector3">Translation keys.</field>
         <field name="Scales" type="KeyGroup" template="float">Scale keys.</field>
     </niobject>
@@ -4279,15 +4279,15 @@
         <field name="Num Morphs" type="uint">Number of morphing object.</field>
         <field name="Num Vertices" type="uint">Number of vertices.</field>
         <field name="Relative Targets" type="byte" default="1">This byte is always 1 in all official files.</field>
-        <field name="Morphs" type="Morph" arg="Num Vertices" arr1="Num Morphs">The geometry morphing objects.</field>
+        <field name="Morphs" type="Morph" arg="Num Vertices" length="Num Morphs">The geometry morphing objects.</field>
     </niobject>
 
     <niobject name="NiNode" inherit="NiAVObject" module="NiMain">
         Generic node object for grouping.
         <field name="Num Children" type="uint">The number of child objects.</field>
-        <field name="Children" type="Ref" template="NiAVObject" arr1="Num Children">List of child node object indices.</field>
+        <field name="Children" type="Ref" template="NiAVObject" length="Num Children">List of child node object indices.</field>
         <field name="Num Effects" type="uint" vercond="#NI_BS_LT_FO4#">The number of references to effect objects that follow.</field>
-        <field name="Effects" type="Ref" template="NiDynamicEffect" arr1="Num Effects" vercond="#NI_BS_LT_FO4#">List of node effects. ADynamicEffect?</field>
+        <field name="Effects" type="Ref" template="NiDynamicEffect" length="Num Effects" vercond="#NI_BS_LT_FO4#">List of node effects. ADynamicEffect?</field>
     </niobject>
 
     <niobject name="NiBone" inherit="NiNode" module="NiLegacy">
@@ -4305,7 +4305,7 @@
     <niobject name="FxWidget" inherit="NiNode" module="NiCustom" versions="V10_0_1_0">
         Firaxis-specific UI widgets?
         <field name="Unknown 3" type="byte" />
-        <field name="Unknown 292 Bytes" type="byte" arr1="292" />
+        <field name="Unknown 292 Bytes" type="byte" length="292" />
     </niobject>
 
     <niobject name="FxButton" inherit="FxWidget" module="NiCustom" versions="V10_0_1_0">
@@ -4318,7 +4318,7 @@
         <field name="Unknown Int 2" type="uint" />
         <field name="Unknown Int 3" type="uint" />
         <field name="Num Buttons" type="uint">Number of unknown links.</field>
-        <field name="Buttons" type="Ptr" template="FxRadioButton" arr1="Num Buttons">Unknown pointers to other buttons.  Maybe other buttons in a group so they can be switch off if this one is switched on?</field>
+        <field name="Buttons" type="Ptr" template="FxRadioButton" length="Num Buttons">Unknown pointers to other buttons.  Maybe other buttons in a group so they can be switch off if this one is switched on?</field>
     </niobject>
 
     <niobject name="NiBillboardNode" inherit="NiNode" module="NiMain">
@@ -4368,7 +4368,7 @@
         Level of detail selector. Links to different levels of detail of the same model, used to switch a geometry at a specified distance.
         <field name="LOD Center" type="Vector3" since="4.0.0.2" until="10.0.1.0" />
         <field name="Num LOD Levels" type="uint" until="10.0.1.0" />
-        <field name="LOD Levels" type="LODRange" arr1="Num LOD Levels" until="10.0.1.0" />
+        <field name="LOD Levels" type="LODRange" length="Num LOD Levels" until="10.0.1.0" />
         <field name="LOD Level Data" type="Ref" template="NiLODData" since="10.1.0.0" />
     </niobject>
 
@@ -4376,8 +4376,8 @@
         NiPalette objects represent mappings from 8-bit indices to 24-bit RGB or 32-bit RGBA colors.
         <field name="Has Alpha" type="byte">Not boolean but used as one, always 8-bit.</field>
         <field name="Num Entries" type="uint" default="256">The number of palette entries. Always 256 but can also be 16.</field>
-        <field name="Palette" type="ByteColor4" arr1="16" cond="Num Entries == 16">The color palette.</field>
-        <field name="Palette" type="ByteColor4" arr1="256" cond="Num Entries != 16">The color palette.</field>
+        <field name="Palette" type="ByteColor4" length="16" cond="Num Entries == 16">The color palette.</field>
+        <field name="Palette" type="ByteColor4" length="256" cond="Num Entries != 16">The color palette.</field>
     </niobject>
 
     <niobject name="NiParticleBomb" inherit="NiParticleModifier" module="NiLegacy" until="V10_0_1_0">
@@ -4406,7 +4406,7 @@
     <niobject name="NiParticleMeshModifier" inherit="NiParticleModifier" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1) particle modifier.
         <field name="Num Particle Meshes" type="uint" />
-        <field name="Particle Meshes" arr1="Num Particle Meshes" type="Ref" template="NiAVObject" />
+        <field name="Particle Meshes" length="Num Particle Meshes" type="Ref" template="NiAVObject" />
     </niobject>
 
     <niobject name="NiParticleRotation" inherit="NiParticleModifier" module="NiLegacy" until="V10_0_1_0">
@@ -4446,7 +4446,7 @@
 
         <field name="World Space" type="bool" default="1" since="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</field>
         <field name="Num Modifiers" type="uint" since="10.1.0.0">The number of modifier references.</field>
-        <field name="Modifiers" type="Ref" template="NiPSysModifier" arr1="Num Modifiers" since="10.1.0.0">The list of particle modifiers.</field>
+        <field name="Modifiers" type="Ref" template="NiPSysModifier" length="Num Modifiers" since="10.1.0.0">The list of particle modifiers.</field>
     </niobject>
 
     <niobject name="NiMeshParticleSystem" inherit="NiParticleSystem" module="NiParticle">
@@ -4501,14 +4501,14 @@
 
         <field name="Num Particles" type="ushort" since="3.3.0.13">Size of the following array. (Maximum number of simultaneous active particles)</field>
         <field name="Num Valid" type="ushort" since="3.3.0.13">Number of valid entries in the following array. (Number of active particles at the time the system was saved)</field>
-        <field name="Particles" type="NiParticleInfo" arr1="Num Particles" since="3.3.0.13" />
+        <field name="Particles" type="NiParticleInfo" length="Num Particles" since="3.3.0.13" />
         <field name="Emitter Modifier" type="Ref" template="NiEmitterModifier" since="3.3.0.13" />
         <field name="Particle Modifier" type="Ref" template="NiParticleModifier">Link to some optional particle modifiers (NiGravity, NiParticleGrowFade, NiParticleBomb, ...)</field>
         <field name="Particle Collider" type="Ref" template="NiParticleCollider" />
         <field name="Static Target Bound" type="byte" since="3.3.0.15" />
         <field name="Color Data" type="Ref" template="NiColorData" until="3.1" />
         <field name="Unknown Float 1" type="float" until="3.1" />
-        <field name="Unknown Floats 2" arr1="Particle Unknown Short" type="float" until="3.1" />
+        <field name="Unknown Floats 2" length="Particle Unknown Short" type="float" until="3.1" />
     </niobject>
 
     <niobject name="NiBSPArrayController" inherit="NiParticleSystemController" module="BSLegacy" until="V10_0_1_0">
@@ -4545,7 +4545,7 @@
         <field name="Blue Mask" type="uint" until="10.4.0.1">0x00ff0000 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
         <field name="Alpha Mask" type="uint" until="10.4.0.1">0xff000000 (for 32bpp) or 0x00000000 (for 24bpp and 8bpp)</field>
         <field name="Bits Per Pixel" type="uint" until="10.4.0.1">Bits per pixel, 0 (Compressed), 8, 24 or 32.</field>
-        <field name="Old Fast Compare" type="byte" arr1="8" until="10.4.0.1">
+        <field name="Old Fast Compare" type="byte" length="8" until="10.4.0.1">
             [96,8,130,0,0,65,0,0] if 24 bits per pixel
             [129,8,130,32,0,65,12,0] if 32 bits per pixel
             [34,0,0,0,0,0,0,0] if 8 bits per pixel
@@ -4558,20 +4558,20 @@
         <field name="Flags" type="byte" since="10.4.0.2" />
         <field name="Tiling" type="PixelTiling" since="10.4.0.2" />
         <field name="sRGB Space" type="bool" since="20.3.0.4" />
-        <field name="Channels" type="PixelFormatComponent" arr1="4" since="10.4.0.2">Channel Data</field>
+        <field name="Channels" type="PixelFormatComponent" length="4" since="10.4.0.2">Channel Data</field>
     </niobject>
 
     <niobject name="NiPersistentSrcTextureRendererData" inherit="NiPixelFormat" module="NiMain">
         <field name="Palette" type="Ref" template="NiPalette" />
         <field name="Num Mipmaps" type="uint" />
         <field name="Bytes Per Pixel" type="uint" />
-        <field name="Mipmaps" type="MipMap" arr1="Num Mipmaps" />
+        <field name="Mipmaps" type="MipMap" length="Num Mipmaps" />
         <field name="Num Pixels" type="uint" />
         <field name="Pad Num Pixels" type="uint" since="20.2.0.6" />
         <field name="Num Faces" type="uint" />
         <field name="Platform" type="PlatformID" until="30.1.0.0" />
         <field name="Renderer" type="RendererID" since="30.1.0.1" />
-        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels * Num Faces" />
+        <field name="Pixel Data" type="byte" binary="true" length="Num Pixels * Num Faces" />
     </niobject>
 
     <niobject name="NiPixelData" inherit="NiPixelFormat" module="NiMain">
@@ -4579,12 +4579,12 @@
         <field name="Palette" type="Ref" template="NiPalette" />
         <field name="Num Mipmaps" type="uint" />
         <field name="Bytes Per Pixel" type="uint" />
-        <field name="Mipmaps" type="MipMap" arr1="Num Mipmaps" />
+        <field name="Mipmaps" type="MipMap" length="Num Mipmaps" />
         <field name="Num Pixels" type="uint" />
         <!-- Technically since 10.3.0.6, fudging for WorldShift custom version as no games have official 10.3 NIFs anyway. -->
         <field name="Num Faces" type="uint" since="10.4.0.2" default="1" />
-        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels" until="10.4.0.1" />
-        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels * Num Faces" since="10.4.0.2" />
+        <field name="Pixel Data" type="byte" binary="true" length="Num Pixels" until="10.4.0.1" />
+        <field name="Pixel Data" type="byte" binary="true" length="Num Pixels * Num Faces" since="10.4.0.2" />
     </niobject>
 
     <niobject name="NiParticleCollider" inherit="NiParticleModifier" module="NiLegacy" until="V10_0_1_0">
@@ -4619,8 +4619,8 @@
         Wrapper for rotation animation keys.
         <field name="Num Rotation Keys" type="uint" />
         <field name="Rotation Type" type="KeyType" cond="Num Rotation Keys != 0" />
-        <field name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" arr1="Num Rotation Keys" cond="Rotation Type != 4" />
-        <field name="XYZ Rotations" type="KeyGroup" template="float" arr1="3" cond="Rotation Type == 4" />
+        <field name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" length="Num Rotation Keys" cond="Rotation Type != 4" />
+        <field name="XYZ Rotations" type="KeyGroup" template="float" length="3" cond="Rotation Type == 4" />
     </niobject>
 
     <niobject name="NiPSysAgeDeathModifier" inherit="NiPSysModifier" module="NiParticle">
@@ -4680,7 +4680,7 @@
         DEPRECATED (10.2). Particle system emitter controller data.
         <field name="Birth Rate Keys" type="KeyGroup" template="float" />
         <field name="Num Active Keys" type="uint" />
-        <field name="Active Keys" type="Key" arg="1" template="byte" arr1="Num Active Keys" />
+        <field name="Active Keys" type="Key" arg="1" template="byte" length="Num Active Keys" />
     </niobject>
 
     <niobject name="NiPSysGravityModifier" inherit="NiPSysModifier" module="NiParticle">
@@ -4707,7 +4707,7 @@
     <niobject name="NiPSysMeshEmitter" inherit="NiPSysEmitter" module="NiParticle">
         Particle emitter that uses points on a specified mesh to emit from.
         <field name="Num Emitter Meshes" type="uint" />
-        <field name="Emitter Meshes" type="Ptr" template="NiAVObject" arr1="Num Emitter Meshes">The meshes which are emitted from.</field>
+        <field name="Emitter Meshes" type="Ptr" template="NiAVObject" length="Num Emitter Meshes">The meshes which are emitted from.</field>
         <field name="Initial Velocity Type" type="VelocityType">The method by which the initial particle velocity will be computed.</field>
         <field name="Emission Type" type="EmitFrom">The manner in which particles are emitted from the Emitter Meshes.</field>
         <field name="Emission Axis" type="Vector3" default="#X_AXIS#">The emission axis if VELOCITY_USE_DIRECTION.</field>
@@ -4716,7 +4716,7 @@
     <niobject name="NiPSysMeshUpdateModifier" inherit="NiPSysModifier" module="NiParticle">
         Particle modifier that updates mesh particles using the age of each particle.
         <field name="Num Meshes" type="uint" />
-        <field name="Meshes" type="Ref" template="NiAVObject" arr1="Num Meshes" />
+        <field name="Meshes" type="Ref" template="NiAVObject" length="Num Meshes" />
     </niobject>
     
     <niobject name="BSPSysInheritVelocityModifier" inherit="NiPSysModifier" module="BSParticle" versions="#BETHESDA#">
@@ -4849,7 +4849,7 @@
     
     <niobject name="BSPSysScaleModifier" inherit="NiPSysModifier" module="BSParticle" versions="#BETHESDA#">
         <field name="Num Scales" type="uint" />
-        <field name="Scales" type="float" arr1="Num Scales" />
+        <field name="Scales" type="float" length="Num Scales" />
     </niobject>
     
     
@@ -4940,7 +4940,7 @@
         NiRangeLODData controls switching LOD levels based on Z depth from the camera to the NiLODNode.
         <field name="LOD Center" type="Vector3" />
         <field name="Num LOD Levels" type="uint" />
-        <field name="LOD Levels" type="LODRange" arr1="Num LOD Levels" />
+        <field name="LOD Levels" type="LODRange" length="Num LOD Levels" />
     </niobject>
 
     <niobject name="NiScreenLODData" inherit="NiLODData" module="NiMain">
@@ -4948,7 +4948,7 @@
         <field name="Bounding Sphere" type="NiBound" />
         <field name="World Bounding Sphere" type="NiBound" />
         <field name="Num Proportions" type="uint" />
-        <field name="Proportion Levels" type="float" arr1="Num Proportions" />
+        <field name="Proportion Levels" type="float" length="Num Proportions" />
     </niobject>
 
     <niobject name="NiRotatingParticles" inherit="NiParticles" module="NiLegacy" until="V10_0_1_0">
@@ -4971,7 +4971,7 @@
         <field name="Num Bones" type="uint">Number of bones.</field>
         <field name="Skin Partition" type="Ref" template="NiSkinPartition" since="4.0.0.2" until="10.1.0.0">This optionally links a NiSkinPartition for hardware-acceleration information.</field>
         <field name="Has Vertex Weights" type="byte" since="4.2.1.0" default="1">Enables Vertex Weights for this NiSkinData.</field>
-        <field name="Bone List" type="BoneData" arr1="Num Bones" arg="Has Vertex Weights">Contains offset data for each node that this skin is influenced by.</field>
+        <field name="Bone List" type="BoneData" length="Num Bones" arg="Has Vertex Weights">Contains offset data for each node that this skin is influenced by.</field>
     </niobject>
 
     <niobject name="NiSkinInstance" inherit="NiObject" module="NiMain">
@@ -4980,15 +4980,15 @@
         <field name="Skin Partition" type="Ref" template="NiSkinPartition" since="10.1.0.101">Refers to a NiSkinPartition objects, which partitions the mesh such that every vertex is only influenced by a limited number of bones.</field>
         <field name="Skeleton Root" type="Ptr" template="NiNode">Armature root node.</field>
         <field name="Num Bones" type="uint">The number of node bones referenced as influences.</field>
-        <field name="Bones" type="Ptr" template="NiNode" arr1="Num Bones">List of all armature bones.</field>
+        <field name="Bones" type="Ptr" template="NiNode" length="Num Bones">List of all armature bones.</field>
     </niobject>
 
     <niobject name="NiTriShapeSkinController" inherit="NiTimeController" module="NiLegacy" until="V10_0_1_0">
         Old version of skinning instance.
         <field name="Num Bones" type="uint">The number of node bones referenced as influences.</field>
-        <field name="Vertex Counts" type="uint" arr1="Num Bones">The number of vertex weights stored for each bone.</field>
-        <field name="Bones" type="Ptr" template="NiBone" arr1="Num Bones">List of all armature bones.</field>
-        <field name="Bone Data" type="OldSkinData" arr1="Num Bones" arr2="Vertex Counts">Contains skin weight data for each node that this skin is influenced by.</field>
+        <field name="Vertex Counts" type="uint" length="Num Bones">The number of vertex weights stored for each bone.</field>
+        <field name="Bones" type="Ptr" template="NiBone" length="Num Bones">List of all armature bones.</field>
+        <field name="Bone Data" type="OldSkinData" length="Num Bones" width="Vertex Counts">Contains skin weight data for each node that this skin is influenced by.</field>
     </niobject>
 
     <niobject name="NiSkinPartition" inherit="NiObject" module="NiMain">
@@ -4997,8 +4997,8 @@
 		<field name="Data Size" type="uint" calc="#LEN[Vertex Data]# #MUL# Vertex Size" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
 		<field name="Vertex Size" type="uint" calc="(Vertex Desc #BITAND# 0xF) #MUL# 4" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
 		<field name="Vertex Desc" type="BSVertexDesc" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc #RSH# 44" arr1="Data Size / Vertex Size" cond="Data Size #GT# 0" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Partitions" type="SkinPartition" arr1="Num Partitions" />
+		<field name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc #RSH# 44" length="Data Size / Vertex Size" cond="Data Size #GT# 0" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Partitions" type="SkinPartition" length="Num Partitions" />
     </niobject>
 
     <niobject name="NiTexture" abstract="true" inherit="NiObjectNET" module="NiMain">
@@ -5075,13 +5075,13 @@
     <niobject name="NiStringsExtraData" inherit="NiExtraData" module="NiMain">
         Extra data in the form of a list of strings.
         <field name="Num Strings" type="uint" default="1">Number of strings.</field>
-        <field name="Data" type="SizedString" arr1="Num Strings">The strings.</field>
+        <field name="Data" type="SizedString" length="Num Strings">The strings.</field>
     </niobject>
 
     <niobject name="NiTextKeyExtraData" inherit="NiExtraData" module="NiMain">
         Extra data that holds an array of NiTextKey objects for use in animation sequences.
         <field name="Num Text Keys" type="uint">The number of text keys that follow.</field>
-        <field name="Text Keys" type="Key" arg="1" template="string" arr1="Num Text Keys">List of textual notes and at which time they take effect. Used for designating the start and stop of animations and the triggering of sounds.</field>
+        <field name="Text Keys" type="Key" arg="1" template="string" length="Num Text Keys">List of textual notes and at which time they take effect. Used for designating the start and stop of animations and the triggering of sounds.</field>
     </niobject>
 
     <niobject name="NiTextureEffect" inherit="NiDynamicEffect" module="NiMain">
@@ -5104,7 +5104,7 @@
 
     <niobject name="NiTextureModeProperty" inherit="NiProperty" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
-        <field name="Unknown Ints" type="uint" arr1="3" until="2.3" />
+        <field name="Unknown Ints" type="uint" length="3" until="2.3" />
         <field name="Flags" type="ushort" since="3.0">Either 210 or 194.</field>
         <field name="PS2 L" type="short" default="0" since="3.1" until="10.2.0.0" />
         <field name="PS2 K" type="short" default="-75" since="3.1" until="10.2.0.0" />
@@ -5121,10 +5121,10 @@
 
     <niobject name="NiTextureProperty" inherit="NiProperty" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
-        <field name="Unknown Ints 1" type="uint" arr1="2" until="2.3" />
+        <field name="Unknown Ints 1" type="uint" length="2" until="2.3" />
         <field name="Flags" type="ushort" since="3.0">Property flags.</field>
         <field name="Image" type="Ref" template="NiImage">Link to the texture image.</field>
-        <field name="Unknown Ints 2" type="uint" arr1="2" since="3.0" until="3.03" />
+        <field name="Unknown Ints 2" type="uint" length="2" since="3.0" until="3.03" />
     </niobject>
 
     <niobject name="NiTexturingProperty" inherit="NiProperty" module="NiMain">
@@ -5167,7 +5167,7 @@
         <field name="Decal 3 Texture" type="TexDesc" cond="Has Decal 3 Texture" />
         
         <field name="Num Shader Textures" type="uint" since="10.0.1.0" />
-        <field name="Shader Textures" type="ShaderTexDesc" arr1="Num Shader Textures" since="10.0.1.0" />
+        <field name="Shader Textures" type="ShaderTexDesc" length="Num Shader Textures" since="10.0.1.0" />
     </niobject>
 
     <niobject name="NiMultiTextureProperty" inherit="NiTexturingProperty" module="NiLegacy" />
@@ -5184,10 +5184,10 @@
         Holds mesh data using a list of singular triangles.
         <field name="Num Triangle Points" type="uint" range="0:196605">Num Triangles times 3.</field>
         <field name="Has Triangles" type="bool" since="10.1.0.0">Do we have triangle data?</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" until="10.0.1.2">Triangle data.</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Has Triangles" since="10.0.1.3">Triangle face data.</field>
+        <field name="Triangles" type="Triangle" length="Num Triangles" until="10.0.1.2">Triangle data.</field>
+        <field name="Triangles" type="Triangle" length="Num Triangles" cond="Has Triangles" since="10.0.1.3">Triangle face data.</field>
         <field name="Num Match Groups" type="ushort" since="3.1">Number of shared normals groups.</field>
-        <field name="Match Groups" type="MatchGroup" arr1="Num Match Groups" since="3.1">The shared normals.</field>
+        <field name="Match Groups" type="MatchGroup" length="Num Match Groups" since="3.1">The shared normals.</field>
     </niobject>
 
     <niobject name="NiTriStrips" inherit="NiTriBasedGeom" module="NiMain">
@@ -5197,10 +5197,10 @@
     <niobject name="NiTriStripsData" inherit="NiTriBasedGeomData" module="NiMain">
         Holds mesh data using strips of triangles.
         <field name="Num Strips" type="ushort" default="1" />
-        <field name="Strip Lengths" type="ushort" arr1="Num Strips">The number of points in each triangle strip.</field>
+        <field name="Strip Lengths" type="ushort" length="Num Strips">The number of points in each triangle strip.</field>
         <field name="Has Points" type="bool" default="1" since="10.0.1.3">Do we have strip point data?</field>
-        <field name="Points" type="ushort" arr1="Num Strips" arr2="Strip Lengths" until="10.0.1.2">The points in the Triangle strips.  Size is the sum of all entries in Strip Lengths.</field>
-        <field name="Points" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="Has Points" since="10.0.1.3">The points in the Triangle strips. Size is the sum of all entries in Strip Lengths.</field>
+        <field name="Points" type="ushort" length="Num Strips" width="Strip Lengths" until="10.0.1.2">The points in the Triangle strips.  Size is the sum of all entries in Strip Lengths.</field>
+        <field name="Points" type="ushort" length="Num Strips" width="Strip Lengths" cond="Has Points" since="10.0.1.3">The points in the Triangle strips. Size is the sum of all entries in Strip Lengths.</field>
     </niobject>
 
     <niobject name="NiEnvMappedTriShape" inherit="NiObjectNET" module="NiLegacy" until="V10_0_1_0">
@@ -5208,7 +5208,7 @@
         <field name="Unknown 1" type="ushort" />
         <field name="Unknown Matrix" type="Matrix44" />
         <field name="Num Children" type="uint">The number of child objects.</field>
-        <field name="Children" type="Ref" template="NiAVObject" arr1="Num Children">List of child node object indices.</field>
+        <field name="Children" type="Ref" template="NiAVObject" length="Num Children">List of child node object indices.</field>
         <field name="Child 2" type="Ref" template="NiObject" />
         <field name="Child 3" type="Ref" template="NiObject" />
     </niobject>
@@ -5220,31 +5220,31 @@
     <niobject name="NiBezierTriangle4" inherit="NiObject" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
         Sub data of NiBezierMesh
-        <field name="Unknown 1" type="uint" arr1="6" />
+        <field name="Unknown 1" type="uint" length="6" />
         <field name="Unknown 2" type="ushort" />
         <field name="Matrix" type="Matrix33" />
         <field name="Vector 1" type="Vector3" />
         <field name="Vector 2" type="Vector3" />
-        <field name="Unknown 3" type="short" arr1="4" />
+        <field name="Unknown 3" type="short" length="4" />
         <field name="Unknown 4" type="byte" />
         <field name="Unknown 5" type="uint" />
-        <field name="Unknown 6" type="short" arr1="24" />
+        <field name="Unknown 6" type="short" length="24" />
     </niobject>
 
     <niobject name="NiBezierMesh" inherit="NiAVObject" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
         Unknown
         <field name="Num Bezier Triangles" type="uint" />
-        <field name="Bezier Triangle" type="Ref" template="NiBezierTriangle4" arr1="Num Bezier Triangles" />
+        <field name="Bezier Triangle" type="Ref" template="NiBezierTriangle4" length="Num Bezier Triangles" />
         <field name="Unknown 3" type="uint" />
         <field name="Count 1" type="ushort" />
         <field name="Unknown 4" type="ushort" />
-        <field name="Points 1" type="Vector3" arr1="Count 1" />
+        <field name="Points 1" type="Vector3" length="Count 1" />
         <field name="Unknown 5" type="uint" />
-        <field name="Points 2" type="float" arr1="Count 1" arr2="2" />
+        <field name="Points 2" type="float" length="Count 1" width="2" />
         <field name="Unknown 6" type="uint" />
         <field name="Count 2" type="ushort" />
-        <field name="Data 2" type="ushort" arr1="Count 2" arr2="4" />
+        <field name="Data 2" type="ushort" length="Count 2" width="4" />
     </niobject>
 
     <niobject name="NiClod" inherit="NiTriBasedGeom" module="NiLegacy" until="V4_0_0_2">
@@ -5263,9 +5263,9 @@
         <field name="Unknown Count 3" type ="ushort" />
         <field name="Unknown Float" type="float" />
         <field name="Unknown Short" type="ushort" />
-        <field name="Unknown Clod Shorts 1" type="ushort" arr1="Unknown Count 1" arr2="6" />
-        <field name="Unknown Clod Shorts 2" type="ushort" arr1="Unknown Count 2" />
-        <field name="Unknown Clod Shorts 3" type="ushort" arr1="Unknown Count 3" arr2="6" />
+        <field name="Unknown Clod Shorts 1" type="ushort" length="Unknown Count 1" width="6" />
+        <field name="Unknown Clod Shorts 2" type="ushort" length="Unknown Count 2" />
+        <field name="Unknown Clod Shorts 3" type="ushort" length="Unknown Count 3" width="6" />
     </niobject>
 
     <niobject name="NiClodSkinInstance" inherit="NiSkinInstance" module="NiLegacy" until="V4_0_0_2">
@@ -5283,7 +5283,7 @@
     <niobject name="NiUVData" inherit="NiObject" module="NiAnimation" until="V20_2_0_8">
         DEPRECATED (pre-10.1), REMOVED (20.3)
         Texture coordinate data.
-        <field name="UV Groups" type="KeyGroup" template="float" arr1="4">
+        <field name="UV Groups" type="KeyGroup" template="float" length="4">
             Four UV data groups. Appear to be U translation, V translation, U scaling/tiling, V scaling/tiling.
         </field>
     </niobject>
@@ -5306,14 +5306,14 @@
         Not used in skinning.
         Unsure of use - perhaps for morphing animation or gravity.
         <field name="Num Vertices" type="ushort">Number of vertices.</field>
-        <field name="Weight" type="float" arr1="Num Vertices">The vertex weights.</field>
+        <field name="Weight" type="float" length="Num Vertices">The vertex weights.</field>
     </niobject>
 
     <niobject name="NiVisData" inherit="NiObject" module="NiAnimation">
         DEPRECATED (10.2), REMOVED (?), Replaced by NiBoolData.
         Visibility data for a controller.
         <field name="Num Keys" type="uint" />
-        <field name="Keys" type="Key" arg="1" template="byte" arr1="Num Keys" />
+        <field name="Keys" type="Key" arg="1" template="byte" length="Num Keys" />
     </niobject>
 
     <niobject name="NiWireframeProperty" inherit="NiProperty" module="NiMain">
@@ -5339,8 +5339,8 @@
         <field name="Width" type="uint">Image width</field>
         <field name="Height" type="uint">Image height</field>
         <field name="Image Type" type="ImageType">The format of the raw image data.</field>
-        <field name="RGB Image Data" type="ByteColor3" arr1="Width" arr2="Height" cond="Image Type == 1" >Image pixel data.</field>
-        <field name="RGBA Image Data" type="ByteColor4" arr1="Width" arr2="Height" cond="Image Type == 2" >Image pixel data.</field>
+        <field name="RGB Image Data" type="ByteColor3" length="Width" width="Height" cond="Image Type == 1" >Image pixel data.</field>
+        <field name="RGBA Image Data" type="ByteColor4" length="Width" width="Height" cond="Image Type == 2" >Image pixel data.</field>
     </niobject>
     
     <niobject name="NiAccumulator" abstract="true" inherit="NiObject" module="NiMain" />
@@ -5362,13 +5362,13 @@
         <field name="Scene Transform" type="NiTransform" />
         <field name="PhysX to World Scale" type="float" default="1.0" />
         <field name="Num Props" type="uint" since="20.3.0.2" />
-        <field name="Props" type="Ref" template="NiPhysXProp" arr1="Num Props" since="20.3.0.2" />
+        <field name="Props" type="Ref" template="NiPhysXProp" length="Num Props" since="20.3.0.2" />
         <field name="Num Sources" type="uint" />
-        <field name="Sources" type="Ref" template="NiPhysXSrc" arr1="Num Sources" />
+        <field name="Sources" type="Ref" template="NiPhysXSrc" length="Num Sources" />
         <field name="Num Dests" type="uint" />
-        <field name="Dests" type="Ref" template="NiPhysXDest" arr1="Num Dests" />
+        <field name="Dests" type="Ref" template="NiPhysXDest" length="Num Dests" />
         <field name="Num Modified Meshes" type="uint" since="20.4.0.0" />
-        <field name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" since="20.4.0.0" />
+        <field name="Modified Meshes" type="Ref" template="NiMesh" length="Num Modified Meshes" since="20.4.0.0" />
         <field name="Time Step" type="float" default="0.016666" since="20.2.0.8" />
         <field name="Keep Meshes" type="bool" since="20.2.0.8" until="20.3.0.1" />
         <field name="Num Sub Steps" type="uint" default="1" since="20.3.0.9" />
@@ -5527,29 +5527,29 @@
         <field name="Grid Cells X" type="uint" since="20.4.0.0" />
         <field name="Grid Cells Y" type="uint" since="20.4.0.0" />
         <field name="Num Actors" type="uint" until="20.3.0.1" />
-        <field name="Actors" type="Ref" template="NiPhysXActorDesc" arr1="Num Actors" until="20.3.0.1" />
+        <field name="Actors" type="Ref" template="NiPhysXActorDesc" length="Num Actors" until="20.3.0.1" />
         <field name="Num Joints" type="uint" until="20.3.0.1" />
-        <field name="Joints" type="Ref" template="NiPhysXJointDesc" arr1="Num Joints" until="20.3.0.1" />
+        <field name="Joints" type="Ref" template="NiPhysXJointDesc" length="Num Joints" until="20.3.0.1" />
         <field name="Num Materials" type="uint" until="20.3.0.1" />
-        <field name="Materials" type="NiPhysXMaterialDescMap" arr1="Num Materials" until="20.3.0.1" />
-        <field name="Group Collision Flags" type="bool" arr1="1024" />
-        <field name="Filter Ops" type="NxFilterOp" arr1="3" />
-        <field name="Filter Constants" type="uint" arr1="8" />
+        <field name="Materials" type="NiPhysXMaterialDescMap" length="Num Materials" until="20.3.0.1" />
+        <field name="Group Collision Flags" type="bool" length="1024" />
+        <field name="Filter Ops" type="NxFilterOp" length="3" />
+        <field name="Filter Constants" type="uint" length="8" />
         <field name="Filter" type="bool" default="1" />
         <field name="Num States" type="uint" until="20.3.0.1" />
         <field name="Num Compartments" type="uint" since="20.3.0.6" />
-        <field name="Compartments" type="NxCompartmentDescMap" arr1="Num Compartments" since="20.3.0.6" />
+        <field name="Compartments" type="NxCompartmentDescMap" length="Num Compartments" since="20.3.0.6" />
     </niobject>
 
     <niobject name="NiPhysXProp" inherit="NiObjectNET" module="NiPhysX" since="V20_2_0_8">
         A PhysX prop which holds information about PhysX actors in a Gamebryo scene
         <field name="PhysX to World Scale" type="float" default="1.0" />
         <field name="Num Sources" type="uint" />
-        <field name="Sources" type="Ref" template="NiPhysXSrc" arr1="Num Sources" />
+        <field name="Sources" type="Ref" template="NiPhysXSrc" length="Num Sources" />
         <field name="Num Dests" type="uint" />
-        <field name="Dests" type="Ref" template="NiPhysXDest" arr1="Num Dests" />
+        <field name="Dests" type="Ref" template="NiPhysXDest" length="Num Dests" />
         <field name="Num Modified Meshes" type="uint" since="20.4.0.0" />
-        <field name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" since="20.4.0.0" />
+        <field name="Modified Meshes" type="Ref" template="NiMesh" length="Num Modified Meshes" since="20.4.0.0" />
         <field name="Temp Name" type="NiFixedString" since="30.1.0.2" until="30.2.0.2" />
         <field name="Keep Meshes" type="bool" />
         <field name="Snapshot" type="Ref" template="NiPhysXPropDesc" />
@@ -5558,13 +5558,13 @@
     <niobject name="NiPhysXPropDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         For serialization of PhysX objects and to attach them to the scene.
         <field name="Num Actors" type="uint" />
-        <field name="Actors" type="Ref" template="NiPhysXActorDesc" arr1="Num Actors" />
+        <field name="Actors" type="Ref" template="NiPhysXActorDesc" length="Num Actors" />
         <field name="Num Joints" type="uint" />
-        <field name="Joints" type="Ref" template="NiPhysXJointDesc" arr1="Num Joints" />
+        <field name="Joints" type="Ref" template="NiPhysXJointDesc" length="Num Joints" />
         <field name="Num Clothes" type="uint" since="20.3.0.5" />
-        <field name="Clothes" type="Ref" template="NiPhysXClothDesc" arr1="Num Clothes" since="20.3.0.5" />
+        <field name="Clothes" type="Ref" template="NiPhysXClothDesc" length="Num Clothes" since="20.3.0.5" />
         <field name="Num Materials" type="uint" />
-        <field name="Materials" type="NiPhysXMaterialDescMap" arr1="Num Materials" />
+        <field name="Materials" type="NiPhysXMaterialDescMap" length="Num Materials" />
         <field name="Num States" type="uint" />
         <field name="State Names" type="NiTFixedStringMap" template="uint" since="20.4.0.0" />
         <field name="Flags" type="byte" since="20.4.0.0" />
@@ -5574,7 +5574,7 @@
         For serializing NxActor objects.
         <field name="Actor Name" type="NiFixedString" />
         <field name="Num Poses" type="uint" />
-        <field name="Poses" type="Matrix34" arr1="Num Poses" />
+        <field name="Poses" type="Matrix34" length="Num Poses" />
         <field name="Body Desc" type="Ref" template="NiPhysXBodyDesc" />
         <field name="Density" type="float" />
         <field name="Actor Flags" type="uint" />
@@ -5584,7 +5584,7 @@
         <field name="Force Field Material" type="ushort" since="20.4.0.0" />
         <field name="Dummy" type="uint" since="20.3.0.1" until="20.3.0.5" />
         <field name="Num Shape Descs" type="uint" />
-        <field name="Shape Descriptions" type="Ref" template="NiPhysXShapeDesc" arr1="Num Shape Descs" />
+        <field name="Shape Descriptions" type="Ref" template="NiPhysXShapeDesc" length="Num Shape Descs" />
         <field name="Actor Parent" type="Ref" template="NiPhysXActorDesc" />
         <field name="Source" type="Ref" template="NiPhysXRigidBodySrc" />
         <field name="Dest" type="Ref" template="NiPhysXRigidBodyDest" />
@@ -5602,7 +5602,7 @@
         <field name="Space Inertia" type="Vector3" />
         <field name="Mass" type="float" />
         <field name="Num Vels" type="uint" />
-        <field name="Vels" type="PhysXBodyStoredVels" arr1="Num Vels" />
+        <field name="Vels" type="PhysXBodyStoredVels" length="Num Vels" />
         <field name="Wake Up Counter" type="float" default="0.4" />
         <field name="Linear Damping" type="float" />
         <field name="Angular Damping" type="float" default="0.05" />
@@ -5678,7 +5678,7 @@
         A PhysX Joint abstract base class.
         <field name="Joint Type" type="NxJointType" />
         <field name="Joint Name" type="NiFixedString" />
-        <field name="Actors" type="NiPhysXJointActor" arr1="2" />
+        <field name="Actors" type="NiPhysXJointActor" length="2" />
         <field name="Max Force" type="float" />
         <field name="Max Torque" type="float" />
         <field name="Solver Extrapolation Factor" type="float" since="20.5.0.3" />
@@ -5686,7 +5686,7 @@
         <field name="Joint Flags" type="uint" />
         <field name="Limit Point" type="Vector3" />
         <field name="Num Limits" type="uint" />
-        <field name="Limits" type="NiPhysXJointLimit" arr1="Num Limits" />
+        <field name="Limits" type="NiPhysXJointLimit" length="Num Limits" />
     </niobject>
 
     <niobject name="NiPhysXD6JointDesc" inherit="NiPhysXJointDesc" module="NiPhysX" since="V20_2_0_8">
@@ -5778,7 +5778,7 @@
         <field name="Skin Width" type="float" default="-1.0" />
         <field name="Shape Name" type="NiFixedString" />
         <field name="Non Interacting Compartment Types" type="uint" since="20.4.0.0" />
-        <field name="Collision Bits" type="uint" arr1="4" />
+        <field name="Collision Bits" type="uint" length="4" />
         <field name="Plane" type="NxPlane" cond="Shape Type == 0" />
         <field name="Sphere Radius" type="float" cond="Shape Type == 1" />
         <field name="Box Half Extents" type="Vector3" cond="Shape Type == 2" />
@@ -5792,7 +5792,7 @@
         <field name="Mesh Name" type="NiFixedString" />
         <field name="Mesh Data" type="ByteArray" />
         <field name="Back Compat Vertex Map Size" type="ushort" since="20.3.0.5" until="30.2.0.2" />
-        <field name="Back Compat Vertex Map" type="ushort" arr1="Back Compat Vertex Map Size" since="20.3.0.5" until="30.2.0.2" />
+        <field name="Back Compat Vertex Map" type="ushort" length="Back Compat Vertex Map Size" since="20.3.0.5" until="30.2.0.2" />
         <field name="Mesh Flags" type="uint" />
         <field name="Mesh Paging Mode" type="uint" since="20.3.0.1" />
         <field name="Is Hardware" type="bool" since="20.3.0.2" until="20.3.0.4" />
@@ -5836,7 +5836,7 @@
         For serializing NxMaterialDesc objects.
         <field name="Index" type="ushort" />
         <field name="Num States" type="uint" />
-        <field name="Material Descs" type="NxMaterialDesc" arr1="Num States" />
+        <field name="Material Descs" type="NxMaterialDesc" length="Num States" />
     </niobject>
 
     <bitflags name="NxClothFlag" storage="uint" prefix="NX_CLF" since="V20_2_0_8">
@@ -5863,10 +5863,10 @@
     <struct name="PhysXClothState" since="V20_2_0_8">
         <field name="Pose" type="Matrix34" />
         <field name="Num Vertex Positions" type="ushort" />
-        <field name="Vertex Positions" type="Vector3" arr1="Num Vertex Positions" />
+        <field name="Vertex Positions" type="Vector3" length="Num Vertex Positions" />
         <field name="Num Tear Indices" type="ushort" />
-        <field name="Tear Indices" type="ushort" arr1="Num Tear Indices" />
-        <field name="Tear Split Planes" type="Vector3" arr1="Num Tear Indices" />
+        <field name="Tear Indices" type="ushort" length="Num Tear Indices" />
+        <field name="Tear Split Planes" type="Vector3" length="Num Tear Indices" />
     </struct>
 
     <struct name="PhysXClothAttachmentPosition" since="V20_2_0_8">
@@ -5879,7 +5879,7 @@
         <field name="Shape" type="Ref" template="NiPhysXShapeDesc" />
         <field name="Num Vertices" type="uint" />
         <field name="Flags" type="uint" cond="Num Vertices == 0" />
-        <field name="Positions" type="PhysXClothAttachmentPosition" cond="Num Vertices #GT# 0" arr1="Num Vertices" />
+        <field name="Positions" type="PhysXClothAttachmentPosition" cond="Num Vertices #GT# 0" length="Num Vertices" />
     </struct>
 
     <niobject name="NiPhysXClothDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5911,15 +5911,15 @@
         <field name="Wake Up Counter" type="float" default="0.4" />
         <field name="Sleep Linear Velocity" type="float" default="-1.0" />
         <field name="Collision Group" type="ushort" />
-        <field name="Collision Bits" type="uint" arr1="4" />
+        <field name="Collision Bits" type="uint" length="4" />
         <field name="Force Field Material" type="ushort" since="20.4.0.0" />
         <field name="Flags" type="NxClothFlag" default="0x20" />
         <field name="Vertex Map Size" type="ushort" since="30.2.0.3" />
-        <field name="Vertex Map" type="ushort" arr1="Vertex Map Size" since="30.2.0.3" />
+        <field name="Vertex Map" type="ushort" length="Vertex Map Size" since="30.2.0.3" />
         <field name="Num States" type="uint" since="20.4.0.0" />
-        <field name="States" type="PhysXClothState" arr1="Num States" since="20.4.0.0" />
+        <field name="States" type="PhysXClothState" length="Num States" since="20.4.0.0" />
         <field name="Num Attachments" type="uint" />
-        <field name="Attachments" type="PhysXClothAttachment" arr1="Num Attachments" />
+        <field name="Attachments" type="PhysXClothAttachment" length="Num Attachments" />
         <field name="Parent Actor" type="Ref" template="NiPhysXActorDesc" />
         <field name="Dest" type="Ref" template="NiPhysXDest" until="20.4.0.9" />
         <field name="Target Mesh" type="Ref" template="NiMesh" until="20.5.0.0" />
@@ -5965,7 +5965,7 @@
 
     <niobject name="NiLinesData" inherit="NiGeometryData" module="NiMain">
         Wireframe geometry data.
-        <field name="Lines" type="bool" arr1="Num Vertices">Is vertex connected to other (next?) vertex?</field>
+        <field name="Lines" type="bool" length="Num Vertices">Is vertex connected to other (next?) vertex?</field>
     </niobject>
 
     <struct name="Polygon" size="8">
@@ -5980,8 +5980,8 @@
         DEPRECATED (20.5), functionality included in NiMeshScreenElements.
         Two dimensional screen elements.
         <field name="Max Polygons" type="ushort" />
-        <field name="Polygons" type="Polygon" arr1="Max Polygons" />
-        <field name="Polygon Indices" type="ushort" arr1="Max Polygons" />
+        <field name="Polygons" type="Polygon" length="Max Polygons" />
+        <field name="Polygon Indices" type="ushort" length="Max Polygons" />
         <field name="Polygon Grow By" type="ushort" default="1" />
         <field name="Num Polygons" type="ushort" />
         <field name="Max Vertices" type="ushort" />
@@ -5999,7 +5999,7 @@
         NiRoomGroup represents a set of connected rooms i.e. a game level.
         <field name="Shell" type="Ptr" template="NiNode">Object that represents the room group as seen from the outside.</field>
         <field name="Num Rooms" type="uint" />
-        <field name="Rooms" type="Ptr" template="NiRoom" arr1="Num Rooms" />
+        <field name="Rooms" type="Ptr" template="NiRoom" length="Num Rooms" />
     </niobject>
 
     <niobject name="NiWall" inherit="NiNode" module="NiMain" until="V3_3_0_13">
@@ -6009,14 +6009,14 @@
     <niobject name="NiRoom" inherit="NiNode" module="NiMain">
         NiRoom objects represent cells in a cell-portal culling system.
         <field name="Num Walls" type="uint" />
-        <field name="Walls" type="Ref" template="NiWall" arr1="Num Walls" until="3.3.0.13" />
-        <field name="Wall Planes" type="NiPlane" arr1="Num Walls" since="4.0.0.0" />
+        <field name="Walls" type="Ref" template="NiWall" length="Num Walls" until="3.3.0.13" />
+        <field name="Wall Planes" type="NiPlane" length="Num Walls" since="4.0.0.0" />
         <field name="Num In Portals" type="uint" />
-        <field name="In Portals" type="Ptr" template="NiPortal" arr1="Num In Portals">The portals which see into the room.</field>
+        <field name="In Portals" type="Ptr" template="NiPortal" length="Num In Portals">The portals which see into the room.</field>
         <field name="Num Out Portals" type="uint" />
-        <field name="Out Portals" type="Ptr" template="NiPortal" arr1="Num Out Portals">The portals which see out of the room.</field>
+        <field name="Out Portals" type="Ptr" template="NiPortal" length="Num Out Portals">The portals which see out of the room.</field>
         <field name="Num Fixtures" type="uint" />
-        <field name="Fixtures" type="Ptr" template="NiAVObject" arr1="Num Fixtures">All geometry associated with the room. Seems to be Ref for legacy.</field>
+        <field name="Fixtures" type="Ptr" template="NiAVObject" length="Num Fixtures">All geometry associated with the room. Seems to be Ref for legacy.</field>
     </niobject>
 
     <niobject name="NiPortal" inherit="NiAVObject" module="NiMain">
@@ -6025,7 +6025,7 @@
         <field name="Portal Flags" type="ushort" />
         <field name="Plane Count" type="ushort">Unused in 20.x, possibly also 10.x.</field>
         <field name="Num Vertices" type="ushort" />
-        <field name="Vertices" type="Vector3" arr1="Num Vertices" />
+        <field name="Vertices" type="Vector3" length="Num Vertices" />
         <field name="Adjoiner" type="Ptr" template="NiNode">Root of the scenegraph which is to be seen through this portal.</field>
     </niobject>
 
@@ -6207,7 +6207,7 @@
    <niobject name="BSShaderTextureSet" inherit="NiObject" module="BSMain" versions="#BETHESDA#">
         Bethesda-specific Texture Set.
         <field name="Num Textures" type="uint" default="6" />
-        <field name="Textures" type="SizedString" arr1="Num Textures">Textures.
+        <field name="Textures" type="SizedString" length="Num Textures">Textures.
             0: Diffuse
             1: Normal/Gloss
             2: Glow(SLSF2_Glow_Map)/Skin/Hair/Rim light(SLSF2_Rim_Lighting)
@@ -6414,7 +6414,7 @@
 
     <struct name="BSTextureArray" versions="#F76#">
         <field name="Texture Array Width" type="uint" />
-        <field name="Texture Array" type="SizedString" arr1="Texture Array Width" />
+        <field name="Texture Array" type="SizedString" length="Texture Array Width" />
     </struct>
 
     <enum name="BSShaderCRC32" storage="uint" prefix="SF" versions="#F76#">
@@ -6486,8 +6486,8 @@
         <field name="Shader Type" type="BSLightingShaderType155" vercond="#BS_F76#" />
         <field name="Num SF1" type="uint" vercond="#BS_F76#" />
         <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" arr1="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" arr1="Num SF2" vercond="#BS_F76#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
         <field name="UV Offset" type="TexCoord">Offset UVs</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures, see above.</field>
         <field name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</field>
@@ -6514,7 +6514,7 @@
         <field name="Translucency" type="BSSPTranslucencyParams" vercond="#BS_F76#" cond="Do Translucency" />
         <field name="Has Texture Arrays" type="byte" vercond="#BS_F76#" />
         <field name="Num Texture Arrays" type="uint" vercond="#BS_F76#" cond="Has Texture Arrays" />
-        <field name="Texture Arrays" type="BSTextureArray" arr1="Num Texture Arrays" vercond="#BS_F76#" cond="Has Texture Arrays" />
+        <field name="Texture Arrays" type="BSTextureArray" length="Num Texture Arrays" vercond="#BS_F76#" cond="Has Texture Arrays" />
         <field name="Environment Map Scale" type="float" default="1.0" range="#F0_10#" cond="Shader Type == 1" vercond="#NI_BS_LTE_FO4#">Scales the intensity of the environment/cube map.</field>
         <field name="Use Screen Space Reflections" type="bool" cond="Shader Type == 1" vercond="#BS_FO4#" />
         <field name="Wetness Control: Use SSR" type="bool" cond="Shader Type == 1" vercond="#BS_FO4#" />
@@ -6543,8 +6543,8 @@
         <field name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" default="0x20" vercond="#BS_FO4#" />
         <field name="Num SF1" type="uint" vercond="#BS_F76#" />
         <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" arr1="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" arr1="Num SF2" vercond="#BS_F76#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
         <field name="UV Offset" type="TexCoord">Offset UVs</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures</field>
         <field name="Source Texture"  type="SizedString">points to an external texture.</field>
@@ -6597,8 +6597,8 @@
         <field name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" default="0x21" vercond="!#BS_F76#" />
         <field name="Num SF1" type="uint" vercond="#BS_F76#" />
         <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" arr1="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" arr1="Num SF2" vercond="#BS_F76#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
         <field name="UV Offset" type="TexCoord">Offset UVs. Seems to be unused, but it fits with the other Skyrim shader properties.</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures, see above.</field>
         <field name="Water Shader Flags" type="WaterShaderPropertyFlags" default="0xC4" />
@@ -6610,8 +6610,8 @@
         <field name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" default="0x21" vercond="!#BS_F76#" />
         <field name="Num SF1" type="uint" vercond="#BS_F76#" />
         <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" arr1="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" arr1="Num SF2" vercond="#BS_F76#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
         <field name="UV Offset" type="TexCoord">Offset UVs. Seems to be unused, but it fits with the other Skyrim shader properties.</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures, see above.</field>
         <field name="Source Texture" type="SizedString">points to an external texture.</field>
@@ -6621,13 +6621,13 @@
     <niobject name="BSDismemberSkinInstance" inherit="NiSkinInstance" module="BSMain" versions="#BETHESDA#">
         Bethesda-specific skin instance.
         <field name="Num Partitions" type="uint" default="1" />
-        <field name="Partitions" type="BodyPartList" arr1="Num Partitions" />
+        <field name="Partitions" type="BodyPartList" length="Num Partitions" />
     </niobject>
 
     <niobject name="BSDecalPlacementVectorExtraData" inherit="NiFloatExtraData" module="BSMain" versions="#FO3_AND_LATER#">
         Bethesda-specific extra data. Lists locations and normals on a mesh that are appropriate for decal placement.
         <field name="Num Vector Blocks" type="ushort" />
-        <field name="Vector Blocks" type="DecalVectorArray" arr1="Num Vector Blocks" />
+        <field name="Vector Blocks" type="DecalVectorArray" length="Num Vector Blocks" />
     </niobject>
 
     <niobject name="BSPSysSimpleColorModifier" inherit="NiPSysModifier" module="BSParticle" versions="#FO3_AND_LATER#">
@@ -6638,8 +6638,8 @@
         <field name="Color 1 Start Percent" type="float" range="#F0_1#" />
         <field name="Color 2 End Percent" type="float" range="#F0_1#" />
         <field name="Color 2 Start Percent" type="float" default="1.0" range="#F0_1#" />
-        <field name="Colors" type="Color4" arr1="3" />
-        <field name="Unknown Shorts" type="ushort" arr1="26" vercond="#BS_F76#" />
+        <field name="Colors" type="Color4" length="3" />
+        <field name="Unknown Shorts" type="ushort" length="26" vercond="#BS_F76#" />
     </niobject>
 
 
@@ -6686,7 +6686,7 @@
         Bethesda-Specific particle system.
         <field name="Max Emitter Objects" type="ushort" default="20" />
         <field name="Num Particle Systems" type="uint" />
-        <field name="Particle Systems" type="Ref" template="NiAVObject" arr1="Num Particle Systems" />
+        <field name="Particle Systems" type="Ref" template="NiAVObject" length="Num Particle Systems" />
 
     </niobject>
 
@@ -6743,7 +6743,7 @@
         
         Shapes collected in a bhkConvexListShape may not have the correct material noise.
         <field name="Num Sub Shapes" type="uint" default="1" range="1:255" />
-        <field name="Sub Shapes" type="Ref" template="bhkConvexShapeBase" arr1="Num Sub Shapes">List of shapes. Max of 255.</field>
+        <field name="Sub Shapes" type="Ref" template="bhkConvexShapeBase" length="Num Sub Shapes">List of shapes. Max of 255.</field>
         <field name="Material" type="HavokMaterial">The material of the shape.</field>
         <field name="Radius" type="float" />
         <field name="Unknown Int 1" type="uint" />
@@ -6763,7 +6763,7 @@
     <niobject name="BSTreadTransfInterpolator" inherit="NiInterpolator" module="BSAnimation" versions="#FO3_AND_LATER#">
         Bethesda-specific interpolator.
         <field name="Num Tread Transforms" type="uint" />
-        <field name="Tread Transforms" type="BSTreadTransform" arr1="Num Tread Transforms" />
+        <field name="Tread Transforms" type="BSTreadTransform" length="Num Tread Transforms" />
         <field name="Data" type="Ref" template="NiFloatData" />
     </niobject>
 
@@ -6786,12 +6786,12 @@
     <niobject name="BSAnimNotes" inherit="NiObject" module="BSAnimation" versions="#FO3_AND_LATER#">
         Bethesda-specific object.
         <field name="Num Anim Notes" type="ushort">Number of BSAnimNote objects.</field>
-        <field name="Anim Notes" type="Ref" template="BSAnimNote" arr1="Num Anim Notes">BSAnimNote objects.</field>
+        <field name="Anim Notes" type="Ref" template="BSAnimNote" length="Num Anim Notes">BSAnimNote objects.</field>
     </niobject>
 
     <niobject name="bhkLiquidAction" inherit="bhkAction" module="BSHavok" versions="#FO3_AND_LATER#">
         Bethesda custom bhkUnaryAction. Does not hold a link to the body like other bhkUnaryActions however.
-        <field name="Unused 01" type="byte" arr1="12" binary="true" />
+        <field name="Unused 01" type="byte" length="12" binary="true" />
         <field name="Initial Stick Force" type="float" default="25.0" />
         <field name="Stick Strength" type="float" default="100.0" />
         <field name="Neighbor Distance" type="float" default="128.0" />
@@ -6850,13 +6850,13 @@
         <field name="Num Primitives" type="uint">The number of triangles belonging to this segment</field>
         <field name="Parent Array Index" type="uint" vercond="#BS_GTE_FO4#" />
         <field name="Num Sub Segments" type="uint" vercond="#BS_GTE_FO4#" />
-        <field name="Sub Segment" type="BSGeometrySubSegment" arr1="Num Sub Segments" vercond="#BS_GTE_FO4#" />
+        <field name="Sub Segment" type="BSGeometrySubSegment" length="Num Sub Segments" vercond="#BS_GTE_FO4#" />
     </struct>
 
     <niobject name="BSSegmentedTriShape" inherit="NiTriShape" module="BSMain" versions="#FO3_AND_LATER#">
         Bethesda-specific AV object.
         <field name="Num Segments" type="uint" default="16">Number of segments in the square grid</field>
-        <field name="Segment" type="BSGeometrySegmentData" arr1="Num Segments">Configuration of each segment</field>
+        <field name="Segment" type="BSGeometrySegmentData" length="Num Segments">Configuration of each segment</field>
     </niobject>
 
     <niobject name="BSMultiBoundAABB" inherit="BSMultiBoundData" module="BSMain" versions="#FO3_AND_LATER#">
@@ -6878,10 +6878,10 @@
     <struct name="NiAGDDataBlock">
         <field name="Block Size" type="uint" />
         <field name="Num Blocks" type="uint" />
-        <field name="Block Offsets" type="uint" arr1="Num Blocks" />
+        <field name="Block Offsets" type="uint" length="Num Blocks" />
         <field name="Num Data" type="uint" />
-        <field name="Data Sizes" type="uint" arr1="Num Data" />
-        <field name="Data" type="byte" arr1="Num Data" arr2="Block Size" />
+        <field name="Data Sizes" type="uint" length="Num Data" />
+        <field name="Data" type="byte" length="Num Data" width="Block Size" />
         <!-- NiBSPackedAGDDataBlock -->
         <field name="Shader Index" type="uint" cond="#ARG# == 1" />
         <field name="Total Size" type="uint" cond="#ARG# == 1" />
@@ -6895,24 +6895,24 @@
     <niobject name="NiAdditionalGeometryData" inherit="AbstractAdditionalGeometryData" module="NiMain">
         <field name="Num Vertices" type="ushort" />
         <field name="Num Block Infos" type="uint" />
-        <field name="Block Infos" type="NiAGDDataStream" arr1="Num Block Infos" />
+        <field name="Block Infos" type="NiAGDDataStream" length="Num Block Infos" />
         <field name="Num Blocks" type="uint" />
-        <field name="Blocks" type="NiAGDDataBlocks" arg="0" arr1="Num Blocks" />
+        <field name="Blocks" type="NiAGDDataBlocks" arg="0" length="Num Blocks" />
     </niobject>
 
     <niobject name="BSPackedAdditionalGeometryData" inherit="AbstractAdditionalGeometryData" module="BSMain" versions="#BETHESDA#">
         No longer appears to occur in any vanilla files. Older versions of FNV had the block in nvdlc01vaultposter01.nif.
         <field name="Num Vertices" type="ushort" />
         <field name="Num Block Infos" type="uint" />
-        <field name="Block Infos" type="NiAGDDataStream" arr1="Num Block Infos" />
+        <field name="Block Infos" type="NiAGDDataStream" length="Num Block Infos" />
         <field name="Num Blocks" type="uint">Usually there is exactly one block.</field>
-        <field name="Blocks" type="NiAGDDataBlocks" arg="1" arr1="Num Blocks" />
+        <field name="Blocks" type="NiAGDDataBlocks" arg="1" length="Num Blocks" />
     </niobject>
 
     <niobject name="BSWArray" inherit="NiExtraData" module="BSMain" versions="#FO3_AND_LATER#">
         Bethesda-specific extra data.
         <field name="Num Items" type="uint" />
-        <field name="Items" type="int" arr1="Num Items" />
+        <field name="Items" type="int" length="Num Items" />
     </niobject>
 
     <niobject name="BSFrustumFOVController" inherit="NiFloatInterpController" module="BSAnimation" versions="#BETHESDA#">
@@ -6933,12 +6933,12 @@
 
     <niobject name="bhkOrientHingedBodyAction" inherit="bhkUnaryAction" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpReorientAction (or similar). Will try to reorient a body to stay facing a given direction.
-        <field name="Unused 02" type="byte" arr1="8" binary="true" />
+        <field name="Unused 02" type="byte" length="8" binary="true" />
         <field name="Hinge Axis LS" type="Vector4" default="#X_AXIS#" />
         <field name="Forward LS" type="Vector4" default="#Y_AXIS#" />
         <field name="Strength" type="float" default="1.0" />
         <field name="Damping" type="float" default="0.1" />
-        <field name="Unused 03" type="byte" arr1="8" binary="true" />
+        <field name="Unused 03" type="byte" length="8" binary="true" />
     </niobject>
 
     <niobject name="bhkPoseArray" inherit="NiObject" module="BSHavok" versions="#FO3_AND_LATER#">
@@ -6946,15 +6946,15 @@
         Defines different kill poses. The game selects the pose randomly and applies it to a skeleton immediately upon ragdolling.
         Poses can be previewed in GECK Object Window-Actor Data-Ragdoll and selecting Pose Matching tab.
         <field name="Num Bones" type="uint" />
-        <field name="Bones" type="NiFixedString" arr1="Num Bones" />
+        <field name="Bones" type="NiFixedString" length="Num Bones" />
         <field name="Num Poses" type="uint" />
-        <field name="Poses" type="BonePose" arr1="Num Poses" />
+        <field name="Poses" type="BonePose" length="Num Poses" />
     </niobject>
 
     <niobject name="bhkRagdollTemplate" inherit="NiExtraData" module="BSHavok" versions="#FO3_AND_LATER#">
         Found in Fallout 3, more ragdoll info?  (meshes\ragdollconstraint\*.rdt)
         <field name="Num Bones" type="uint" />
-        <field name="Bones" type="Ref" template="NiObject" arr1="Num Bones" />
+        <field name="Bones" type="Ref" template="NiObject" length="Num Bones" />
     </niobject>
 
     <niobject name="bhkRagdollTemplateData" inherit="NiObject" module="BSHavok" versions="#FO3_AND_LATER#">
@@ -6966,7 +6966,7 @@
         <field name="Radius" type="float" default="1.0" />
         <field name="Material" type="HavokMaterial" />
         <field name="Num Constraints" type="uint" />
-        <field name="Constraint" type="bhkWrappedConstraintData" arr1="Num Constraints" />
+        <field name="Constraint" type="bhkWrappedConstraintData" length="Num Constraints" />
     </niobject>
 
     <struct name="Region" size="8" since="V20_5_0_0">
@@ -7075,10 +7075,10 @@
         <field name="Num Bytes" type="uint">The size in bytes of this data stream.</field>
         <field name="Cloning Behavior" type="CloningBehavior" default="CLONING_SHARE" />
         <field name="Num Regions" type="uint">Number of regions (such as submeshes).</field>
-        <field name="Regions" type="Region" arr1="Num Regions">The regions in the mesh. Regions can be used to mark off submeshes which are independent draw calls.</field>
+        <field name="Regions" type="Region" length="Num Regions">The regions in the mesh. Regions can be used to mark off submeshes which are independent draw calls.</field>
         <field name="Num Components" type="uint">Number of components of the data (matches corresponding field in MeshData).</field>
-        <field name="Component Formats" type="ComponentFormat" arr1="Num Components">The format of each component in this data stream.</field>
-        <field name="Data" type="byte" binary="true" arr1="Num Bytes" />
+        <field name="Component Formats" type="ComponentFormat" length="Num Components">The format of each component in this data stream.</field>
+        <field name="Data" type="byte" binary="true" length="Num Bytes" />
         <field name="Streamable" type="bool" default="1" />
     </niobject>
 
@@ -7099,9 +7099,9 @@
         <field name="Stream" type="Ref" template="NiDataStream">Reference to a data stream object which holds the data used by this reference.</field>
         <field name="Is Per Instance" type="bool" default="0">Sets whether this stream data is per-instance data for use in hardware instancing.</field>
         <field name="Num Submeshes" type="ushort" default="1">The number of submesh-to-region mappings that this data stream has.</field>
-        <field name="Submesh To Region Map" type="ushort" arr1="Num Submeshes">A lookup table that maps submeshes to regions.</field>
+        <field name="Submesh To Region Map" type="ushort" length="Num Submeshes">A lookup table that maps submeshes to regions.</field>
         <field name="Num Components" type="uint" default="1" />
-        <field name="Component Semantics" type="SemanticData" arr1="Num Components">Describes the semantic of each component.</field>
+        <field name="Component Semantics" type="SemanticData" length="Num Components">Describes the semantic of each component.</field>
     </struct>
 
     <niobject name="NiRenderObject" abstract="true" inherit="NiAVObject" module="NiMain" since="V20_5_0_0">
@@ -7134,9 +7134,9 @@
     <niobject name="NiMeshModifier" abstract="true" inherit="NiObject" module="NiMesh">
         Base class for mesh modifiers.
         <field name="Num Submit Points" type="uint" />
-        <field name="Submit Points" type="SyncPoint" arr1="Num Submit Points">The sync points supported by this mesh modifier for SubmitTasks.</field>
+        <field name="Submit Points" type="SyncPoint" length="Num Submit Points">The sync points supported by this mesh modifier for SubmitTasks.</field>
         <field name="Num Complete Points" type="uint" />
-        <field name="Complete Points" type="SyncPoint" arr1="Num Complete Points">The sync points supported by this mesh modifier for CompleteTasks.</field>
+        <field name="Complete Points" type="SyncPoint" length="Num Complete Points">The sync points supported by this mesh modifier for CompleteTasks.</field>
     </niobject>
 
     <struct name="MeshDataEpicMickey" versions="V20_6_5_0_DEM">
@@ -7149,33 +7149,33 @@
     </struct>
 
     <struct name="WeightDataEpicMickey" size="24" versions="V20_6_5_0_DEM">
-        <field name="Bone Indices" type="int" arr1="3" />
-        <field name="Weights" type="float" arr1="3" />
+        <field name="Bone Indices" type="int" length="3" />
+        <field name="Weights" type="float" length="3" />
     </struct>
 
     <struct name="PartitionDataEpicMickey" size="28" versions="V20_6_5_0_DEM">
         <field name="Start" type="int" />
         <field name="End" type="int" />
-        <field name="Weight Indices" type="ushort" arr1="10" />
+        <field name="Weight Indices" type="ushort" length="10" />
     </struct>
 
     <struct name="ExtraMeshDataEpicMickey" versions="V20_6_5_0_DEM">
         <field name="Unknown 1" type="uint" />
         <field name="Num Unknown Floats" type="uint" />
-        <field name="Unknown Floats 1" type="float" arr1="Num Unknown Floats" />
+        <field name="Unknown Floats 1" type="float" length="Num Unknown Floats" />
         <field name="Num Weights" type="uint" />
-        <field name="Weights" type="WeightDataEpicMickey" arr1="Num Weights" />
+        <field name="Weights" type="WeightDataEpicMickey" length="Num Weights" />
         <field name="Vertex to Weight Map Size" type="uint" />
-        <field name="Vertex to Weight Map" type="uint" arr1="Vertex to Weight Map Size" />
+        <field name="Vertex to Weight Map" type="uint" length="Vertex to Weight Map Size" />
         <field name="Unknown Data Size" type="uint" />
         <field name="Unknown Data Width" type="uint" />
-        <field name="Unknown Data" type="Vector3" arr1="Unknown Data Size" arr2="Unknown Data Width" />
-        <field name="Unknown Indices" type="ushort" arr1="Unknown Data Size" />
+        <field name="Unknown Data" type="Vector3" length="Unknown Data Size" width="Unknown Data Width" />
+        <field name="Unknown Indices" type="ushort" length="Unknown Data Size" />
         <field name="Num Mapped Primitives" type="ushort" vercond="#USER# #LT# 17">When non-zero, equal to the number of primitives.</field>
         <field name="Num Mapped Primitives" type="uint" vercond="#USER# == 17">When non-zero, equal to the number of primitives.</field>
-        <field name="Mapped Primitives" type="byte" arr1="Num Mapped Primitives">Some integer associated with each primitive.</field>
+        <field name="Mapped Primitives" type="byte" length="Num Mapped Primitives">Some integer associated with each primitive.</field>
         <field name="Partition Size" type="uint" />
-        <field name="Partitions" type="PartitionDataEpicMickey" arr1="Partition Size" />
+        <field name="Partitions" type="PartitionDataEpicMickey" length="Partition Size" />
         <field name="Max Primitive Map Index" type="uint">The max value to appear in the Mapped Primitives array.</field>
     </struct>
 
@@ -7186,9 +7186,9 @@
         <field name="Instancing Enabled" type="bool">Sets whether hardware instancing is being used.</field>
         <field name="Bounding Sphere" type="NiBound">The combined bounding volume of all submeshes.</field>
         <field name="Num Datastreams" type="uint" />
-        <field name="Datastreams" type="DataStreamRef" arr1="Num Datastreams" />
+        <field name="Datastreams" type="DataStreamRef" length="Num Datastreams" />
         <field name="Num Modifiers" type="uint" />
-        <field name="Modifiers" type="Ref" template="NiMeshModifier" arr1="Num Modifiers" />
+        <field name="Modifiers" type="Ref" template="NiMeshModifier" length="Num Modifiers" />
         <field name="Has Extra EM Data" type="bool" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 9" />
         <field name="Extra EM Data" type="ExtraMeshDataEpicMickey" cond="Has Extra EM Data" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 9" />
     </niobject>
@@ -7197,9 +7197,9 @@
         Manipulates a mesh with the semantic MORPHWEIGHTS using an NiMorphMeshModifier.
         <field name="Count" type="uint" />
         <field name="Num Interpolators" type="uint" />
-        <field name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" />
+        <field name="Interpolators" type="Ref" template="NiInterpolator" length="Num Interpolators" />
         <field name="Num Targets" type="uint" />
-        <field name="Target Names" type="NiFixedString" arr1="Num Targets" />
+        <field name="Target Names" type="NiFixedString" length="Num Targets" />
     </niobject>
 
     <struct name="ElementReference" size="12" since="V20_5_0_0">
@@ -7220,7 +7220,7 @@
         </field>
         <field name="Num Targets" type="ushort">The number of morph targets.</field>
         <field name="Num Elements" type="uint">The number of morphing data stream elements.</field>
-        <field name="Elements" type="ElementReference" arr1="Num Elements">Semantics and normalization of the morphing data stream elements.</field>
+        <field name="Elements" type="ElementReference" length="Num Elements">Semantics and normalization of the morphing data stream elements.</field>
     </niobject>
 
     <niobject name="NiSkinningMeshModifier" inherit="NiMeshModifier" module="NiMesh" since="V20_5_0_0">
@@ -7231,9 +7231,9 @@
         <field name="Skeleton Root" type="Ptr" template="NiAVObject">The root bone of the skeleton.</field>
         <field name="Skeleton Transform" type="NiTransform">The transform that takes the root bone parent coordinate system into the skin coordinate system.</field>
         <field name="Num Bones" type="uint">The number of bones referenced by this mesh modifier.</field>
-        <field name="Bones" type="Ptr" template="NiAVObject" arr1="Num Bones">Pointers to the bone nodes that affect this skin.</field>
-        <field name="Bone Transforms" type="NiTransform" arr1="Num Bones">The transforms that go from bind-pose space to bone space.</field>
-        <field name="Bone Bounds" type="NiBound" cond="Flags #BITAND# 2" arr1="Num Bones">The bounds of the bones.  Only stored if the RECOMPUTE_BOUNDS bit is set.</field>
+        <field name="Bones" type="Ptr" template="NiAVObject" length="Num Bones">Pointers to the bone nodes that affect this skin.</field>
+        <field name="Bone Transforms" type="NiTransform" length="Num Bones">The transforms that go from bind-pose space to bone space.</field>
+        <field name="Bone Bounds" type="NiBound" cond="Flags #BITAND# 2" length="Num Bones">The bounds of the bones.  Only stored if the RECOMPUTE_BOUNDS bit is set.</field>
     </niobject>
 
     <niobject name="NiMeshHWInstance" inherit="NiAVObject" module="NiMesh" since="V20_5_0_0">
@@ -7250,24 +7250,24 @@
         <field name="Affected Mesh" type="Ref" template="NiMesh" />
         <field name="Bounding Sphere" type="NiBound" cond="Has Static Bounds" />
         <field name="Num Instance Nodes" type="uint" cond="Has Instance Nodes" />
-        <field name="Instance Nodes" type="Ref" template="NiMeshHWInstance" arr1="Num Instance Nodes" cond="Has Instance Nodes" />
+        <field name="Instance Nodes" type="Ref" template="NiMeshHWInstance" length="Num Instance Nodes" cond="Has Instance Nodes" />
     </niobject>
 
     <struct name="LODInfo">
         <field name="Num Bones" type="uint" />
         <field name="Num Active Skins" type="uint" />
-        <field name="Skin Indices" type="uint" arr1="Num Active Skins" />
+        <field name="Skin Indices" type="uint" length="Num Active Skins" />
     </struct>
 
     <niobject name="NiSkinningLODController" inherit="NiTimeController" module="NiAnimation" since="V20_5_0_0">
         Defines the levels of detail for a given character and dictates the character's current LOD.
         <field name="Current LOD" type="uint" />
         <field name="Num Bones" type="uint" />
-        <field name="Bones" type="Ref" template="NiNode" arr1="Num Bones" />
+        <field name="Bones" type="Ref" template="NiNode" length="Num Bones" />
         <field name="Num Skins" type="uint" />
-        <field name="Skins" type="Ref" template="NiMesh" arr1="Num Skins" />
+        <field name="Skins" type="Ref" template="NiMesh" length="Num Skins" />
         <field name="Num LOD Levels" type="uint" />
-        <field name="LODs" type="LODInfo" arr1="Num LOD Levels" />
+        <field name="LODs" type="LODInfo" length="Num LOD Levels" />
     </niobject>
 
 
@@ -7293,9 +7293,9 @@
         <field name="Simulator" type="Ref" template="NiPSSimulator" />
         <field name="Generator" type="Ref" template="NiPSBoundUpdater" />
         <field name="Num Emitters" type="uint" />
-        <field name="Emitters" type="Ref" template="NiPSEmitter" arr1="Num Emitters" />
+        <field name="Emitters" type="Ref" template="NiPSEmitter" length="Num Emitters" />
         <field name="Num Spawners" type="uint" />
-        <field name="Spawners" type="Ref" template="NiPSSpawner" arr1="Num Spawners" />
+        <field name="Spawners" type="Ref" template="NiPSSpawner" length="Num Spawners" />
         <field name="Death Spawner" type="Ref" template="NiPSSpawner" />
         <field name="Max Num Particles" type="uint" />
         <field name="Has Colors" type="bool" />
@@ -7309,7 +7309,7 @@
         <field name="Up Direction" type="Vector3" since="20.6.1.0" />
         <field name="Living Spawner" type="Ref" template="NiPSSpawner" since="20.6.1.0" />
         <field name="Num Spawn Rate Keys" type="byte" since="20.6.1.0" />
-        <field name="Spawn Rate Keys" type="PSSpawnRateKey" arr1="Num Spawn Rate Keys" since="20.6.1.0" />
+        <field name="Spawn Rate Keys" type="PSSpawnRateKey" length="Num Spawn Rate Keys" since="20.6.1.0" />
         <field name="Pre RPI" type="bool" since="20.6.1.0" />
         <field name="DEM Unknown Int" type="uint" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
         <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
@@ -7318,7 +7318,7 @@
     <niobject name="NiPSMeshParticleSystem" inherit="NiPSParticleSystem" module="NiPSParticle" since="V20_5_0_0">
         Represents a particle system that uses mesh particles instead of sprite-based particles.
         <field name="Num Generations" type="uint" />
-        <field name="Master Particles" type="Ref" template="NiAVObject" arr1="Num Generations" />
+        <field name="Master Particles" type="Ref" template="NiAVObject" length="Num Generations" />
         <field name="Pool Size" type="uint" />
         <field name="Auto Fill Pools" type="bool" />
     </niobject>
@@ -7356,7 +7356,7 @@
     <niobject name="NiPSSimulator" inherit="NiMeshModifier" module="NiPSParticle" since="V20_5_0_0">
         The mesh modifier that performs all particle system simulation.
         <field name="Num Simulation Steps" type="uint" />
-        <field name="Simulation Steps" type="Ref" template="NiPSSimulatorStep" arr1="Num Simulation Steps" />
+        <field name="Simulation Steps" type="Ref" template="NiPSSimulatorStep" length="Num Simulation Steps" />
     </niobject>
 
     <niobject name="NiPSSimulatorStep" abstract="true" inherit="NiObject" module="NiPSParticle" since="V20_5_0_0">
@@ -7374,13 +7374,13 @@
     <niobject name="NiPSSimulatorGeneralStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
         Encapsulates a floodgate kernel that updates particle size, colors, and rotations.
         <field name="Num Size Keys" type="byte" since="20.6.1.0" />
-        <field name="Size Keys" type="Key" template="float" arg="1" arr1="Num Size Keys" since="20.6.1.0">The particle size keys.</field>
+        <field name="Size Keys" type="Key" template="float" arg="1" length="Num Size Keys" since="20.6.1.0">The particle size keys.</field>
         <field name="Size Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" since="20.6.1.0">The loop behavior for the size keys.</field>
         <field name="Num Color Keys" type="byte" />
-        <field name="Color Keys" type="Key" template="ByteColor4" arg="1" arr1="Num Color Keys">The particle color keys.</field>
+        <field name="Color Keys" type="Key" template="ByteColor4" arg="1" length="Num Color Keys">The particle color keys.</field>
         <field name="Color Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" since="20.6.1.0">The loop behavior for the color keys.</field>
         <field name="Num Rotation Keys" type="byte" since="20.6.1.0" />
-        <field name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys" since="20.6.1.0">The particle rotation keys.</field>
+        <field name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" length="Num Rotation Keys" since="20.6.1.0">The particle rotation keys.</field>
         <field name="Rotation Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" since="20.6.1.0">The loop behavior for the rotation keys.</field>
         <field name="Grow Time" type="float"> The the amount of time over which a particle's size is ramped from 0.0 to 1.0 in seconds</field>
         <field name="Shrink Time" type="float">The the amount of time over which a particle's size is ramped from 1.0 to 0.0 in seconds</field>
@@ -7392,19 +7392,19 @@
     <niobject name="NiPSSimulatorForcesStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
         Encapsulates a floodgate kernel that simulates particle forces.
         <field name="Num Forces" type="uint" />
-        <field name="Forces" type="Ref" template="NiPSForce" arr1="Num Forces">The forces affecting the particle system.</field>
+        <field name="Forces" type="Ref" template="NiPSForce" length="Num Forces">The forces affecting the particle system.</field>
     </niobject>
 
     <niobject name="NiPSSimulatorCollidersStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
         Encapsulates a floodgate kernel that simulates particle colliders.
         <field name="Num Colliders" type="uint" />
-        <field name="Colliders" type="Ref" template="NiPSCollider" arr1="Num Colliders">The colliders affecting the particle system.</field>
+        <field name="Colliders" type="Ref" template="NiPSCollider" length="Num Colliders">The colliders affecting the particle system.</field>
     </niobject>
 
     <niobject name="NiPSSimulatorMeshAlignStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
         Encapsulates a floodgate kernel that updates mesh particle alignment and transforms.
         <field name="Num Rotation Keys" type="byte" />
-        <field name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys">The particle rotation keys.</field>
+        <field name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" length="Num Rotation Keys">The particle rotation keys.</field>
         <field name="Rotation Loop Behavior" type="PSLoopBehavior">The loop behavior for the rotation keys.</field>
     </niobject>
 
@@ -7587,7 +7587,7 @@
     <niobject name="NiPSMeshEmitter" inherit="NiPSEmitter" module="NiPSParticle" since="V20_5_0_0">
         Emits particles from one or more NiMesh objects. A random mesh emitter is selected for each particle emission.
         <field name="Num Mesh Emitters" type="uint" />
-        <field name="Mesh Emitters" type="Ptr" template="NiMesh" arr1="Num Mesh Emitters" />
+        <field name="Mesh Emitters" type="Ptr" template="NiMesh" length="Num Mesh Emitters" />
         <field name="Emit Axis" type="Vector3" until="20.6.0.0" />
         <field name="Emitter Object" type="Ptr" template="NiAVObject" since="20.6.1.0" />
         <field name="Mesh Emission Type" type="EmitFrom" />
@@ -7764,7 +7764,7 @@
     <niobject name="NiPhysXPSParticleSystemProp" inherit="NiPhysXProp" module="NiPhysX" since="V20_5_0_0">
         A PhysX prop which holds information about a PhysX particle system prop.
         <field name="Num Systems" type="uint" />
-        <field name="Systems" type="Ptr" template="NiPhysXPSParticleSystem" arr1="Num Systems" />
+        <field name="Systems" type="Ptr" template="NiPhysXPSParticleSystem" length="Num Systems" />
     </niobject>
 
     <niobject name="NiPhysXPSParticleSystemDest" inherit="NiPhysXDest" module="NiPhysX" since="V20_5_0_0">
@@ -7792,7 +7792,7 @@
         <field name="Controller Type" type="NiFixedString">The RTTI type of the NiTimeController.</field>
         <field name="Controller ID" type="NiFixedString">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
         <field name="Interpolator ID" type="NiFixedString">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
-        <field name="Channel Types" type="byte" arr1="4">
+        <field name="Channel Types" type="byte" length="4">
             Channel Indices are BASE/POS = 0, ROT = 1, SCALE = 2, FLAG = 3
             Channel Types are:
              INVALID = 0, COLOR, BOOL, FLOAT, POINT3, ROT = 5
@@ -7932,9 +7932,9 @@
         <field name="Name" type="NiFixedString" />
         <field name="Num Controlled Blocks" type="uint" until="20.5.0.1" />
         <field name="Array Grow By" type="uint" until="20.5.0.1" />
-        <field name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" until="20.5.0.1" />
+        <field name="Controlled Blocks" type="ControlledBlock" length="Num Controlled Blocks" until="20.5.0.1" />
         <field name="Num Evaluators" type="uint" since="20.5.0.2" />
-        <field name="Evaluators" type="Ref" template="NiEvaluator" arr1="Num Evaluators" since="20.5.0.2" />
+        <field name="Evaluators" type="Ref" template="NiEvaluator" length="Num Evaluators" since="20.5.0.2" />
         <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" />
         <field name="Duration" type="float" />
         <field name="Cycle Type" type="CycleType" />
@@ -7965,9 +7965,9 @@
         <field name="Name" type="string" default="NiStandardShadowTechnique" />
         <field name="Flags" type="NiShadowGeneratorFlags" default="0x3DB" />
         <field name="Num Shadow Casters" type="uint" />
-        <field name="Shadow Casters" type="Ref" template="NiNode" arr1="Num Shadow Casters" />
+        <field name="Shadow Casters" type="Ref" template="NiNode" length="Num Shadow Casters" />
         <field name="Num Shadow Receivers" type="uint" />
-        <field name="Shadow Receivers" type="Ref" template="NiNode" arr1="Num Shadow Receivers" />
+        <field name="Shadow Receivers" type="Ref" template="NiNode" length="Num Shadow Receivers" />
         <field name="Target" type="Ptr" template="NiDynamicEffect" />
         <field name="Depth Bias" type="float" />
         <field name="Size Hint" type="ushort" default="1024" />
@@ -7982,9 +7982,9 @@
         <field name="Unknown Float" type="float"></field>
         <field name="Unknown Float 2" type="float"></field>
         <field name="Num Bones" type="uint">The number of node bones referenced as influences.</field>
-        <field name="Bones" type="Ptr" template="NiNode" arr1="Num Bones">List of all armature bones.</field>
+        <field name="Bones" type="Ptr" template="NiNode" length="Num Bones">List of all armature bones.</field>
         <field name="Num Bones 2" type="uint">The number of node bones referenced as influences.</field>
-        <field name="Bones 2" type="Ptr" template="NiNode" arr1="Num Bones 2">List of all armature bones.</field>
+        <field name="Bones 2" type="Ptr" template="NiNode" length="Num Bones 2">List of all armature bones.</field>
     </niobject>
 
     <niobject name="CStreamableAssetData" inherit="NiObject" module="NiCustom" versions="V20_3_0_9 V20_3_0_9_DIV2">
@@ -7993,7 +7993,7 @@
         <field name="Has Data" type="bool" />
         <field name="Data" type="ByteArray" cond="Has Data" />
         <field name="Num Refs" type="uint" />
-        <field name="Refs" type="Ref" template="NiObject" arr1="Num Refs" />
+        <field name="Refs" type="Ref" template="NiObject" length="Num Refs" />
     </niobject>
 
     <niobject name="bhkCompressedMeshShape" inherit="bhkShape" module="BSHavok" versions="#SKY_AND_LATER#">
@@ -8035,22 +8035,22 @@
 		<field name="Welding Type" type="hkWeldingType" default="ANTICLOCKWISE" />
 		<field name="Material Type" type="bhkCMSMatType" default="SINGLE_VALUE_PER_CHUNK" />
 		<field name="Num Materials 32" type="uint" />
-		<field name="Materials 32" type="uint" arr1="Num Materials 32">Unused.</field>
+		<field name="Materials 32" type="uint" length="Num Materials 32">Unused.</field>
 		<field name="Num Materials 16" type="uint" />
-		<field name="Materials 16" type="uint" arr1="Num Materials 16">Unused.</field>
+		<field name="Materials 16" type="uint" length="Num Materials 16">Unused.</field>
 		<field name="Num Materials 8" type="uint" />
-		<field name="Materials 8" type="uint" arr1="Num Materials 8">Unused.</field>
+		<field name="Materials 8" type="uint" length="Num Materials 8">Unused.</field>
 		<field name="Num Materials" type="uint" default="1" />
-		<field name="Chunk Materials" type="bhkMeshMaterial" arr1="Num Materials">Materials used by Chunks. Chunks refer to this table by index.</field>
+		<field name="Chunk Materials" type="bhkMeshMaterial" length="Num Materials">Materials used by Chunks. Chunks refer to this table by index.</field>
 		<field name="Num Named Materials" type="uint">Number of hkpNamedMeshMaterial. Unused.</field>
 		<field name="Num Transforms" type="uint" default="1">Number of chunk transformations</field>
-        <field name="Chunk Transforms" type="bhkQsTransform" arr1="Num Transforms">Transforms used by Chunks. Chunks refer to this table by index.</field>
+        <field name="Chunk Transforms" type="bhkQsTransform" length="Num Transforms">Transforms used by Chunks. Chunks refer to this table by index.</field>
 		<field name="Num Big Verts" type="uint" />
-		<field name="Big Verts" type="Vector4" arr1="Num Big Verts">Vertices paired with Big Tris (triangles that are too large for chunks)</field>
+		<field name="Big Verts" type="Vector4" length="Num Big Verts">Vertices paired with Big Tris (triangles that are too large for chunks)</field>
         <field name="Num Big Tris" type="uint" />
-        <field name="Big Tris" type="bhkCMSBigTri" arr1="Num Big Tris">Triangles that are too large to fit in a chunk.</field>
+        <field name="Big Tris" type="bhkCMSBigTri" length="Num Big Tris">Triangles that are too large to fit in a chunk.</field>
         <field name="Num Chunks" type="uint" default="1" />
-        <field name="Chunks" type="bhkCMSChunk" arr1="Num Chunks" />
+        <field name="Chunks" type="bhkCMSChunk" length="Num Chunks" />
         <field name="Num Convex Piece A" type="uint">Number of hkpCompressedMeshShape::ConvexPiece. Unused.</field>
 	</niobject>
 	
@@ -8071,7 +8071,7 @@
 	<niobject name="BSBoneLODExtraData" inherit="NiExtraData" module="BSMain" versions="#SKY_AND_LATER#">
     Unknown
 		<field name="BoneLOD Count" type="uint" default="3">Number of bone entries</field>
-        <field name="BoneLOD Info" type="BoneLOD" arr1="BoneLOD Count">Bone Entry</field>
+        <field name="BoneLOD Info" type="BoneLOD" length="BoneLOD Count">Bone Entry</field>
 	</niobject>
 	
 	<niobject name="BSBehaviorGraphExtraData" inherit="NiExtraData" module="BSMain" versions="#SKY_AND_LATER#">
@@ -8105,9 +8105,9 @@
     <niobject name="BSTreeNode" inherit="NiNode" module="BSMain" versions="#BETHESDA#">
         Node for handling Trees, Switches branch configurations for variation?
         <field name="Num Bones 1" type="uint" default="1" />
-        <field name="Bones 1" type="Ref" arr1="Num Bones 1" template="NiNode" />
+        <field name="Bones 1" type="Ref" length="Num Bones 1" template="NiNode" />
         <field name="Num Bones 2" type="uint" default="3" />
-        <field name="Bones" type="Ref" arr1="Num Bones 2" template="NiNode" />
+        <field name="Bones" type="Ref" length="Num Bones 2" template="NiNode" />
     </niobject>
     
     
@@ -8116,7 +8116,7 @@
     <niobject name="BSTriShape" inherit="NiAVObject" module="BSMain" versions="#SSE# #FO4# #F76#">
         Fallout 4 Tri Shape
         <field name="Bounding Sphere" type="NiBound" />
-        <field name="Bound Min Max" type="float" arr1="6" vercond="#BS_F76#" />
+        <field name="Bound Min Max" type="float" length="6" vercond="#BS_F76#" />
         <field name="Skin" type="Ref" template="NiObject" />
         <field name="Shader Property" type="Ref" template="BSShaderProperty" />
         <field name="Alpha Property" type="Ref" template="NiAlphaProperty" />
@@ -8125,13 +8125,13 @@
         <field name="Num Triangles" type="ushort" vercond="#NI_BS_LT_FO4#" />
         <field name="Num Vertices" type="ushort" />
         <field name="Data Size" type="uint" calc="((Vertex Desc #BITAND# 0xF) #MUL# Num Vertices #MUL# 4) #ADD# (Num Triangles #MUL# 6)" />
-        <field name="Vertex Data" type="BSVertexData" arr1="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_GTE_FO4#" />
-        <field name="Vertex Data" type="BSVertexDataSSE" arr1="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_SSE#" />
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Data Size #GT# 0" />
+        <field name="Vertex Data" type="BSVertexData" length="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_GTE_FO4#" />
+        <field name="Vertex Data" type="BSVertexDataSSE" length="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_SSE#" />
+        <field name="Triangles" type="Triangle" length="Num Triangles" cond="Data Size #GT# 0" />
         <field name="Particle Data Size" type="uint" calc="(Num Vertices #MUL# 6) #ADD# (Num Triangles #MUL# 3)" vercond="#BS_SSE#" />
-        <field name="Particle Vertices" type="HalfVector3" arr1="Num Vertices" cond="Particle Data Size #GT# 0" vercond="#BS_SSE#" />
-        <field name="Particle Normals" type="HalfVector3" arr1="Num Vertices" cond="Particle Data Size #GT# 0" vercond="#BS_SSE#" />
-        <field name="Particle Triangles" type="Triangle" arr1="Num Triangles" cond="Particle Data Size #GT# 0" vercond="#BS_SSE#" />
+        <field name="Particle Vertices" type="HalfVector3" length="Num Vertices" cond="Particle Data Size #GT# 0" vercond="#BS_SSE#" />
+        <field name="Particle Normals" type="HalfVector3" length="Num Vertices" cond="Particle Data Size #GT# 0" vercond="#BS_SSE#" />
+        <field name="Particle Triangles" type="Triangle" length="Num Triangles" cond="Particle Data Size #GT# 0" vercond="#BS_SSE#" />
     </niobject>
 
     <niobject name="BSMeshLODTriShape" inherit="BSTriShape" module="BSMain" versions="#FO4#">
@@ -8145,14 +8145,14 @@
         <field name="User Index" type="uint">If Bone ID is 0xffffffff, this value refers to the Segment at the listed index. Otherwise this is the "Biped Object", which is like the body part types in Skyrim and earlier.</field>
         <field name="Bone ID" type="uint" default="#UINT_MAX#">A hash of the bone name string.</field>
         <field name="Num Cut Offsets" type="uint" range="0:8">Maximum of 8.</field>
-        <field name="Cut Offsets" type="float" arr1="Num Cut Offsets" />
+        <field name="Cut Offsets" type="float" length="Num Cut Offsets" />
     </struct>
 
     <struct name="BSGeometrySegmentSharedData" versions="#FO4# #F76#">
         <field name="Num Segments" type="uint" />
         <field name="Total Segments" type="uint" />
-        <field name="Segment Starts" type="uint" arr1="Num Segments" />
-        <field name="Per Segment Data" type="BSGeometryPerSegmentSharedData" arr1="Total Segments" />>
+        <field name="Segment Starts" type="uint" length="Num Segments" />
+        <field name="Per Segment Data" type="BSGeometryPerSegmentSharedData" length="Total Segments" />>
         <field name="SSF File" type="SizedString16" />
     </struct>
 
@@ -8161,10 +8161,10 @@
 		<field name="Num Primitives" type="uint" calc="#LEN[Triangles]#" vercond="#BS_GTE_FO4#" cond="Data Size #GT# 0" />
 		<field name="Num Segments" type="uint" vercond="#BS_GTE_FO4#" cond="Data Size #GT# 0" />
 		<field name="Total Segments" type="uint" vercond="#BS_GTE_FO4#" cond="Data Size #GT# 0" />
-		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_GTE_FO4#" arr1="Num Segments" cond="Data Size #GT# 0" />
+		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_GTE_FO4#" length="Num Segments" cond="Data Size #GT# 0" />
 		<field name="Segment Data" type="BSGeometrySegmentSharedData" vercond="#BS_GTE_FO4#" cond="(Num Segments #LT# Total Segments) #AND# (Data Size #GT# 0)" />
 		<field name="Num Segments" type="uint" vercond="#BS_SSE#" />
-		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_SSE#" arr1="Num Segments" />
+		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_SSE#" length="Num Segments" />
     </niobject>
     
     <!-- Fallout 4 Physics -->
@@ -8216,21 +8216,21 @@
         <field name="Skeleton Root" type="Ptr" template="NiAVObject" />
         <field name="Data" type="Ref" template="BSSkin::BoneData" />
         <field name="Num Bones" type="uint" />
-        <field name="Bones" type="Ptr" template="NiNode" arr1="Num Bones" />
+        <field name="Bones" type="Ptr" template="NiNode" length="Num Bones" />
         <field name="Num Scales" type="uint" />
-        <field name="Scales" type="Vector3" arr1="Num Scales" />
+        <field name="Scales" type="Vector3" length="Num Scales" />
     </niobject>
 
     <niobject name="BSSkin::BoneData" inherit="NiObject" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Bone Data
         <field name="Num Bones" type="uint" />
-        <field name="Bone List" type="BSSkinBoneTrans" arr1="Num Bones" />
+        <field name="Bone List" type="BSSkinBoneTrans" length="Num Bones" />
     </niobject>
 
     <niobject name="BSPositionData" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Positional Data
         <field name="Num Data" type="uint" />
-        <field name="Data" type="hfloat" arr1="Num Data" />
+        <field name="Data" type="hfloat" length="Num Data" />
     </niobject>
 
     <struct name="BSConnectPoint" versions="#FO4# #F76#">
@@ -8244,20 +8244,20 @@
     <niobject name="BSConnectPoint::Parents" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Item Slot Parent
         <field name="Num Connect Points" type="uint" default="1" />
-        <field name="Connect Points" type="BSConnectPoint" arr1="Num Connect Points" />
+        <field name="Connect Points" type="BSConnectPoint" length="Num Connect Points" />
     </niobject>
 
     <niobject name="BSConnectPoint::Children" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Item Slot Child
         <field name="Skinned" type="bool" />
         <field name="Num Points" type="uint" default="1" />
-        <field name="Point Name" type="SizedString" arr1="Num Points" />
+        <field name="Point Name" type="SizedString" length="Num Points" />
     </niobject>
     
     <niobject name="BSEyeCenterExtraData" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Eye Center Data
         <field name="Num Data" type="uint" />
-        <field name="Data" type="float" arr1="Num Data" />
+        <field name="Data" type="float" length="Num Data" />
     </niobject>
 	
     <struct name="BSPackedGeomDataCombined" size="72" versions="#FO4# #F76#">
@@ -8276,10 +8276,10 @@
         <field name="Tri Count LOD2" type="uint" />
         <field name="Tri Offset LOD2" type="uint" />
         <field name="Num Combined" type="uint" />
-        <field name="Combined" type="BSPackedGeomDataCombined" arr1="Num Combined" />
+        <field name="Combined" type="BSPackedGeomDataCombined" length="Num Combined" />
         <field name="Vertex Desc" type="BSVertexDesc" />
-        <field name="Vertex Data" type="BSVertexData" arr1="Num Verts" arg="Vertex Desc #RSH# 44" />
-        <field name="Triangles" type="Triangle" arr1="Tri Count LOD0 + Tri Count LOD1 + Tri Count LOD2" />
+        <field name="Vertex Data" type="BSVertexData" length="Num Verts" arg="Vertex Desc #RSH# 44" />
+        <field name="Triangles" type="Triangle" length="Tri Count LOD0 + Tri Count LOD1 + Tri Count LOD2" />
     </struct>
 
     <struct name="BSPackedSharedGeomData" versions="#FO4# #F76#">
@@ -8292,7 +8292,7 @@
         <field name="Tri Count LOD2" type="uint" />
         <field name="Tri Offset LOD2" type="uint" />
         <field name="Num Combined" type="uint" />
-        <field name="Combined" type="BSPackedGeomDataCombined" arr1="Num Combined" />
+        <field name="Combined" type="BSPackedGeomDataCombined" length="Num Combined" />
         <field name="Vertex Desc" type="BSVertexDesc" />
     </struct>
 
@@ -8311,7 +8311,7 @@
         <field name="Unknown Flags 1" type="uint" />
         <field name="Unknown Flags 2" type="uint" />
         <field name="Num Data" type="uint" />
-        <field name="Object Data" type="BSPackedGeomData" arr1="Num Data" />
+        <field name="Object Data" type="BSPackedGeomData" length="Num Data" />
     </niobject>
 
     <niobject name="BSPackedCombinedSharedGeomDataExtra" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
@@ -8323,8 +8323,8 @@
         <field name="Unknown Flags 1" type="uint" />
         <field name="Unknown Flags 2" type="uint" />
         <field name="Num Data" type="uint" />
-        <field name="Object" type="BSPackedGeomObject" arr1="Num Data" />
-        <field name="Object Data" type="BSPackedSharedGeomData" arr1="Num Data" />
+        <field name="Object" type="BSPackedGeomObject" length="Num Data" />
+        <field name="Object Data" type="BSPackedSharedGeomData" length="Num Data" />
     </niobject>
 
     <!-- Fallout 4 Animation -->
@@ -8337,7 +8337,7 @@
 
 	<niobject name="BSDynamicTriShape" inherit="BSTriShape" module="BSMain" versions="#SSE#">
 		<field name="Dynamic Data Size" type="uint" calc="Num Vertices #MUL# 16" />
-		<field name="Vertices" type="Vector4" arr1="Dynamic Data Size / 16" />
+		<field name="Vertices" type="Vector4" length="Dynamic Data Size / 16" />
 	</niobject>
 	
 	<niobject name="BSDistantObjectLargeRefExtraData" inherit="NiExtraData" module="BSMain" versions="#SSE#">
@@ -8351,23 +8351,23 @@
     </niobject>
 
     <struct name="BSDistantObjectInstance" module="BSMain" versions="#F76#">
-        <field name="Unknown Bytes 1" type="byte" arr1="12" />
+        <field name="Unknown Bytes 1" type="byte" length="12" />
         <field name="Num Unknown 1" type="uint" />
-        <field name="Unknown Ints 1" type="uint" arr1="3 #MUL# Num Unknown 1" />
+        <field name="Unknown Ints 1" type="uint" length="3 #MUL# Num Unknown 1" />
         <field name="Num Unknown 2" type="uint" />
-        <field name="Unknown Bytes 2" type="byte" binary="true" arr1="64 #MUL# Num Unknown 2" />
+        <field name="Unknown Bytes 2" type="byte" binary="true" length="64 #MUL# Num Unknown 2" />
     </struct>
 
     <struct name="BSDistantObjectTextureArray" module="BSMain" versions="#F76#">
         <field name="Unknown Byte" type="byte" default="1" />
         <field name="Num Texture Arrays" type="uint" />
-        <field name="Texture Arrays" type="BSTextureArray" arr1="Num Texture Arrays" />
+        <field name="Texture Arrays" type="BSTextureArray" length="Num Texture Arrays" />
     </struct>
 
     <niobject name="BSDistantObjectInstancedNode" inherit="BSMultiBoundNode" module="BSMain" versions="#F76#">
         <field name="Num Instances" type="uint" />
-        <field name="Instances" type="BSDistantObjectInstance" arr1="Num Instances" />
-        <field name="Texture Arrays" type="BSDistantObjectTextureArray" arr1="3" />
+        <field name="Instances" type="BSDistantObjectInstance" length="Num Instances" />
+        <field name="Texture Arrays" type="BSDistantObjectTextureArray" length="3" />
     </niobject>
 
 </niftoolsxml>

--- a/nif.xml
+++ b/nif.xml
@@ -1734,7 +1734,14 @@
         <field name="z" type="hfloat">Third coordinate.</field>
     </struct>
 
-    <struct name="ByteVector3" size="3" convertible="Vector3" module="NiMain">
+    <struct name="UshortVector3" size="6" convertible="Vector3" module="NiMain">
+        A vector in 3D space (x,y,z).
+        <field name="x" type="ushort">First coordinate.</field>
+        <field name="y" type="ushort">Second coordinate.</field>
+        <field name="z" type="ushort">Third coordinate.</field>
+    </struct>
+
+    <struct name="ByteVector3" size="3" convertible="Vector3 UshortVector3" module="NiMain">
         A vector in 3D space (x,y,z).
         <field name="x" type="byte">First coordinate.</field>
         <field name="y" type="byte">Second coordinate.</field>
@@ -2575,20 +2582,27 @@
         <field name="Translation" type="Vector4">A vector that moves the chunk by the specified amount. W is not used.</field>
         <field name="Rotation" type="hkQuaternion">Rotation. Reference point for rotation is bhkRigidBody translation.</field>
     </struct>
-    
+
+    <bitfield name="bhkWeldInfo" storage="ushort">
+        <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
+        <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
+        <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
+        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false">
+    </bitfield>
+
     <struct name="bhkCMSChunk" module="BSHavok" versions="#SKY_AND_LATER#">
         Bethesda extension of hkpCompressedMeshShape::Chunk. A compressed chunk of hkpCompressedMeshShape geometry.
         <field name="Translation" type="Vector4" />
         <field name="Material Index" type="uint">Index of material in bhkCompressedMeshShapeData::Chunk Materials</field>
         <field name="Reference" type="ushort" default="#USHRT_MAX#">Index of another chunk in the chunks list.</field>
         <field name="Transform Index" type="ushort">Index of transformation in bhkCompressedMeshShapeData::Chunk Transforms</field>
-        <field name="Num Vertices" type="uint" />
-        <field name="Vertices" type="ushort" length="Num Vertices" />
+        <field name="Num Vertices" type="uint">Number of vertices, multiplied by 3.</field>
+        <field name="Vertices" type="UshortVector3" length="Num Vertices #DIV# 3">Vertex positions in havok coordinates*1000.</field>
         <field name="Num Indices" type="uint" />
-        <field name="Indices" type="ushort" length="Num Indices" />
+        <field name="Indices" type="ushort" length="Num Indices">Vertex indices as used by strips.</field>
         <field name="Num Strips" type="uint" />
-        <field name="Strips" type="ushort" length="Num Strips" />
-        <field name="Num Welding Info" type="uint" />
+        <field name="Strips" type="ushort" length="Num Strips">Length of strips longer than one triangle.</field>
+        <field name="Num Welding Info" type="uint">Generally the same as Num Indices field.</field>
         <field name="Welding Info" type="ushort" length="Num Welding Info" />
     </struct>
 

--- a/nif.xml
+++ b/nif.xml
@@ -68,6 +68,7 @@
     <version id="V20_2_0_7_SKY" num="20.2.0.7" user="12" bsver="83" ext="bto btr">{{Skyrim}}</version>
     <version id="V20_2_0_7_SSE" num="20.2.0.7" user="12" bsver="100" ext="bto btr">{{Skyrim SE}}</version>
     <version id="V20_2_0_7_FO4" num="20.2.0.7" user="12" bsver="130" ext="bto btr">{{Fallout 4}}</version>
+    <version id="V20_2_0_7_FO4_2" num="20.2.0.7" user="12" bsver="132 139" ext="bto btr" supported="false">Fallout 4 (LS_Mirelurk.nif, Screen.nif)</version>
     <version id="V20_2_0_7_F76" num="20.2.0.7" user="12" bsver="155" ext="bto">{{Fallout 76}}</version>
     <version id="V20_2_0_8" num="20.2.0.8" ext="nifcache">{{Empire Earth III}}, {{FFT Online}}, Atlantica Online, IRIS Online, Wizard101</version>
     <version id="V20_3_0_1" num="20.3.0.1">Emerge</version>
@@ -78,12 +79,15 @@
     <version id="V20_3_0_9_DIV2" num="20.3.0.9" user="0x20000 0x30000" ext="item">{{Divinity 2}}</version>
     <version id="V20_5_0_0" num="20.5.0.0">MicroVolts, KrazyRain</version>
     <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101</version>
-    <version id="V20_6_5_0_DEM" num="20.6.5.0" user="17" supported="false">Epic Mickey 2</version>
+    <version id="V20_6_5_0" num="20.6.5.0" supported="false">Epic Mickey</version>
+    <version id="V20_6_5_0_DEM" num="20.6.5.0" user="15" supported="false">Epic Mickey</version>
+    <version id="V20_6_5_0_DEM2" num="20.6.5.0" user="17" supported="false">Epic Mickey 2</version>
     <version id="V30_0_0_2" num="30.0.0.2">Emerge</version>
     <version id="V30_1_0_1" num="30.1.0.1">Emerge</version>
     <version id="V30_1_0_3" num="30.1.0.3">Rocksmith, Rocksmith 2014</version>
     <version id="V30_2_0_3" num="30.2.0.3">Ghost In The Shell: First Assault, MapleStory 2</version>
 
+    <!-- BSMain = 0x1fff384d000 -->
     <module name="NiMain" priority="0" />
     <module name="NiAnimation" priority="25" depends="NiMain" />
     <module name="NiParticle" priority="50" depends="NiMain NiAnimation" />
@@ -92,9 +96,9 @@
     <module name="NiPhysX" priority="90" depends="NiMain NiMesh NiPSParticle" />
     <module name="NiLegacy" priority="99" depends="NiMain NiAnimation NiParticle" />
     <module name="BSMain" priority="100" depends="NiMain" custom="true" />
-    <module name="BSAnimation" priority="125" depends="NiMain BSMain NiAnimation" custom="true" />
-    <module name="BSParticle" priority="150" depends="NiMain NiParticle" custom="true" />
-    <module name="BSHavok" priority="190" depends="NiMain" custom="true" />
+    <module name="BSAnimation" priority="125" depends="NiMain NiAnimation BSMain" custom="true" />
+    <module name="BSParticle" priority="150" depends="NiMain NiParticle BSMain" custom="true" />
+    <module name="BSHavok" priority="190" depends="NiMain BSMain" custom="true" />
     <module name="BSLegacy" priority="199" depends="NiMain NiLegacy" custom="true" />
     <module name="NiCustom" priority="255" depends="NiMain NiParticle" custom="true" />
 
@@ -110,20 +114,26 @@
         <verexpr token="#NI_BS_LTE_FO3#" string="(#BSVER# #LTE# 34)">All NI + BS until Fallout 3.</verexpr>
         <verexpr token="#NI_BS_LT_SSE#" string="(#BSVER# #LT# 100)">All NI + BS before SSE.</verexpr>
         <verexpr token="#NI_BS_LT_FO4#" string="(#BSVER# #LT# 130)">All NI + BS before Fallout 4.</verexpr>
-        <verexpr token="#NI_BS_LTE_FO4#" string="(#BSVER# #LTE# 130)">All NI + BS until Fallout 4.</verexpr>
+        <verexpr token="#NI_BS_LTE_FO4#" string="(#BSVER# #LTE# 139)">All NI + BS until Fallout 4.</verexpr>
         <verexpr token="#BS_GT_FO3#" string="(#BSVER# #GT# 34)">Skyrim, SSE, and Fallout 4</verexpr>
         <verexpr token="#BS_GTE_FO3#" string="(#BSVER# #GTE# 34)">FO3 and later.</verexpr>
         <verexpr token="#BS_GTE_SKY#" string="(#BSVER# #GTE# 83)">Skyrim and later.</verexpr>
         <verexpr token="#BS_GTE_SSE#" string="(#BSVER# #GTE# 100)">SSE and later.</verexpr>
         <verexpr token="#BS_SSE#" string="(#BSVER# #EQ# 100)">SSE only.</verexpr>
-        <verexpr token="#BS_FO4#" string="(#BSVER# #EQ# 130)">Fallout 4 only.</verexpr>
-        <verexpr token="#BS_GTE_FO4#" string="(#BSVER# #GTE# 130)">Fallout 4 and FO76.</verexpr>
-        <verexpr token="#BS_F76#" string="(#BSVER# #EQ# 155)">Fallout 76 only.</verexpr>
+        <verexpr token="#BS_FO4#" string="(#BSVER# #EQ# 130)">Fallout 4 strictly, excluding stream 132 and 139 in dev files.</verexpr>
+        <verexpr token="#BS_FO4_2#" string="((#BSVER# #GTE# 130) #AND# (#BSVER# #LTE# 139))">Fallout 4/76 including dev files.</verexpr>
+        <verexpr token="#BS_GT_130#" string="(#BSVER# #GT# 130)">Later than Bethesda 130.</verexpr>
+        <verexpr token="#BS_GTE_130#" string="(#BSVER# #GTE# 130)">Bethesda 130 and later.</verexpr>
+        <verexpr token="#BS_GTE_132#" string="(#BSVER# #GTE# 132)">Bethesda 132 and later.</verexpr>
+        <verexpr token="#BS_GTE_152#" string="(#BSVER# #GTE# 152)">Bethesda 152 and later.</verexpr>
+        <verexpr token="#BS_F76#" string="(#BSVER# #EQ# 155)">Fallout 76 stream 155 only.</verexpr>
+        <verexpr token="#BS_GTE_152#" string="(#BSVER# #GTE# 152)">Fallout 76 stream 152 and higher</verexpr>
         <verexpr token="#BS202#" string="((#VER# #EQ# 20.2.0.7) #AND# (#BSVER# #GT# 0))">Bethesda 20.2 only.</verexpr>
         <verexpr token="#DIVINITY2#" string="((#USER# #EQ# 0x20000) #OR# (#USER# #EQ# 0x30000))">Divinity 2</verexpr>
     </token>
 
     <token name="condexpr" attrs="cond">
+        <condexpr token="#FLT_MAX#" string="0x7F7FFFFF" />
         <condexpr token="#BSSTREAMHEADER#" string="(Version #EQ# 10.0.1.2) #OR# ((Version #EQ# 20.2.0.7) #OR# (Version #EQ# 20.0.0.5) #OR# ((Version #GTE# 10.1.0.0) #AND# (Version #LTE# 20.0.0.4) #AND# (User Version #LTE# 11))) #AND# (User Version #GTE# 3)" />
     </token>
 
@@ -316,7 +326,7 @@
     <basic name="NiFixedString" integral="true" countable="false" size="4">
         A 32-bit unsigned integer, used to refer to strings in the header.
     </basic>
-    
+
     <!--Enumerations
         These are like C enums and consist of a list of options.  They can appear
         as parts of structs or niobjects.-->
@@ -539,6 +549,7 @@
 
     <enum name="SkyrimHavokMaterial" storage="uint" versions="#SKY_AND_LATER#">
         Bethesda Havok. Material descriptor for a Havok shape in Skyrim.
+        <option value="0" name="SKY_HAV_MAT_NONE">Invalid Material</option>
         <option value="131151687" name="SKY_HAV_MAT_BROKEN_STONE">Broken Stone</option>
         <option value="365420259" name="SKY_HAV_MAT_LIGHT_WOOD">Light Wood</option>
         <option value="398949039" name="SKY_HAV_MAT_SNOW">Snow</option>
@@ -600,6 +611,21 @@
         <option value="3969592277" name="SKY_HAV_MAT_MATERIAL_BLUNT_2HAND">Material Blunt 2Hand</option>
         <option value="4239621792" name="SKY_HAV_MAT_UNKNOWN_4239621792">Unknown in Creation Kit v1.9.32.0. Found in Dawnguard DLC in meshes\dlc01\prototype\dlc1protoswingingbridge.nif.</option>
         <option value="4283869410" name="SKY_HAV_MAT_MATERIAL_BOULDER_MEDIUM">Material Boulder Medium</option>
+        <option value="3855001958" name="SKY_HAV_MAT_UNKNOWN_3855001958" />
+        <option value="3387452107" name="SKY_HAV_MAT_UNKNOWN_3387452107" />
+        <option value="2742858142" name="SKY_HAV_MAT_UNKNOWN_2742858142" />
+        <option value="2794252627" name="SKY_HAV_MAT_UNKNOWN_2794252627" />
+        <option value="346811165" name="SKY_HAV_MAT_UNKNOWN_346811165" />
+        <option value="1668849266" name="SKY_HAV_MAT_UNKNOWN_1668849266" />
+        <option value="1734341287" name="SKY_HAV_MAT_UNKNOWN_1734341287" />
+        <option value="3974071006" name="SKY_HAV_MAT_UNKNOWN_3974071006" />
+        <option value="3895166727" name="SKY_HAV_MAT_UNKNOWN_3895166727">dlc1shadowshieldfx</option>
+        <option value="880200008" name="SKY_HAV_MAT_UNKNOWN_880200008">azurafloorhex01</option>
+        <option value="3934839107" name="SKY_HAV_MAT_UNKNOWN_3934839107">fxspiderwebhitstrip01</option>
+        <option value="3941234649" name="SKY_HAV_MAT_UNKNOWN_3941234649">tfxsteelswordbloody</option>
+        <option value="322207473" name="SKY_HAV_MAT_UNKNOWN_322207473">prisonercarriage01</option>
+        <option value="3764646153" name="SKY_HAV_MAT_UNKNOWN_3764646153">tundrastreambend01watera</option>
+        <option value="1820198263" name="SKY_HAV_MAT_UNKNOWN_1820198263">steelgreatsword</option>
     </enum>
 
     <enum name="OblivionLayer" storage="byte" versions="#BETHESDA#">
@@ -819,6 +845,9 @@
         <option value="3" name="DX9" />
         <option value="4" name="WII" />
         <option value="5" name="D3D10" />
+        <option value="6" name="UNKNOWN_6" />
+        <option value="7" name="UNKNOWN_7" />
+        <option value="8" name="UNKNOWN_8" />
     </enum>
 
     <enum name="RendererID" storage="uint" prefix="RENDERER">
@@ -987,6 +1016,10 @@
         <option value="4" name="RIGID_FACE_CENTER">Billboard forward vector always faces camera ceneter. Non-minimized rotation.</option>
         <option value="5" name="BSROTATE_ABOUT_UP">The billboard will only rotate around its local Z axis (it always stays in its local X-Y plane).</option>
         <option value="9" name="ROTATE_ABOUT_UP2">The billboard will only rotate around the up axis (same as ROTATE_ABOUT_UP?).</option>
+        <option value="8" name="UNKNOWN_8">Found in Civ IV Gravebringer and Gravebringer_FX</option>
+        <option value="10" name="UNKNOWN_10">Found in FO3 dlc04lighthouselightmech01</option>
+        <option value="11" name="UNKNOWN_11">Found in Civ IV Afterworld_Boss_FX</option>
+        <option value="12" name="UNKNOWN_12">Found in IRIS Online etc.</option>
     </enum>
 
     <enum name="StencilTestFunc" storage="uint" prefix="STENCIL">
@@ -1205,6 +1238,7 @@
         <option value="1" name="PROPAGATE_ON_FAILURE">(Deprecated) Propagation only occurs as a result of a failed collision.</option>
         <option value="2" name="PROPAGATE_ALWAYS">Propagation always occurs regardless of collision result.</option>
         <option value="3" name="PROPAGATE_NEVER">Propagation never occurs regardless of collision result.</option>
+        <option value="6" name="PROPAGATE_UNKNOWN_6">Propagation mode found in Civ IV Chariot_Celtic.</option>
     </enum>
 
     <enum name="CollisionMode" prefix="CM" storage="uint">
@@ -1300,6 +1334,7 @@
         
         <option value="130" name="SBP_130_HEAD">Skyrim, Head slot, use on full-face helmets</option>
         <option value="131" name="SBP_131_HAIR">Skyrim, Hair slot 1, use on hoods</option>
+        <option value="132" name="SBP_132_HAIR">Skyrim, Hair slot 2?, use on hoods</option>
         <option value="141" name="SBP_141_LONGHAIR">Skyrim, Hair slot 2, use for longer hair</option>
         <option value="142" name="SBP_142_CIRCLET">Skyrim, Circlet slot 1, use for circlets</option>
         <option value="143" name="SBP_143_EARS">Skyrim, Ear slot</option>
@@ -1361,7 +1396,7 @@
         <option value="20" name="FO4 Dismemberment" />
     </enum>
 
-    <enum name="BSLightingShaderType155" storage="uint" prefix="ST" versions="#F76#">
+    <enum name="BSShaderType155" storage="uint" prefix="ST155" versions="#F76#">
         Values for configuring the shader type in a BSLightingShaderProperty
         <option value="0" name="Default" />
         <option value="2" name="Glow" />
@@ -1382,6 +1417,10 @@
         <option value="7" name="U Scale">U Scale.</option>
         <option value="8" name="V Offset">V Offset.</option>
         <option value="9" name="V Scale">V Scale.</option>
+        <option value="11" name="Unknown 11" />
+        <option value="12" name="Unknown 12" />
+        <option value="13" name="Unknown 13" />
+        <option value="14" name="Unknown 14" />
     </enum>
 
     <enum name="EffectShaderControlledColor" storage="uint" prefix="ECSC" versions="#SKY_AND_LATER#">
@@ -1392,11 +1431,15 @@
     <enum name="LightingShaderControlledFloat" storage="uint" prefix="LSCF" versions="#SKY_AND_LATER#">
         An unsigned 32-bit integer, describing which float variable in BSLightingShaderProperty to animate.
         <option value="0" name="Refraction Strength">The amount of distortion.</option>
+        <option value="3" name="Unknown 3" />
+        <option value="4" name="Unknown 4" />
         <option value="8" name="Environment Map Scale">Environment Map Scale.</option>
         <option value="9" name="Glossiness">Glossiness.</option>
         <option value="10" name="Specular Strength">Specular Strength.</option>
         <option value="11" name="Emissive Multiple">Emissive Multiple.</option>
         <option value="12" name="Alpha">Alpha.</option>
+        <option value="13" name="Unknown 13" />
+        <option value="14" name="Unknown 14" />
         <option value="20" name="U Offset">U Offset.</option>
         <option value="21" name="U Scale">U Scale.</option>
         <option value="22" name="V Offset">V Offset.</option>
@@ -1556,7 +1599,7 @@
     </enum>
 
     <bitfield name="NiGeometryDataFlags" storage="ushort">
-        <member width="6" pos="0" mask="0x003F" name="Num UV Sets" type="bool" />
+        <member width="6" pos="0" mask="0x003F" name="Num UV Sets" type="ushort" />
         <member width="6" pos="6" mask="0x0FC0" name="Havok Material" type="ushort">Unused for non-Bethesda, non-bhk NiGeometryData.</member>
         <member width="2" pos="12" mask="0xF000" name="NBT Method" type="NiNBTMethod" />
     </bitfield>
@@ -1574,70 +1617,69 @@
         <member width="1" pos="7" mask="0x0080" name="Linked Group" type="bool">If Layer is CHARCONTROLLER (CC), true means "CC Trigger Only".</member>
     </bitfield>
 
-
     <!--Structs
         These are like C structures and are used as sub-parts of more complex
         classes when there are multiple pieces of data repeated in an array.-->
 
-    <struct name="SizedString">
+    <struct name="SizedString" module="NiMain">
         A string of given length.
         <field name="Length" type="uint">The string length.</field>
         <field name="Value" type="char" length="Length">The string itself.</field>
     </struct>
 
-    <struct name="SizedString16">
+    <struct name="SizedString16" module="NiMain">
         A string of given length, using a ushort to store string length.
         <field name="Length" type="ushort">The string length.</field>
         <field name="Value" type="char" length="Length">The string itself.</field>
     </struct>
 
-    <struct name="string">
+    <struct name="string" module="NiMain">
         A string type.
         <field name="String" type="SizedString" until="20.0.0.5">The normal string.</field>
         <field name="Index" type="NiFixedString" since="20.1.0.3">The string index.</field>
     </struct>
 
-    <struct name="NiTFixedStringMapItem" generic="true">
+    <struct name="NiTFixedStringMapItem" generic="true" module="NiMain">
         Currently, #T# must be a basic type due to nif.xml restrictions.
         <field name="String" type="NiFixedString" />
         <field name="Value" type="#T#" />
     </struct>
 
-    <struct name="NiTFixedStringMap" generic="true">
+    <struct name="NiTFixedStringMap" generic="true" module="NiMain">
         A mapping or hash table between NiFixedString keys and a generic value.
         Currently, #T# must be a basic type due to nif.xml restrictions.
         <field name="Num Strings" type="uint" />
         <field name="Strings" type="NiTFixedStringMapItem" template="#T#" length="Num Strings" />
     </struct>
 
-    <struct name="ByteArray">
+    <struct name="ByteArray" module="NiMain">
         An array of bytes.
         <field name="Data Size" type="uint">The number of bytes in this array</field>
         <field name="Data" type="byte" length="Data Size">The bytes which make up the array</field>
     </struct>
 
-    <struct name="ByteMatrix">
+    <struct name="ByteMatrix" module="NiMain">
         An array of bytes.
         <field name="Data Size 1" type="uint">The number of bytes in this array</field>
         <field name="Data Size 2" type="uint">The number of bytes in this array</field>
         <field name="Data" type="byte" length="Data Size 2" width="Data Size 1">The bytes which make up the array</field>
     </struct>
 
-    <struct name="Color3" size="12">
+    <struct name="Color3" size="12" module="NiMain">
         A color without alpha (red, green, blue).
         <field name="r" type="float">Red color component.</field>
         <field name="g" type="float">Green color component.</field>
         <field name="b" type="float">Blue color component.</field>
     </struct>
 
-    <struct name="ByteColor3" size="3" convertible="Color3">
+    <struct name="ByteColor3" size="3" convertible="Color3" module="NiMain">
         A color without alpha (red, green, blue).
         <field name="r" type="byte">Red color component.</field>
         <field name="g" type="byte">Green color component.</field>
         <field name="b" type="byte">Blue color component.</field>
     </struct>
 
-    <struct name="Color4" size="16">
+    <struct name="Color4" size="16" module="NiMain">
         A color with alpha (red, green, blue, alpha).
         <field name="r" type="float">Red component.</field>
         <field name="g" type="float">Green component.</field>
@@ -1645,7 +1687,7 @@
         <field name="a" type="float">Alpha.</field>
     </struct>
 
-    <struct name="ByteColor4" size="4" convertible="Color4">
+    <struct name="ByteColor4" size="4" convertible="Color4" module="NiMain">
         A color with alpha (red, green, blue, alpha).
         <field name="r" type="byte">Red color component.</field>
         <field name="g" type="byte">Green color component.</field>
@@ -1653,53 +1695,53 @@
         <field name="a" type="byte">Alpha color component.</field>
     </struct>
 
-    <struct name="FilePath">
+    <struct name="FilePath" module="NiMain">
         A string that contains the path to a file.
         <field name="String" type="SizedString" until="20.0.0.5">The normal string.</field>
         <field name="Index" type="NiFixedString" since="20.1.0.3">The string index.</field>
     </struct>
 
-    <struct name="Footer">
+    <struct name="Footer" module="NiMain">
         The NIF file footer.
         <field name="Num Roots" type="uint" since="3.3.0.13">The number of root references.</field>
         <field name="Roots" type="Ref" template="NiObject" length="Num Roots" since="3.3.0.13">List of root NIF objects. If there is a camera, for 1st person view, then this NIF object is referred to as well in this list, even if it is not a root object (usually we want the camera to be attached to the Bip Head node).</field>
     </struct>
 
-    <struct name="LODRange">
+    <struct name="LODRange" module="NiMain">
         The distance range where a specific level of detail applies.
         <field name="Near Extent" type="float">Begining of range.</field>
         <field name="Far Extent" type="float">End of Range.</field>
         <field name="Unknown Ints" type="uint" length="3" until="3.1" />
     </struct>
 
-    <struct name="MatchGroup">
+    <struct name="MatchGroup" module="NiMain">
         Group of vertex indices of vertices that match.
         <field name="Num Vertices" type="ushort">Number of vertices in this group.</field>
         <field name="Vertex Indices" type="ushort" length="Num Vertices">The vertex indices.</field>
     </struct>
     
-    <struct name="Vector3" size="12">
+    <struct name="Vector3" size="12" module="NiMain">
         A vector in 3D space (x,y,z).
         <field name="x" type="float">First coordinate.</field>
         <field name="y" type="float">Second coordinate.</field>
         <field name="z" type="float">Third coordinate.</field>
     </struct>
     
-    <struct name="HalfVector3" size="6" convertible="Vector3">
+    <struct name="HalfVector3" size="6" convertible="Vector3" module="NiMain">
         A vector in 3D space (x,y,z).
         <field name="x" type="hfloat">First coordinate.</field>
         <field name="y" type="hfloat">Second coordinate.</field>
         <field name="z" type="hfloat">Third coordinate.</field>
     </struct>
 
-    <struct name="ByteVector3" size="3" convertible="Vector3">
+    <struct name="ByteVector3" size="3" convertible="Vector3" module="NiMain">
         A vector in 3D space (x,y,z).
         <field name="x" type="byte">First coordinate.</field>
         <field name="y" type="byte">Second coordinate.</field>
         <field name="z" type="byte">Third coordinate.</field>
     </struct>
 
-    <struct name="Vector4" size="16">
+    <struct name="Vector4" size="16" module="NiMain">
         A 4-dimensional vector.
         <field name="x" type="float">First coordinate.</field>
         <field name="y" type="float">Second coordinate.</field>
@@ -1707,7 +1749,7 @@
         <field name="w" type="float">Fourth coordinate.</field>
     </struct>
 
-    <struct name="Quaternion" size="16">
+    <struct name="Quaternion" size="16" module="NiMain">
         A quaternion.
         <field name="w" type="float" default="1.0">The w-coordinate.</field>
         <field name="x" type="float" default="0.0">The x-coordinate.</field>
@@ -1715,7 +1757,7 @@
         <field name="z" type="float" default="0.0">The z-coordinate.</field>
     </struct>
 
-    <struct name="hkQuaternion" size="16" versions="#BETHESDA#">
+    <struct name="hkQuaternion" size="16" module="BSMain" versions="#BETHESDA#">
         A quaternion as it appears in the havok objects.
         <field name="x" type="float" default="0.0">The x-coordinate.</field>
         <field name="y" type="float" default="0.0">The y-coordinate.</field>
@@ -1723,7 +1765,7 @@
         <field name="w" type="float" default="1.0">The w-coordinate.</field>
     </struct>
 
-    <struct name="Matrix22" size="16">
+    <struct name="Matrix22" size="16" module="NiMain">
         A 2x2 matrix of float values.  Stored in OpenGL column-major format.
         <field name="m11" type="float" default="1.0">Member 1,1 (top left)</field>
         <field name="m21" type="float" default="0.0">Member 2,1 (bottom left)</field>
@@ -1731,7 +1773,7 @@
         <field name="m22" type="float" default="1.0">Member 2,2 (bottom right)</field>
     </struct>
 
-    <struct name="Matrix33" size="36">
+    <struct name="Matrix33" size="36" module="NiMain">
         A 3x3 rotation matrix; M^T M=identity, det(M)=1.    Stored in OpenGL column-major format.
         <field name="m11" type="float" default="1.0">Member 1,1 (top left)</field>
         <field name="m21" type="float" default="0.0">Member 2,1</field>
@@ -1744,7 +1786,7 @@
         <field name="m33" type="float" default="1.0">Member 3,3 (bottom left)</field>
     </struct>
 
-    <struct name="Matrix34" size="48">
+    <struct name="Matrix34" size="48" module="NiMain">
         A 3x4 transformation matrix.
         <field name="m11" type="float" default="1.0">The (1,1) element.</field>
         <field name="m21" type="float" default="0.0">The (2,1) element.</field>
@@ -1760,7 +1802,7 @@
         <field name="m34" type="float" default="0.0">The (3,4) element.</field>
     </struct>
 
-    <struct name="Matrix44" size="64">
+    <struct name="Matrix44" size="64" module="NiMain">
         A 4x4 transformation matrix.
         <field name="m11" type="float" default="1.0">The (1,1) element.</field>
         <field name="m21" type="float" default="0.0">The (2,1) element.</field>
@@ -1780,7 +1822,7 @@
         <field name="m44" type="float" default="1.0">The (4,4) element.</field>
     </struct>
 
-    <struct name="hkMatrix3" size="48" versions="#BETHESDA#">
+    <struct name="hkMatrix3" size="48" module="BSHavok" versions="#BETHESDA#">
         A 3x3 Havok matrix stored in 4x3 due to memory alignment.
         <field name="m11" type="float" default="1.0" />
         <field name="m12" type="float" />
@@ -1796,50 +1838,50 @@
         <field name="m34" type="float">Unused</field>
     </struct>
 
-    <struct name="MipMap" size="12">
+    <struct name="MipMap" size="12" module="NiMain">
         Description of a mipmap within an NiPixelData object.
         <field name="Width" type="uint">Width of the mipmap image.</field>
         <field name="Height" type="uint">Height of the mipmap image.</field>
         <field name="Offset" type="uint">Offset into the pixel data array where this mipmap starts.</field>
     </struct>
 
-    <struct name="NodeSet">
+    <struct name="NodeSet" module="NiAnimation">
         A set of NiNode references.
         <field name="Num Nodes" type="uint">Number of node references that follow.</field>
         <field name="Nodes" type="Ptr" template="NiNode" length="Num Nodes">The list of NiNode references.</field>
     </struct>
 
-    <struct name="ExportString">
+    <struct name="ExportString" module="BSMain">
         Specific to Bethesda-specific header export strings.
         <field name="Length" type="byte">The string length.</field>
         <field name="Value" type="char" length="Length">The string itself, null terminated (the null terminator is taken into account in the length byte).</field>
     </struct>
 
-    <struct name="SkinInfo" size="8" since="V4_2_2_0">
+    <struct name="SkinInfo" size="8" module="NiAnimation" since="V4_2_2_0">
         NiBoneLODController::SkinInfo. Reference to shape and skin instance.
         <field name="Shape" type="Ptr" template="NiTriBasedGeom" />
         <field name="Skin Instance" type="Ref" template="NiSkinInstance" />
     </struct>
 
-    <struct name="SkinInfoSet" since="V4_2_2_0">
+    <struct name="SkinInfoSet" module="NiAnimation" since="V4_2_2_0">
         A set of NiBoneLODController::SkinInfo.
         <field name="Num Skin Info" type="uint" />
         <field name="Skin Info" type="SkinInfo" length="Num Skin Info" />
     </struct>
 
-    <struct name="BoneVertData" size="6">
+    <struct name="BoneVertData" size="6" module="NiMain">
         NiSkinData::BoneVertData. A vertex and its weight.
         <field name="Index" type="ushort">The vertex index, in the mesh.</field>
         <field name="Weight" type="float" range="#F0_1#">The vertex weight - between 0.0 and 1.0</field>
     </struct>
 
-    <struct name="AVObject">
+    <struct name="AVObject" module="NiMain">
         Used in NiDefaultAVObjectPalette.
         <field name="Name" type="SizedString">Object name.</field>
         <field name="AV Object" type="Ptr" template="NiAVObject">Object reference.</field>
     </struct>
 
-    <struct name="ControlledBlock">
+    <struct name="ControlledBlock" module="NiAnimation">
         In a .kf file, this links to a controllable object, via its name (or for version 10.2.0.0 and up, a link and offset to a NiStringPalette that contains the name), and a sequence of interpolators that apply to this controllable object, via links.
         For Controller ID, NiInterpController::GetCtlrID() virtual function returns a string formatted specifically for the derived type.
         For Interpolator ID, NiInterpController::GetInterpolatorID() virtual function returns a string formatted specifically for the derived type.
@@ -1872,7 +1914,7 @@
         <field name="Interpolator ID" type="string" since="20.1.0.1">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
     </struct>
 
-    <struct name="BSStreamHeader" versions="#BETHESDA#">
+    <struct name="BSStreamHeader" versions="#BETHESDA#" module="BSMain">
     	Information about how the file was exported
         <field name="BS Version" type="ulittle32" />
         <field name="Author" type="ExportString" />
@@ -1883,7 +1925,7 @@
     </struct>
 
     <!-- Don't use vercond in Header, it breaks niflib -->
-    <struct name="Header">
+    <struct name="Header" module="NiMain">
         The NIF file header.
         <field name="Header String" type="HeaderString">'NetImmerse File Format x.x.x.x' (versions &lt;= 10.0.1.2) or 'Gamebryo File Format x.x.x.x' (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</field>
         <field name="Copyright" type="LineString" length="3" until="3.1.0.0" />
@@ -1905,20 +1947,20 @@
         <field name="Groups" type="uint" length="Num Groups" since="5.0.0.6" />
     </struct>
 
-    <struct name="StringPalette">
+    <struct name="StringPalette" module="NiMain">
         A list of \\0 terminated strings.
         <field name="Palette" type="SizedString">A bunch of 0x00 seperated strings.</field>
         <field name="Length" type="uint">Length of the palette string is repeated here.</field>
     </struct>
 
-    <struct name="TBC" size="12">
+    <struct name="TBC" size="12" module="NiMain">
         Tension, bias, continuity.
         <field name="t" type="float">Tension.</field>
         <field name="b" type="float">Bias.</field>
         <field name="c" type="float">Continuity.</field>
     </struct>
 
-    <struct name="Key" generic="true">
+    <struct name="Key" generic="true" module="NiMain">
         A generic key with support for interpolation. Type 1 is normal linear interpolation, type 2 has forward and backward tangents, and type 3 has tension, bias and continuity arguments. Note that color4 and byte always seem to be of type 1.
         <field name="Time" type="float">Time of the key.</field>
         <field name="Value" type="#T#">The key value.</field>
@@ -1927,14 +1969,14 @@
         <field name="TBC" type="TBC" cond="#ARG# == 3">The TBC of the key.</field>
     </struct>
 
-    <struct name="KeyGroup" generic="true">
+    <struct name="KeyGroup" generic="true" module="NiMain">
         Array of vector keys (anything that can be interpolated, except rotations).
         <field name="Num Keys" type="uint">Number of keys in the array.</field>
         <field name="Interpolation" type="KeyType" cond="Num Keys != 0">The key type.</field>
         <field name="Keys" type="Key" arg="Interpolation" template="#T#" length="Num Keys">The keys.</field>
     </struct>
 
-    <struct name="QuatKey" generic="true">
+    <struct name="QuatKey" generic="true" module="NiMain">
         A special version of the key type used for quaternions. Never has tangents. #T# should always be Quaternion.
         <field name="Time" type="float" until="10.1.0.0">Time the key applies.</field>
         <field name="Time" type="float" cond="#ARG# != 4" since="10.1.0.106">Time the key applies.</field>
@@ -1942,13 +1984,13 @@
         <field name="TBC" type="TBC" cond="#ARG# == 3">The TBC of the key.</field>
     </struct>
 
-    <struct name="TexCoord" size="8">
+    <struct name="TexCoord" size="8" module="NiMain">
         Texture coordinates (u,v). As in OpenGL; image origin is in the lower left corner.
         <field name="u" type="float" range="#FPM_100#">First coordinate.</field>
         <field name="v" type="float" range="#FPM_100#">Second coordinate.</field>
     </struct>
     
-    <struct name="HalfTexCoord" size="4">
+    <struct name="HalfTexCoord" size="4" module="NiMain">
         Texture coordinates (u,v).
         <field name="u" type="hfloat" range="#FPM_10#">First coordinate.</field>
         <field name="v" type="hfloat" range="#FPM_10#">Second coordinate.</field>
@@ -1962,7 +2004,7 @@
         <option value="2" name="Maya">Center * Rotation * Back * FromMaya * Translate * Scale</option>
     </enum>
 
-    <struct name="TexDesc">
+    <struct name="TexDesc" module="NiMain">
         NiTexturingProperty::Map. Texture description.
         <field name="Image" type="Ref" template="NiImage" until="3.1">Link to the texture image.</field>
         <field name="Source" type="Ref" template="NiSourceTexture" since="3.3.0.13">NiSourceTexture object index.</field>
@@ -1983,14 +2025,14 @@
         <field name="Center" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0">The origin around which the texture rotates.</field>
     </struct>
 
-    <struct name="ShaderTexDesc">
+    <struct name="ShaderTexDesc" module="NiMain">
         NiTexturingProperty::ShaderMap. Shader texture description.
         <field name="Has Map" type="bool" />
         <field name="Map" type="TexDesc" cond="Has Map" />
         <field name="Map ID" type="uint" cond="Has Map">Unique identifier for the Gamebryo shader system.</field>
     </struct>
 
-    <struct name="Triangle" size="6">
+    <struct name="Triangle" size="6" module="NiMain">
         List of three vertex indices.
         <field name="v1" type="ushort">First vertex index.</field>
         <field name="v2" type="ushort">Second vertex index.</field>
@@ -2027,7 +2069,7 @@
         <member width="12" pos="44" mask="0xFFF00000000000" name="Vertex Attributes" type="VertexAttribute" />
     </bitfield>
 
-	<struct name="BSVertexData" versions="#SSE# #FO4# #F76#">
+	<struct name="BSVertexData" versions="#SSE# #FO4# #F76#" module="BSMain">
 		<field name="Vertex" type="Vector3" cond="(#ARG# #BITAND# 0x401) == 0x401" />
 		<field name="Bitangent X" type="float" cond="(#ARG# #BITAND# 0x411) == 0x411" />
 		<field name="Unused W" type="uint" cond="(#ARG# #BITAND# 0x411) == 0x401" />
@@ -2047,7 +2089,7 @@
 		<field name="Eye Data" type="float" cond="#ARG# #BITAND# 0x100" />
 	</struct>
 
-	<struct name="BSVertexDataSSE" versions="#SSE# #FO4#">
+	<struct name="BSVertexDataSSE" versions="#SSE# #FO4#" module="BSMain">
 		<field name="Vertex" type="Vector3" cond="#ARG# #BITAND# 0x1" />
 		<field name="Bitangent X" type="float" cond="(#ARG# #BITAND# 0x11) == 0x11" />
 		<field name="Unused W" type="uint" cond="(#ARG# #BITAND# 0x11) == 0x1" />
@@ -2062,7 +2104,7 @@
 		<field name="Eye Data" type="float" cond="#ARG# #BITAND# 0x100" />
 	</struct>
 
-    <struct name="SkinPartition" since="V4_2_1_0">
+    <struct name="SkinPartition" since="V4_2_1_0" module="NiMain">
         Skinning data for a submesh, optimized for hardware skinning. Part of NiSkinPartition.
         <field name="Num Vertices" type="ushort">Number of vertices in this submesh.</field>
         <field name="Num Triangles" type="ushort" calc="(#LEN2[Strips]# #GT# 0) #THEN# (#LEN2[Strips]# - 2) #ELSE# (#LEN[Triangles]#)">Number of triangles in this submesh.</field>
@@ -2090,26 +2132,26 @@
 		<field name="Triangles Copy" type="Triangle" length="Num Triangles" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
     </struct>
 
-    <struct name="NiPlane" size="16">
+    <struct name="NiPlane" size="16" module="NiMain">
         A plane.
         <field name="Normal" type="Vector3">The plane normal.</field>
         <field name="Constant" type="float">The plane constant.</field>
     </struct>
 
-    <struct name="NiBoundAABB" size="26">
+    <struct name="NiBoundAABB" size="26" module="NiMain">
         Divinity 2 specific NiBound extension.
         <field name="Num Corners" type="ushort" default="2" />
         <field name="Corners" type="Vector3" length="2">Corners are only non-zero if Num Corners is 2. Hardcoded to 2.</field>
     </struct>
 
-    <struct name="NiBound">
+    <struct name="NiBound" module="NiMain">
         A sphere.
         <field name="Center" type="Vector3">The sphere's center.</field>
         <field name="Radius" type="float">The sphere's radius.</field>
         <field name="DIV2 AABB" type="NiBoundAABB" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
     </struct>
 
-    <struct name="NiCurve3">
+    <struct name="NiCurve3" module="NiMain">
         A 3D curve made up of control points and knots.
         <field name="Degree" type="uint" />
         <field name="Num Control Points" type="uint" />
@@ -2118,14 +2160,14 @@
         <field name="Knots" type="float" length="Num Knots" />
     </struct>
 
-    <struct name="NiQuatTransform">
+    <struct name="NiQuatTransform" module="NiMain">
         <field name="Translation" type="Vector3" />
         <field name="Rotation" type="Quaternion" />
         <field name="Scale" type="float" default="1.0" />
         <field name="TRS Valid" type="bool" length="3" until="10.1.0.109">Whether each transform component is valid.</field>
     </struct>
 
-    <struct name="NiTransform" size="52">
+    <struct name="NiTransform" size="52" module="NiMain">
         <field name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</field>
         <field name="Translation" type="Vector3">The translation vector.</field>
         <field name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</field>
@@ -2147,7 +2189,7 @@
 		<option value="4" name="Lean">Used for lean animations?</option>
 	</enum>
 
-    <struct name="FurniturePosition" versions="#BETHESDA#">
+    <struct name="FurniturePosition" module="BSMain" versions="#BETHESDA#">
         Bethesda Animation. Describes a furniture position?
         <field name="Offset" type="Vector3">Offset of furniture marker.</field>
         <field name="Orientation" type="ushort" vercond="#NI_BS_LTE_FO3#">Furniture marker orientation.</field>
@@ -2158,14 +2200,14 @@
         <field name="Entry Properties" type="FurnitureEntryPoints" vercond="#BS_GT_FO3#" />
     </struct>
 
-    <struct name="TriangleData" versions="#BETHESDA#">
+    <struct name="TriangleData" module="BSHavok" versions="#BETHESDA#">
         Bethesda Havok. A triangle with extra data used for physics.
         <field name="Triangle" type="Triangle">The triangle.</field>
         <field name="Welding Info" type="ushort">Additional havok information on how triangles are welded.</field>
         <field name="Normal" type="Vector3" until="20.0.0.5">This is the triangle's normal.</field>
     </struct>
 
-    <struct name="Morph">
+    <struct name="Morph" module="NiAnimation">
         Geometry morphing data component.
         <field name="Frame Name" type="string" since="10.1.0.106">Name of the frame.</field>
         <field name="Num Keys" type="uint" until="10.1.0.0">The number of morph keys that follow.</field>
@@ -2175,7 +2217,7 @@
         <field name="Vectors" type="Vector3" length="#ARG#">Morph vectors.</field>
     </struct>
 
-    <struct name="NiParticleInfo" size="40">
+    <struct name="NiParticleInfo" size="40" module="NiMain">
         Called NiPerParticleData in NiOldParticles.
         Holds the state of a particle at the time the system was saved.
         <field name="Velocity" type="Vector3">Particle direction and speed.</field>
@@ -2187,7 +2229,7 @@
         <field name="Code" type="ushort">Usually matches array index</field>
     </struct>
 
-    <struct name="BoneData">
+    <struct name="BoneData" module="NiMain">
         NiSkinData::BoneData. Skinning data component.
         <field name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</field>
         <field name="Bounding Sphere" type="NiBound">Note that its a Sphere Containing Axis Aligned Box not a minimum volume Sphere</field>
@@ -2196,7 +2238,7 @@
         <field name="Vertex Weights" type="BoneVertData" length="Num Vertices" since="4.2.2.0" cond="#ARG# != 0">The vertex weights.</field>
     </struct>
 
-    <struct name="HavokFilter" size="4" versions="#BETHESDA#">
+    <struct name="HavokFilter" size="4" module="BSHavok" versions="#BETHESDA#">
         Bethesda Havok. Collision filter info representing Layer, Flags, Part Number, and Group all combined into one uint.
         <field name="Layer" suffix="OB" type="OblivionLayer" default="OL_STATIC" until="20.0.0.5" vercond="#BSVER# #LT# 16">The layer the collision belongs to.</field>
         <field name="Layer" suffix="FO" type="Fallout3Layer" default="FOL_STATIC" vercond="(#VER# == 20.2.0.7) #AND# #NI_BS_LTE_FO3#">The layer the collision belongs to.</field>
@@ -2205,7 +2247,7 @@
         <field name="Group" type="ushort" />
     </struct>
 
-    <struct name="HavokMaterial" versions="#BETHESDA#">
+    <struct name="HavokMaterial" module="BSHavok" versions="#BETHESDA#">
         Bethesda Havok. Material wrapper for varying material enums by game.
         <field name="Unknown Int" type="uint" until="10.0.1.2" />
         <field name="Material" suffix="OB" type="OblivionHavokMaterial" until="20.0.0.5" vercond="#BSVER# #LT# 16">The material of the shape.</field>
@@ -2213,14 +2255,14 @@
         <field name="Material" suffix="SK" type="SkyrimHavokMaterial" vercond="(#VER# == 20.2.0.7) #AND# #BS_GT_FO3#">The material of the shape.</field>
     </struct>
 
-    <struct name="hkSubPartData" versions="#BETHESDA#">
+    <struct name="hkSubPartData" module="BSHavok" versions="#BETHESDA#">
         Bethesda Havok. Havok Information for packed TriStrip shapes.
         <field name="Havok Filter" type="HavokFilter" />
         <field name="Num Vertices" type="uint">The number of vertices that form this sub shape.</field>
         <field name="Material" type="HavokMaterial">The material of the subshape.</field>
     </struct>
 
-    <struct name="hkAabb" versions="#BETHESDA#">
+    <struct name="hkAabb" module="BSHavok" versions="#BETHESDA#">
         Havok AABB using min/max coordinates instead of center/half extents.
         <field name="Min" type="Vector4">Coordinates of the corner with the lowest numerical values.</field>
         <field name="Max" type="Vector4">Coordinates of the corner with the highest numerical values.</field>
@@ -2234,7 +2276,7 @@
         <option value="3" name="PRIORITY_TOI">Constraint is also solved at time of impact events.</option>
     </enum>
 
-    <struct name="bhkConstraintCInfo" size="16" versions="#BETHESDA#">
+    <struct name="bhkConstraintCInfo" size="16" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpConstraintInstance.
         <field name="Num Entities" type="uint" default="2">Always 2 (Hardcoded). Number of bodies affected by this constraint.</field>
         <field name="Entity A" type="Ptr" template="bhkEntity">The entity affected by this constraint.</field>
@@ -2242,14 +2284,14 @@
         <field name="Priority" type="ConstraintPriority" default="PRIORITY_PSI">Either PSI or TOI priority. TOI is higher priority.</field>
     </struct>
 
-    <struct name="bhkConstraintChainCInfo" versions="#BETHESDA#">
+    <struct name="bhkConstraintChainCInfo" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpConstraintChainInstance.
         <field name="Num Chained Entities" type="uint" />
         <field name="Chained Entities" type="Ptr" template="bhkRigidBody" length="Num Chained Entities" />
         <field name="Constraint Info" type="bhkConstraintCInfo" />
     </struct>
 
-    <struct name="bhkPositionConstraintMotor" size="25" versions="#BETHESDA#">
+    <struct name="bhkPositionConstraintMotor" size="25" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpPositionConstraintMotor.
         A motor which tries to reach a desired position/angle given a max force and recovery speed.
         This motor is a good choice for driving a ragdoll to a given pose.
@@ -2262,7 +2304,7 @@
         <field name="Motor Enabled" type="bool" default="0">Is Motor enabled</field>
     </struct>
 
-    <struct name="bhkVelocityConstraintMotor" size="18" versions="#BETHESDA#">
+    <struct name="bhkVelocityConstraintMotor" size="18" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpVelocityConstraintMotor. Tries to reach and keep a desired target velocity.
         <field name="Min Force" type="float" default="-1000000.0">Minimum motor force</field>
         <field name="Max Force" type="float" default="1000000.0">Maximum motor force</field>
@@ -2272,7 +2314,7 @@
         <field name="Motor Enabled" type="bool" default="0">Is Motor enabled</field>
     </struct>
 
-    <struct name="bhkSpringDamperConstraintMotor" size="17" versions="#BETHESDA#">
+    <struct name="bhkSpringDamperConstraintMotor" size="17" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpSpringDamperConstraintMotor.
         Tries to reach a given target position using an angular spring which has a spring constant.
         <field name="Min Force" type="float" default="-1000000.0">Minimum motor force</field>
@@ -2289,7 +2331,7 @@
         <option value="3" name="MOTOR_SPRING" />
     </enum>
 
-    <struct name="bhkConstraintMotorCInfo" versions="#BETHESDA#">
+    <struct name="bhkConstraintMotorCInfo" module="BSHavok" versions="#BETHESDA#">
         hkConstraintCinfo::SaveMotor(). Not a Bethesda extension of hkpConstraintMotor, but a wrapper for its serialization function. 
         <field name="Type" type="hkMotorType" default="MOTOR_NONE" />
         <field name="Position Motor" type="bhkPositionConstraintMotor" cond="Type == 1" />
@@ -2297,7 +2339,7 @@
         <field name="Spring Damper Motor" type="bhkSpringDamperConstraintMotor" cond="Type == 3" />
     </struct>
 
-    <struct name="bhkRagdollConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkRagdollConstraintCInfo" module="BSHavok" versions="#BETHESDA#">
         Serialization data for bhkRagdollConstraint.
         The area of movement can be represented as a main cone + 2 orthogonal cones which may subtract from the main cone volume depending on limits.
         <!-- Oblivion and Fallout 3, Havok 550 -->
@@ -2328,7 +2370,7 @@
         <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
     </struct>
 
-    <struct name="bhkLimitedHingeConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkLimitedHingeConstraintCInfo" module="BSHavok" versions="#BETHESDA#">
         Serialization data for bhkLimitedHingeConstraint.
         This constraint allows rotation about a specified axis, limited by specified boundaries.
     
@@ -2359,7 +2401,7 @@
         <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
     </struct>
 
-    <struct name="bhkHingeConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkHingeConstraintCInfo" module="BSHavok" versions="#BETHESDA#">
         Serialization data for bhkHingeConstraint. A basic hinge with no angular limits or motor.
         <!-- Oblivion -->
         <field name="Pivot A" type="Vector4" until="20.0.0.5">Pivot point around which the object will rotate.</field>
@@ -2379,14 +2421,14 @@
         <field name="Pivot B" type="Vector4" since="20.2.0.7">Pivot A in second entity coordinate system.</field>
     </struct>
 
-    <struct name="bhkBallAndSocketConstraintCInfo" size="32" versions="#BETHESDA#">
+    <struct name="bhkBallAndSocketConstraintCInfo" size="32" module="BSHavok" versions="#BETHESDA#">
         Serialization data for bhkBallAndSocketConstraint.
         Point-to-point constraint that attempts to keep the pivot point of two bodies in the same space.
         <field name="Pivot A" type="Vector4">Constraint pivot in Entity A space.</field>
         <field name="Pivot B" type="Vector4">Constraint pivot in Entity B space.</field>
     </struct>
 
-    <struct name="bhkPrismaticConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkPrismaticConstraintCInfo" module="BSHavok" versions="#BETHESDA#">
         Serialization data for bhkPrismaticConstraint.
         Creates a rail between two bodies that allows translation along a single axis with linear limits and a motor.
         All three rotation axes and the remaining two translation axes are fixed.
@@ -2418,34 +2460,34 @@
         <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
     </struct>
 
-    <struct name="bhkStiffSpringConstraintCInfo" size="36" versions="#BETHESDA#">
+    <struct name="bhkStiffSpringConstraintCInfo" size="36" module="BSHavok" versions="#BETHESDA#">
         bhkStiffSpringConstraint serialization data. Holds two bodies at a specified distance from one another.
         <field name="Pivot A" type="Vector4" />
         <field name="Pivot B" type="Vector4" />
         <field name="Length" type="float" />
     </struct>
 
-    <struct name="OldSkinData" size="18">
+    <struct name="OldSkinData" size="18" module="NiMain">
         Used to store skin weights in NiTriShapeSkinController.
         <field name="Vertex Weight" type="float">The amount that this bone affects the vertex.</field>
         <field name="Vertex Index" type="ushort">The index of the vertex that this weight applies to.</field>
         <field name="Unknown Vector" type="Vector3" />
     </struct>
 
-    <enum name="ImageType" storage="uint">
+    <enum name="ImageType" storage="uint" module="NiMain">
         Determines how the raw image data is stored in NiRawImageData.
         <option value="1" name="RGB">Colors store red, blue, and green components.</option>
         <option value="2" name="RGBA">Colors store red, blue, green, and alpha components.</option>
     </enum>
 
-    <struct name="BoxBV" size="60">
+    <struct name="BoxBV" size="60" module="NiMain">
         Box Bounding Volume
         <field name="Center" type="Vector3" />
         <field name="Axis" type="Vector3" length="3" />
         <field name="Extent" type="Vector3" />
     </struct>
 
-    <struct name="CapsuleBV" size="32">
+    <struct name="CapsuleBV" size="32" module="NiMain">
         Capsule Bounding Volume
         <field name="Center" type="Vector3" />
         <field name="Origin" type="Vector3" />
@@ -2453,12 +2495,12 @@
         <field name="Radius" type="float" />
     </struct>
 
-    <struct name="HalfSpaceBV" size="28">
+    <struct name="HalfSpaceBV" size="28" module="NiMain">
         <field name="Plane" type="NiPlane" />
         <field name="Center" type="Vector3" />
     </struct>
 
-    <struct name="BoundingVolume">
+    <struct name="BoundingVolume" module="NiMain">
         <field name="Collision Type" type="BoundVolumeType">Type of collision data.</field>
         <field name="Sphere" type="NiBound" cond="Collision Type == 0" />
         <field name="Box" type="BoxBV" cond="Collision Type == 1" />
@@ -2467,74 +2509,74 @@
         <field name="Half Space" type="HalfSpaceBV" cond="Collision Type == 5" />
     </struct>
 
-    <struct name="UnionBV">
+    <struct name="UnionBV" module="NiMain">
         <field name="Num BV" type="uint" />
         <field name="Bounding Volumes" type="BoundingVolume" length="Num BV" />
     </struct>
 
-    <struct name="MorphWeight" size="8">
+    <struct name="MorphWeight" size="8" module="NiAnimation">
         <field name="Interpolator" type="Ref" template="NiInterpolator" />
         <field name="Weight" type="float" />
     </struct>
 
-    <struct name="BoneTransform" size="40">
+    <struct name="BoneTransform" size="40" module="BSMain" versions="#FO3_AND_LATER#">
         Transformation data for the bone at this index in bhkPoseArray.
         <field name="Translation" type="Vector3" />
         <field name="Rotation" type="hkQuaternion" />
         <field name="Scale" type="Vector3" />
     </struct>
 
-    <struct name="BonePose" versions="#FO3_AND_LATER#">
+    <struct name="BonePose" module="BSMain" versions="#FO3_AND_LATER#">
         A list of transforms for each bone in bhkPoseArray.
         <field name="Num Transforms" type="uint" />
         <field name="Transforms" type="BoneTransform" length="Num Transforms" />
     </struct>
 
-    <struct name="DecalVectorArray" versions="#FO3_AND_LATER#">
+    <struct name="DecalVectorArray" module="BSMain" versions="#FO3_AND_LATER#">
         Array of Vectors for Decal placement in BSDecalPlacementVectorExtraData.
         <field name="Num Vectors" type="ushort" />
         <field name="Points" type="Vector3" length="Num Vectors">Vector XYZ coords</field>
         <field name="Normals" type="Vector3" length="Num Vectors">Vector Normals</field>
     </struct>
 
-    <bitflags name="BSPartFlag" storage="ushort" versions="#BETHESDA#">
+    <bitflags name="BSPartFlag" storage="ushort" module="BSMain" versions="#BETHESDA#">
         Editor flags for the Body Partitions. 
         <option bit="0" name="PF_EDITOR_VISIBLE">Visible in Editor</option>
         <option bit="8" name="PF_START_NET_BONESET">Start a new shared boneset.  It is expected this BoneSet and the following sets in the Skin Partition will have the same bones.</option>
     </bitflags>
 
-    <struct name="BodyPartList" size="4" versions="#BETHESDA#">
+    <struct name="BodyPartList" size="4" module="BSMain" versions="#BETHESDA#">
         Body part list for DismemberSkinInstance
         <field name="Part Flag" type="BSPartFlag" default="257">Flags related to the Body Partition</field>
         <field name="Body Part" type="BSDismemberBodyPartType">Body Part Index</field>
     </struct>
     
-    <struct name="BoneLOD" size="8" versions="#SKY_AND_LATER#">
+    <struct name="BoneLOD" size="8" module="BSMain" versions="#SKY_AND_LATER#">
         Stores Bone Level of Detail info in a BSBoneLODExtraData
         <field name="Distance" type="uint" />
         <field name="Bone Name" type="NiFixedString" />
     </struct>
 
-    <struct name="bhkMeshMaterial" size="8" versions="#SKY_AND_LATER#">
+    <struct name="bhkMeshMaterial" size="8" module="BSHavok" versions="#SKY_AND_LATER#">
         hkpBSMaterial, a subclass of hkpMeshMaterial. hkpMeshMaterial is a base class for material info for hkMeshShapes.
         <field name="Material" type="SkyrimHavokMaterial" />
         <field name="Filter" type="HavokFilter" />
     </struct>
 
-    <struct name="bhkCMSBigTri" size="12" versions="#SKY_AND_LATER#">
+    <struct name="bhkCMSBigTri" size="12" module="BSHavok" versions="#SKY_AND_LATER#">
         Bethesda extension of hkpCompressedMeshShape::BigTriangle. Triangles that don't fit the maximum size.
         <field name="Triangle" type="Triangle" />
         <field name="Material" type="uint" />
         <field name="Welding Info" type="ushort" />
     </struct>
     
-    <struct name="bhkQsTransform" size="32" versions="#SKY_AND_LATER#">
+    <struct name="bhkQsTransform" size="32" module="BSHavok" versions="#SKY_AND_LATER#">
         Bethesda extension of hkQsTransform. The scale vector is not serialized.
         <field name="Translation" type="Vector4">A vector that moves the chunk by the specified amount. W is not used.</field>
         <field name="Rotation" type="hkQuaternion">Rotation. Reference point for rotation is bhkRigidBody translation.</field>
     </struct>
     
-    <struct name="bhkCMSChunk" versions="#SKY_AND_LATER#">
+    <struct name="bhkCMSChunk" module="BSHavok" versions="#SKY_AND_LATER#">
         Bethesda extension of hkpCompressedMeshShape::Chunk. A compressed chunk of hkpCompressedMeshShape geometry.
         <field name="Translation" type="Vector4" />
         <field name="Material Index" type="uint">Index of material in bhkCompressedMeshShapeData::Chunk Materials</field>
@@ -2550,7 +2592,7 @@
         <field name="Welding Info" type="ushort" length="Num Welding Info" />
     </struct>
 
-    <struct name="bhkMalleableConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkMalleableConstraintCInfo" module="BSHavok" versions="#BETHESDA#">
         bhkMalleableConstraint serialization data. A constraint wrapper used to soften or harden constraints.
         <field name="Type" type="hkConstraintType">Type of constraint.</field>
         <field name="Constraint Info" type="bhkConstraintCInfo" />
@@ -2565,7 +2607,7 @@
         <field name="Strength" type="float" since="20.2.0.7" />
     </struct>
 
-    <struct name="bhkWrappedConstraintData" versions="#BETHESDA#">
+    <struct name="bhkWrappedConstraintData" module="BSHavok" versions="#BETHESDA#">
         A constraint wrapper for polymorphic hkpConstraintData serialization.
         <field name="Type" type="hkConstraintType">Type of constraint.</field>
         <field name="Constraint Info" type="bhkConstraintCInfo" />
@@ -2663,14 +2705,14 @@
         Bethesda class to combine NiObject and hkReferencedObject so that Havok classes can be read/written with NiStream.
     </niobject>
 
-    <struct name="bhkWorldObjCInfoProperty" size="12" versions="#BETHESDA#">
+    <struct name="bhkWorldObjCInfoProperty" size="12" module="BSHavok" versions="#BETHESDA#">
         hkWorldObjectCinfo::Property struct
         <field name="Data" type="uint" default="0" />
         <field name="Size" type="uint" default="0" />
         <field name="Capacity and Flags" type="uint" default="0x80000000" />
     </struct>
 
-    <struct name="bhkWorldObjectCInfo">
+    <struct name="bhkWorldObjectCInfo" module="BSHavok" versions="#BETHESDA#">
         <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Broad Phase Type" type="BroadPhaseType" default="BROAD_PHASE_ENTITY" />
         <field name="Unused 02" type="byte" length="3" binary="true" />
@@ -2709,7 +2751,7 @@
         <field name="Transform" type="Matrix44" />
     </niobject>
 
-    <struct name="bhkEntityCInfo">
+    <struct name="bhkEntityCInfo" module="BSHavok" versions="#BETHESDA#">
         <field name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT">How the body reacts to collisions. See hkResponseType for hkpWorld default implementations.</field>
         <field name="Unused 01" type="byte" />
         <field name="Process Contact Callback Delay" type="ushort" default="0xffff">Lowers the frequency for processContactCallbacks. A value of 5 means that a callback is raised every 5th frame. The default is once every 65535 frames.</field>
@@ -2720,7 +2762,7 @@
         <field name="Entity Info" type="bhkEntityCInfo" />
     </niobject>
 
-    <struct name="bhkRigidBodyCInfo550_660">
+    <struct name="bhkRigidBodyCInfo550_660" module="BSHavok" versions="#BETHESDA#">
         <field name="Unused 01" type="byte" length="4" binary="true" since="10.1.0.0" />
         <field name="Havok Filter" type="HavokFilter" since="10.1.0.0" />
         <field name="Unused 02" type="byte" length="4" binary="true" since="10.1.0.0" />
@@ -2756,7 +2798,7 @@
         <field name="Unused 05" type="byte" length="12" binary="true" />
     </struct>
 
-    <struct name="bhkRigidBodyCInfo2010">
+    <struct name="bhkRigidBodyCInfo2010" module="BSHavok" versions="#BETHESDA#">
         <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Havok Filter" type="HavokFilter" />
         <field name="Unused 02" type="byte" length="4" binary="true" />
@@ -2799,7 +2841,7 @@
         <field name="Unused 04" type="byte" length="12" binary="true" />
     </struct>
 
-    <struct name="bhkRigidBodyCInfo2014">
+    <struct name="bhkRigidBodyCInfo2014" module="BSHavok" versions="#BETHESDA#">
         <field name="Unused 01" type="byte" length="4" binary="true" />
         <field name="Havok Filter" type="HavokFilter" />
         <field name="Unused 02" type="byte" length="12" binary="true" />
@@ -3052,7 +3094,7 @@
         <field name="Shape" type="Ref" template="bhkShape">The shape.</field>
     </niobject>
 
-    <struct name="hkpMoppCode" versions="#BETHESDA#">
+    <struct name="hkpMoppCode" module="BSHavok" versions="#BETHESDA#">
         <field name="Data Size" type="uint">Number of bytes for MOPP data.</field>
         <field name="Offset" type="Vector4" since="10.1.0.0">
             XYZ: Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus 0.1.
@@ -3202,11 +3244,13 @@
         Unlike NiBoolInterpolator, it ensures that keys have not been missed between two updates.
     </niobject>
 
-    <enum name="InterpBlendFlags" storage="byte">
-        <option value="1" name="MANAGER_CONTROLLED">MANAGER_CONTROLLED</option>
-    </enum>
+    <bitflags name="InterpBlendFlags" storage="byte">
+        Flags for NiBlendInterpolator
+        <option bit="0" name="Manager Controlled" />
+        <option bit="1" name="Use Only Highest Weight" />
+    </bitflags>
 
-    <struct name="InterpBlendItem">
+    <struct name="InterpBlendItem" module="NiAnimation">
         Interpolator item for array in NiBlendInterpolator.
         <field name="Interpolator" type="Ref" template="NiInterpolator">Reference to an interpolator.</field>
         <field name="Weight" type="float" />
@@ -3258,7 +3302,7 @@
         <field name="Basis Data" type="Ref" template="NiBSplineBasisData" />
     </niobject>
 
-    <struct name="LegacyExtraData" until="V2_3">
+    <struct name="LegacyExtraData" module="NiLegacy" until="V2_3">
         Extra Data for pre-3.0 versions
         <field name="Has Extra Data" type="bool" />
         <field name="Extra Prop Name" cond="Has Extra Data" type="SizedString" />
@@ -3747,7 +3791,7 @@
         A simple LOD controller for bones.
     </niobject>
     
-    <struct name="MaterialData">
+    <struct name="MaterialData" module="NiMain">
         <field name="Has Shader" type="bool" since="10.0.1.0" until="20.1.0.3">Shader.</field>
         <field name="Shader Name" type="string" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">The shader name.</field>
         <field name="Shader Extra Data" type="int" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">Extra data associated with the shader. A value of -1 means the shader is the default implementation.</field>
@@ -3802,8 +3846,8 @@
         <field name="Material CRC" type="uint" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
         <field name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</field>
         <field name="Normals" type="Vector3" length="Num Vertices" cond="Has Normals">The lighting normals.</field>
-        <field name="Tangents" type="Vector3" length="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Tangent vectors.</field>
-        <field name="Bitangents" type="Vector3" length="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Bitangent vectors.</field>
+        <field name="Tangents" type="Vector3" length="Num Vertices" cond="(Has Normals) #AND# ((Data Flags #BITOR# BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Tangent vectors.</field>
+        <field name="Bitangents" type="Vector3" length="Num Vertices" cond="(Has Normals) #AND# ((Data Flags #BITOR# BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Bitangent vectors.</field>
         <field name="Has DIV2 Floats" type="bool" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
         <field name="DIV2 Floats" type="float" length="Num Vertices" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" cond="Has DIV2 Floats" />
         <field name="Bounding Sphere" type="NiBound" />
@@ -3821,7 +3865,7 @@
 
             Note: for compatibility with NifTexture, set this value to either 0x00000000 or 0xFFFFFFFF.
         </field>
-        <field name="UV Sets" type="TexCoord" length="((Data Flags #BITAND# 63) | (BS Data Flags #BITAND# 1))" width="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</field>
+        <field name="UV Sets" type="TexCoord" length="((Data Flags #BITAND# 63) #BITOR# (BS Data Flags #BITAND# 1))" width="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</field>
         <field name="Consistency Flags" type="ConsistencyType" since="10.0.1.0" default="CT_MUTABLE">Consistency Flags</field>
         <field name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" since="20.0.0.4" />
     </niobject>
@@ -4534,7 +4578,7 @@
         <field name="Percent Data" type="Ref" template="NiFloatData" />
     </niobject>
 
-    <struct name="PixelFormatComponent">
+    <struct name="PixelFormatComponent" module="NiMain">
         <field name="Type" type="PixelComponent">Component Type</field>
         <field name="Convention" type="PixelRepresentation">Data Storage Convention</field>
         <field name="Bits Per Channel" type="byte">Bits per component</field>
@@ -5012,7 +5056,7 @@
         A texture.
     </niobject>
 
-    <struct name="FormatPrefs" size="12">
+    <struct name="FormatPrefs" size="12" module="NiMain">
         NiTexture::FormatPrefs. These preferences are a request to the renderer to use a format the most closely matches the settings and may be ignored.
         <field name="Pixel Layout" type="PixelLayout">Requests the way the image will be stored.</field>
         <field name="Use Mipmaps" type="MipMapFormat" default="MIP_FMT_DEFAULT">Requests if mipmaps are used or not.</field>
@@ -5340,7 +5384,7 @@
         Morrowind-specific node for collision mesh.
     </niobject>
 
-    <niobject name="NiRawImageData" inherit="NiObject" module="NiLegacy" until="V3_1">
+    <niobject name="NiRawImageData" inherit="NiObject" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
         Raw image data.
         <field name="Width" type="uint">Image width</field>
@@ -5480,12 +5524,12 @@
         <option bit="11" name="ENERGY_SLEEP_TEST" />
     </bitflags>
 
-    <struct name="NiPhysXMaterialDescMap" size="6" since="V20_2_0_8">
+    <struct name="NiPhysXMaterialDescMap" size="6" module="NiPhysX" since="V20_2_0_8">
         <field name="Key" type="ushort" />
         <field name="Material" type="Ref" template="NiPhysXMaterialDesc" />
     </struct>
 
-    <struct name="NxCompartmentDescMap" size="20" since="V20_2_0_8">
+    <struct name="NxCompartmentDescMap" size="20" module="NiPhysX" since="V20_2_0_8">
         <field name="ID" type="uint" />
         <field name="Type" type="NxCompartmentType" default="SCT_RIGIDBODY" />
         <field name="Device Code" type="NxDeviceCode" default="CPU" />
@@ -5597,7 +5641,7 @@
         <field name="Dest" type="Ref" template="NiPhysXRigidBodyDest" />
     </niobject>
 
-    <struct name="PhysXBodyStoredVels" since="V20_2_0_8">
+    <struct name="PhysXBodyStoredVels" module="NiPhysX" since="V20_2_0_8">
         <field name="Linear Velocity" type="Vector3" />
         <field name="Angular Velocity" type="Vector3" />
         <field name="Sleep" type="bool" since="30.2.0.3" />
@@ -5654,28 +5698,28 @@
         <option value="2" name="JPM_LINEAR_MINDIST" />
     </enum>
 
-    <struct name="NiPhysXJointActor" size="40" since="V20_2_0_8">
+    <struct name="NiPhysXJointActor" size="40" module="NiPhysX" since="V20_2_0_8">
         <field name="Actor" type="Ref" template="NiPhysXActorDesc" />
         <field name="Local Normal" type="Vector3" />
         <field name="Local Axis" type="Vector3" />
         <field name="Local Anchor" type="Vector3" />
     </struct>
 
-    <struct name="NxJointLimitSoftDesc" size="16" since="V20_2_0_8">
+    <struct name="NxJointLimitSoftDesc" size="16" module="NiPhysX" since="V20_2_0_8">
         <field name="Value" type="float" />
         <field name="Restitution" type="float" />
         <field name="Spring" type="float" />
         <field name="Damping" type="float" />
     </struct>
 
-    <struct name="NxJointDriveDesc" size="16" since="V20_2_0_8">
+    <struct name="NxJointDriveDesc" size="16" module="NiPhysX" since="V20_2_0_8">
         <field name="Drive Type" type="NxD6JointDriveType" />
         <field name="Spring" type="float" />
         <field name="Damping" type="float" />
         <field name="Force Limit" type="float" default="#FLT_MAX#" />
     </struct>
 
-    <struct name="NiPhysXJointLimit" since="V20_2_0_8">
+    <struct name="NiPhysXJointLimit" module="NiPhysX" since="V20_2_0_8">
         <field name="Limit Plane Normal" type="Vector3" />
         <field name="Limit Plane D" type="float" />
         <field name="Limit Plane R" type="float" since="20.4.0.0" />
@@ -5762,12 +5806,12 @@
         <option bit="20" name="SOFTBODY_TWOWAY" />
     </bitflags>
 
-    <struct name="NxPlane" size="16" since="V20_2_0_8">
+    <struct name="NxPlane" size="16" module="NiPhysX" since="V20_2_0_8">
         <field name="Val 1" type="float" />
         <field name="Point 1" type="Vector3" />
     </struct>
 
-    <struct name="NxCapsule" size="12" since="V20_2_0_8">
+    <struct name="NxCapsule" size="12" module="NiPhysX" since="V20_2_0_8">
         <field name="Val 1" type="float" />
         <field name="Val 2" type="float" />
         <field name="Capsule Flags" type="uint" />
@@ -5790,7 +5834,7 @@
         <field name="Sphere Radius" type="float" cond="Shape Type == 1" />
         <field name="Box Half Extents" type="Vector3" cond="Shape Type == 2" />
         <field name="Capsule" type="NxCapsule" cond="Shape Type == 3" />
-        <field name="Mesh" type="Ref" template="NiPhysXMeshDesc" cond="(Shape Type == 5) || (Shape Type == 6)" />
+        <field name="Mesh" type="Ref" template="NiPhysXMeshDesc" cond="(Shape Type == 5) #OR# (Shape Type == 6)" />
     </niobject>
 
     <niobject name="NiPhysXMeshDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5812,7 +5856,7 @@
         <option bit="5" name="DISABLE_STRONG_FRICTION" />
     </bitflags>
 
-    <struct name="NxSpringDesc" size="12" since="V20_2_0_8">
+    <struct name="NxSpringDesc" size="12" module="NiPhysX" since="V20_2_0_8">
         <field name="Spring" type="float" />
         <field name="Damper" type="float" />
         <field name="Target Value" type="float" />
@@ -5825,7 +5869,7 @@
         <option value="3" name="MAX" />
     </enum>
 
-    <struct name="NxMaterialDesc" since="V20_2_0_8">
+    <struct name="NxMaterialDesc" module="NiPhysX" since="V20_2_0_8">
         <field name="Dynamic Friction" type="float" />
         <field name="Static Friction" type="float" />
         <field name="Restitution" type="float" />
@@ -5867,7 +5911,7 @@
         <option bit="18" name="ADHERE" />
     </bitflags>
 
-    <struct name="PhysXClothState" since="V20_2_0_8">
+    <struct name="PhysXClothState" module="NiPhysX" since="V20_2_0_8">
         <field name="Pose" type="Matrix34" />
         <field name="Num Vertex Positions" type="ushort" />
         <field name="Vertex Positions" type="Vector3" length="Num Vertex Positions" />
@@ -5876,13 +5920,13 @@
         <field name="Tear Split Planes" type="Vector3" length="Num Tear Indices" />
     </struct>
 
-    <struct name="PhysXClothAttachmentPosition" since="V20_2_0_8">
+    <struct name="PhysXClothAttachmentPosition" module="NiPhysX" since="V20_2_0_8">
         <field name="Vertex ID" type="uint" />
         <field name="Position" type="Vector3" />
         <field name="Flags" type="uint" />
     </struct>
 
-    <struct name="PhysXClothAttachment" since="V20_2_0_8">
+    <struct name="PhysXClothAttachment" module="NiPhysX" since="V20_2_0_8">
         <field name="Shape" type="Ref" template="NiPhysXShapeDesc" />
         <field name="Num Vertices" type="uint" />
         <field name="Flags" type="uint" cond="Num Vertices == 0" />
@@ -5929,7 +5973,7 @@
         <field name="Attachments" type="PhysXClothAttachment" length="Num Attachments" />
         <field name="Parent Actor" type="Ref" template="NiPhysXActorDesc" />
         <field name="Dest" type="Ref" template="NiPhysXDest" until="20.4.0.9" />
-        <field name="Target Mesh" type="Ref" template="NiMesh" until="20.5.0.0" />
+        <field name="Target Mesh" type="Ref" template="NiMesh" since="20.5.0.0" until="20.5.0.0" />
     </niobject>
 
     <niobject name="NiPhysXDest" abstract="true" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5975,7 +6019,7 @@
         <field name="Lines" type="bool" length="Num Vertices">Is vertex connected to other (next?) vertex?</field>
     </niobject>
 
-    <struct name="Polygon" size="8">
+    <struct name="Polygon" size="8" module="NiMain">
         Two dimensional screen elements.
         <field name="Num Vertices" type="ushort" />
         <field name="Vertex Offset" type="ushort">Offset in vertex array.</field>
@@ -6045,7 +6089,8 @@
         <option value="0" name="SHADER_TALL_GRASS">Tall Grass Shader</option>
         <option value="1" name="SHADER_DEFAULT">Standard Lighting Shader</option>
         <option value="10" name="SHADER_SKY">Sky Shader</option>
-		<option value="14" name="SHADER_SKIN">Skin Shader</option>
+        <option value="14" name="SHADER_SKIN">Skin Shader</option>
+        <option value="15" name="SHADER_UNKNOWN">scolbld06georgetown01</option>
         <option value="17" name="SHADER_WATER">Water Shader</option>
         <option value="29" name="SHADER_LIGHTING30">Lighting 3.0 Shader</option>
         <option value="32" name="SHADER_TILE">Tiled Shader</option>
@@ -6419,7 +6464,7 @@
         <option bit="31" name="Refraction_Writes_Depth" />
     </bitflags>
 
-    <struct name="BSTextureArray" versions="#F76#">
+    <struct name="BSTextureArray" module="BSMain" versions="#F76#">
         <field name="Texture Array Width" type="uint" />
         <field name="Texture Array" type="SizedString" length="Texture Array Width" />
     </struct>
@@ -6456,6 +6501,7 @@
         <option name="GRAYSCALE_TO_PALETTE_ALPHA" value="2901038324" />
         <option name="WEAPON_BLOOD" value="2078326675" />
         <option name="LOD_OBJECTS" value="2896726515" />
+        <option name="NO_EXPOSURE" value="3707406987" />
     </enum>
 
     <struct name="BSSPWetnessParams" module="BSMain" versions="#FO4# #F76#">
@@ -6465,7 +6511,7 @@
         <field name="Env Map Scale" type="float" default="-1.0" vercond="#BS_FO4#" />
         <field name="Fresnel Power" type="float" default="-1.0" />
         <field name="Metalness" type="float" default="-1.0" />
-        <field name="Unknown 1" type="float" default="-1.0" vercond="#BS_F76#" />
+        <field name="Unknown 1" type="float" default="-1.0" vercond="#BS_GT_130#" />
         <field name="Unknown 2" type="float" default="-1.0" vercond="#BS_F76#" />
     </struct>
 
@@ -6484,38 +6530,38 @@
         <field name="Mix Albedo" type="bool" />
     </struct>
 
-    <niobject name="BSLightingShaderProperty" inherit="BSShaderProperty" module="BSMain" versions="#SKY_AND_LATER#">
+    <niobject name="BSLightingShaderProperty" inherit="BSShaderProperty" stopcond="#BSVER# #GTE# 155 #AND# Name" module="BSMain" versions="#SKY_AND_LATER#">
         Bethesda shader property for Skyrim and later.
         <field name="Shader Flags 1" suffix="SK" type="SkyrimShaderPropertyFlags1" vercond="#NI_BS_LT_FO4#" default="0x82400301">Skyrim Shader Flags for setting render/shader options.</field>
         <field name="Shader Flags 2" suffix="SK" type="SkyrimShaderPropertyFlags2" vercond="#NI_BS_LT_FO4#" default="0x8021">Skyrim Shader Flags for setting render/shader options.</field>
         <field name="Shader Flags 1" suffix="FO4" type="Fallout4ShaderPropertyFlags1" vercond="#BS_FO4#" default="0x80400201">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</field>
         <field name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" vercond="#BS_FO4#" default="1">Fallout 4 Shader Flags. Mostly overridden if "Name" is a path to a BGSM/BGEM file.</field>
-        <field name="Shader Type" type="BSLightingShaderType155" vercond="#BS_F76#" />
-        <field name="Num SF1" type="uint" vercond="#BS_F76#" />
-        <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
+        <field name="Shader Type" type="BSShaderType155" vercond="#BS_F76#" />
+        <field name="Num SF1" type="uint" vercond="#BS_GTE_132#" />
+        <field name="Num SF2" type="uint" vercond="#BS_GTE_152#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_GTE_132#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_GTE_152#" />
         <field name="UV Offset" type="TexCoord">Offset UVs</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures, see above.</field>
         <field name="Texture Set" type="Ref" template="BSShaderTextureSet">Texture Set, can have override in an esm/esp</field>
         <field name="Emissive Color" type="Color3" default="#VEC3_ZERO#">Glow color and alpha</field>
         <field name="Emissive Multiple" type="float" default="1.0" range="#F0_10#">Multiplied emissive colors</field>
-        <field name="Root Material" type="NiFixedString" vercond="#BS_GTE_FO4#" />
+        <field name="Root Material" type="NiFixedString" vercond="#BS_GTE_130#" />
         <field name="Texture Clamp Mode" type="TexClampMode" default="WRAP_S_WRAP_T">How to handle texture borders.</field>
         <field name="Alpha" type="float" default="1.0" range="0.0:128.0">The material opacity (1=opaque). Greater than 1.0 is used to affect alpha falloff i.e. staying opaque longer based on vertex alpha and alpha mask.</field>
         <field name="Refraction Strength" type="float" range="#F0_1#">The amount of distortion. **Not based on physically accurate refractive index** (0=none)</field>
         <field name="Glossiness" type="float" default="80.0" range="#F0_999#" vercond="#NI_BS_LT_FO4#">The material specular power, or glossiness.</field>
-        <field name="Smoothness" type="float" default="1.0" range="#F0_1#" vercond="#BS_GTE_FO4#">The base roughness, multiplied by the smoothness map.</field>
+        <field name="Smoothness" type="float" default="1.0" range="#F0_1#" vercond="#BS_GTE_130#">The base roughness, multiplied by the smoothness map.</field>
         <field name="Specular Color" type="Color3" default="#VEC3_ONE#">Adds a colored highlight.</field>
         <field name="Specular Strength" type="float" default="1.0" range="#F0_10#">Brightness of specular highlight. (0=not visible)</field>
         <field name="Lighting Effect 1" type="float" default="0.3" range="#F0_10#" vercond="#NI_BS_LT_FO4#">Controls strength for envmap/backlight/rim/softlight lighting effect?</field>
         <field name="Lighting Effect 2" type="float" default="2.0" range="#F0_1000#" vercond="#NI_BS_LT_FO4#">Controls strength for envmap/backlight/rim/softlight lighting effect?</field>
-        <field name="Subsurface Rolloff" type="float" default="0.0" range="#F0_10#" vercond="#BS_FO4#" />
-        <field name="Rimlight Power" type="float" default="#FLT_MAX#" vercond="#BS_FO4#" />
-        <field name="Backlight Power" type="float" range="#F0_1000#" cond="Rimlight Power == 0x7F7FFFFF" vercond="#BS_FO4#" />
-        <field name="Grayscale to Palette Scale" type="float" default="1.0" range="#F0_1#" vercond="#BS_GTE_FO4#" />
-        <field name="Fresnel Power" type="float" default="5.0" range="#F_PNZ#" vercond="#BS_GTE_FO4#" />
-        <field name="Wetness" type="BSSPWetnessParams" vercond="#BS_GTE_FO4#" />
+        <field name="Subsurface Rolloff" type="float" default="0.0" range="#F0_10#" vercond="#BS_FO4_2#" />
+        <field name="Rimlight Power" type="float" default="#FLT_MAX#" vercond="#BS_FO4_2#" />
+        <field name="Backlight Power" type="float" range="#F0_1000#" cond="Rimlight Power == #FLT_MAX#" vercond="#BS_FO4_2#" />
+        <field name="Grayscale to Palette Scale" type="float" default="1.0" range="#F0_1#" vercond="#BS_GTE_130#" />
+        <field name="Fresnel Power" type="float" default="5.0" range="#F_PNZ#" vercond="#BS_GTE_130#" />
+        <field name="Wetness" type="BSSPWetnessParams" vercond="#BS_GTE_130#" />
         <field name="Luminance" type="BSSPLuminanceParams" vercond="#BS_F76#" />
         <field name="Do Translucency" type="bool" vercond="#BS_F76#" />
         <field name="Translucency" type="BSSPTranslucencyParams" vercond="#BS_F76#" cond="Do Translucency" />
@@ -6523,12 +6569,12 @@
         <field name="Num Texture Arrays" type="uint" vercond="#BS_F76#" cond="Has Texture Arrays" />
         <field name="Texture Arrays" type="BSTextureArray" length="Num Texture Arrays" vercond="#BS_F76#" cond="Has Texture Arrays" />
         <field name="Environment Map Scale" type="float" default="1.0" range="#F0_10#" cond="Shader Type == 1" vercond="#NI_BS_LTE_FO4#">Scales the intensity of the environment/cube map.</field>
-        <field name="Use Screen Space Reflections" type="bool" cond="Shader Type == 1" vercond="#BS_FO4#" />
-        <field name="Wetness Control: Use SSR" type="bool" cond="Shader Type == 1" vercond="#BS_FO4#" />
+        <field name="Use Screen Space Reflections" type="bool" cond="Shader Type == 1" vercond="#BS_FO4_2#" />
+        <field name="Wetness Control: Use SSR" type="bool" cond="Shader Type == 1" vercond="#BS_FO4_2#" />
         <field name="Skin Tint Color" type="Color4" vercond="#BS_F76#" cond="Shader Type == 4" />
         <field name="Hair Tint Color" type="Color3" vercond="#BS_F76#" cond="Shader Type == 5" />
         <field name="Skin Tint Color" type="Color3" default="#VEC3_ONE#" vercond="#NI_BS_LTE_FO4#" cond="Shader Type == 5">Tints the base texture. Overridden by game settings.</field>
-        <field name="Skin Tint Alpha" type="float" default="1.0" vercond="#BS_FO4#" cond="Shader Type == 5" />
+        <field name="Skin Tint Alpha" type="float" default="1.0" vercond="#BS_FO4_2#" cond="Shader Type == 5" />
         <field name="Hair Tint Color" type="Color3" default="#VEC3_ONE#" vercond="#NI_BS_LTE_FO4#" cond="Shader Type == 6">Tints the base texture. Overridden by game settings.</field>
         <field name="Max Passes" type="float" default="4.0" range="1.0:320.0" cond="Shader Type == 7" />
         <field name="Scale" type="float" default="1.0" range="#F0_10#" cond="Shader Type == 7" />
@@ -6542,16 +6588,16 @@
         <field name="Right Eye Reflection Center" type="Vector3" cond="Shader Type == 16">Offset to set center for right eye cubemap</field>
     </niobject>
 
-    <niobject name="BSEffectShaderProperty" inherit="BSShaderProperty" module="BSMain" versions="#SKY_AND_LATER#">
+    <niobject name="BSEffectShaderProperty" inherit="BSShaderProperty" stopcond="#BSVER# #GTE# 155 #AND# Name" module="BSMain" versions="#SKY_AND_LATER#">
         Bethesda effect shader property for Skyrim and later.
         <field name="Shader Flags 1" suffix="SK" type="SkyrimShaderPropertyFlags1" default="0x80000000" vercond="#NI_BS_LT_FO4#" />
         <field name="Shader Flags 2" suffix="SK" type="SkyrimShaderPropertyFlags2" default="0x20" vercond="#NI_BS_LT_FO4#" />
         <field name="Shader Flags 1" suffix="FO4" type="Fallout4ShaderPropertyFlags1" default="0x80000000" vercond="#BS_FO4#" />
         <field name="Shader Flags 2" suffix="FO4" type="Fallout4ShaderPropertyFlags2" default="0x20" vercond="#BS_FO4#" />
-        <field name="Num SF1" type="uint" vercond="#BS_F76#" />
-        <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
+        <field name="Num SF1" type="uint" vercond="#BS_GTE_132#" />
+        <field name="Num SF2" type="uint" vercond="#BS_GTE_152#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_GTE_132#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_GTE_152#" />
         <field name="UV Offset" type="TexCoord">Offset UVs</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures</field>
         <field name="Source Texture"  type="SizedString">points to an external texture.</field>
@@ -6569,10 +6615,10 @@
         <field name="Base Color Scale" type="float" default="1.0" range="0.0:360.0">Multiplier for Base Color (RGB part)</field>
         <field name="Soft Falloff Depth" type="float" default="100.0" range="0.0:9999.0" />
         <field name="Greyscale Texture"  type="SizedString">Points to an external texture, used as palette for SLSF1_Greyscale_To_PaletteColor/SLSF1_Greyscale_To_PaletteAlpha.</field>
-        <field name="Env Map Texture" type="SizedString" vercond="#BS_GTE_FO4#" />
-        <field name="Normal Texture" type="SizedString" vercond="#BS_GTE_FO4#" />
-        <field name="Env Mask Texture" type="SizedString" vercond="#BS_GTE_FO4#" />
-        <field name="Environment Map Scale" type="float" default="1.0" range="0.01:20.0" vercond="#BS_GTE_FO4#" />
+        <field name="Env Map Texture" type="SizedString" vercond="#BS_GTE_130#" />
+        <field name="Normal Texture" type="SizedString" vercond="#BS_GTE_130#" />
+        <field name="Env Mask Texture" type="SizedString" vercond="#BS_GTE_130#" />
+        <field name="Environment Map Scale" type="float" default="1.0" range="0.01:20.0" vercond="#BS_GTE_130#" />
         <field name="Reflectance Texture" type="SizedString" vercond="#BS_F76#" />
         <field name="Lighting Texture" type="SizedString" vercond="#BS_F76#" />
         <field name="Emittance Color" type="Color3" vercond="#BS_F76#" />
@@ -6600,12 +6646,12 @@
     
     <niobject name="BSWaterShaderProperty" inherit="BSShaderProperty" module="BSMain" versions="#SKY_AND_LATER#">
         Skyrim water shader property, different from "WaterShaderProperty" seen in Fallout.
-        <field name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" default="0x80000008" vercond="!#BS_F76#" />
-        <field name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" default="0x21" vercond="!#BS_F76#" />
-        <field name="Num SF1" type="uint" vercond="#BS_F76#" />
-        <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
+        <field name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" default="0x80000008" vercond="!#BS_GTE_132#" />
+        <field name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" default="0x21" vercond="!#BS_GTE_132#" />
+        <field name="Num SF1" type="uint" vercond="#BS_GTE_132#" />
+        <field name="Num SF2" type="uint" vercond="#BS_GTE_152#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_GTE_132#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_GTE_152#" />
         <field name="UV Offset" type="TexCoord">Offset UVs. Seems to be unused, but it fits with the other Skyrim shader properties.</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures, see above.</field>
         <field name="Water Shader Flags" type="WaterShaderPropertyFlags" default="0xC4" />
@@ -6613,12 +6659,12 @@
     
     <niobject name="BSSkyShaderProperty" inherit="BSShaderProperty" module="BSMain" versions="#SKY_AND_LATER#">
         Skyrim Sky shader block.
-        <field name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" default="0x80000000" vercond="!#BS_F76#" />
-        <field name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" default="0x21" vercond="!#BS_F76#" />
-        <field name="Num SF1" type="uint" vercond="#BS_F76#" />
-        <field name="Num SF2" type="uint" vercond="#BS_F76#" />
-        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_F76#" />
-        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_F76#" />
+        <field name="Shader Flags 1" type="SkyrimShaderPropertyFlags1" default="0x80000000" vercond="!#BS_GTE_132#" />
+        <field name="Shader Flags 2" type="SkyrimShaderPropertyFlags2" default="0x21" vercond="!#BS_GTE_132#" />
+        <field name="Num SF1" type="uint" vercond="#BS_GTE_132#" />
+        <field name="Num SF2" type="uint" vercond="#BS_GTE_152#" />
+        <field name="SF1" type="BSShaderCRC32" length="Num SF1" vercond="#BS_GTE_132#" />
+        <field name="SF2" type="BSShaderCRC32" length="Num SF2" vercond="#BS_GTE_152#" />
         <field name="UV Offset" type="TexCoord">Offset UVs. Seems to be unused, but it fits with the other Skyrim shader properties.</field>
         <field name="UV Scale" type="TexCoord" default="#VEC2_ONE#">Offset UV Scale to repeat tiling textures, see above.</field>
         <field name="Source Texture" type="SizedString">points to an external texture.</field>
@@ -6760,8 +6806,8 @@
         <field name="Closest Point Min Distance" type="float">A distance which is used for getClosestPoint(). If the object being tested is closer, the children are recursed. Otherwise it returns this value.</field>
     </niobject>
 
-    <struct name="BSTreadTransform" size="68" versions="#FO3_AND_LATER#">
-        Bethesda-specific struct.
+    <struct name="BSTreadTransform" size="68" module="BSAnimation" versions="#FO3_AND_LATER#">
+        Bethesda-specific class.
         <field name="Name" type="NiFixedString" />
         <field name="Transform 1" type="NiQuatTransform" />
         <field name="Transform 2" type="NiQuatTransform" />
@@ -6842,7 +6888,7 @@
         <field name="Radius" type="float" />
     </niobject>
 
-    <struct name="BSGeometrySubSegment" size="16" versions="#FO3_AND_LATER#">
+    <struct name="BSGeometrySubSegment" size="16" module="BSMain" versions="#FO3_AND_LATER#">
         This is only defined because of recursion issues.
         <field name="Start Index" type="uint" />
         <field name="Num Primitives" type="uint" />
@@ -6850,14 +6896,14 @@
         <field name="Unused" type="uint" />
     </struct>
 
-    <struct name="BSGeometrySegmentData" versions="#FO3_AND_LATER#">
+    <struct name="BSGeometrySegmentData" module="BSMain" versions="#FO3_AND_LATER#">
         Bethesda-specific. Describes groups of triangles either segmented in a grid (for LOD) or by body part for skinned FO4 meshes.
         <field name="Flags" type="byte" vercond="#NI_BS_LT_FO4#" />
         <field name="Start Index" type="uint">Index = previous Index + previous Num Tris in Segment * 3</field>
         <field name="Num Primitives" type="uint">The number of triangles belonging to this segment</field>
-        <field name="Parent Array Index" type="uint" vercond="#BS_GTE_FO4#" />
-        <field name="Num Sub Segments" type="uint" vercond="#BS_GTE_FO4#" />
-        <field name="Sub Segment" type="BSGeometrySubSegment" length="Num Sub Segments" vercond="#BS_GTE_FO4#" />
+        <field name="Parent Array Index" type="uint" vercond="#BS_GTE_130#" />
+        <field name="Num Sub Segments" type="uint" vercond="#BS_GTE_130#" />
+        <field name="Sub Segment" type="BSGeometrySubSegment" length="Num Sub Segments" vercond="#BS_GTE_130#" />
     </struct>
 
     <niobject name="BSSegmentedTriShape" inherit="NiTriShape" module="BSMain" versions="#FO3_AND_LATER#">
@@ -6872,7 +6918,7 @@
         <field name="Extent" type="Vector3">Extent of the AABB in all directions</field>
     </niobject>
 
-    <struct name="NiAGDDataStream">
+    <struct name="NiAGDDataStream" module="NiMain">
         <field name="Type" type="uint">Type of data in this channel</field>
         <field name="Unit Size" type="uint">Number of bytes per element of this channel</field>
         <field name="Total Size" type="uint">Total number of bytes of this channel (num vertices times num bytes per element)</field>
@@ -6882,7 +6928,7 @@
         <field name="Flags" type="NiAGDDataStreamFlags" default="2" />
     </struct>
 
-    <struct name="NiAGDDataBlock">
+    <struct name="NiAGDDataBlock" module="NiMain">
         <field name="Block Size" type="uint" />
         <field name="Num Blocks" type="uint" />
         <field name="Block Offsets" type="uint" length="Num Blocks" />
@@ -6894,7 +6940,7 @@
         <field name="Total Size" type="uint" cond="#ARG# == 1" />
     </struct>
 
-    <struct name="NiAGDDataBlocks">
+    <struct name="NiAGDDataBlocks" module="NiMain">
         <field name="Has Data" type="bool" />
         <field name="Data Block" type="NiAGDDataBlock" cond="Has Data" arg="#ARG#" />
     </struct>
@@ -6976,13 +7022,13 @@
         <field name="Constraint" type="bhkWrappedConstraintData" length="Num Constraints" />
     </niobject>
 
-    <struct name="Region" size="8" since="V20_5_0_0">
+    <struct name="Region" size="8" module="NiMesh" since="V20_5_0_0">
         A range of indices, which make up a region (such as a submesh).
         <field name="Start Index" type="uint" />
         <field name="Num Indices" type="uint" />
     </struct>
 
-    <enum name="CloningBehavior" storage="uint" since="V20_5_0_0">
+    <enum name="CloningBehavior" storage="uint" module="NiMesh" since="V20_5_0_0">
         Sets how objects are to be cloned.
         <option value="0" name="CLONING_SHARE">Share this object pointer with the newly cloned scene.</option>
         <option value="1" name="CLONING_COPY">Create an exact duplicate of this object for use with the newly cloned scene.</option>
@@ -7054,6 +7100,7 @@
         <option value="0x0004013C" name="F_NORMUINT8_4_BGRA"></option>
         <option value="0x0001043D" name="F_NORMINT_10_10_10_2"></option>
         <option value="0x0001043E" name="F_UINT_10_10_10_2"></option>
+        <option value="0x00020240" name="F_UNKNOWN_20240"></option>
     </enum>
 
     <enum name="DataStreamUsage" storage="uint" since="V20_5_0_0">
@@ -7089,7 +7136,7 @@
         <field name="Streamable" type="bool" default="1" />
     </niobject>
 
-    <struct name="SemanticData" size="8" since="V20_5_0_0">
+    <struct name="SemanticData" size="8" module="NiMesh" since="V20_5_0_0">
         <field name="Name" type="NiFixedString">
             Type of data (POSITION, POSITION_BP, INDEX, NORMAL, NORMAL_BP,
             TEXCOORD, BLENDINDICES, BLENDWEIGHT, BONE_PALETTE, COLOR, DISPLAYLIST,
@@ -7102,7 +7149,7 @@
         </field>
     </struct>
 
-    <struct name="DataStreamRef" since="V20_5_0_0">
+    <struct name="DataStreamRef" module="NiMesh" since="V20_5_0_0">
         <field name="Stream" type="Ref" template="NiDataStream">Reference to a data stream object which holds the data used by this reference.</field>
         <field name="Is Per Instance" type="bool" default="0">Sets whether this stream data is per-instance data for use in hardware instancing.</field>
         <field name="Num Submeshes" type="ushort" default="1">The number of submesh-to-region mappings that this data stream has.</field>
@@ -7138,7 +7185,7 @@
         <option value="0x8070" name="SYNC_REFLECTIONS">Synchronize after all data necessary to calculate reflections is ready.</option>
     </enum>
 
-    <niobject name="NiMeshModifier" abstract="true" inherit="NiObject" module="NiMesh">
+    <niobject name="NiMeshModifier" abstract="true" inherit="NiObject" module="NiMesh" since="V20_5_0_0">
         Base class for mesh modifiers.
         <field name="Num Submit Points" type="uint" />
         <field name="Submit Points" type="SyncPoint" length="Num Submit Points">The sync points supported by this mesh modifier for SubmitTasks.</field>
@@ -7146,27 +7193,27 @@
         <field name="Complete Points" type="SyncPoint" length="Num Complete Points">The sync points supported by this mesh modifier for CompleteTasks.</field>
     </niobject>
 
-    <struct name="MeshDataEpicMickey" versions="V20_6_5_0_DEM">
+    <struct name="MeshDataEpicMickey" module="NiMesh" versions="V20_6_5_0_DEM">
         <field name="Unknown 1" type="int" />
         <field name="Unknown 2" type="int" />
         <field name="Unknown 3" type="int" vercond="#USER# #GT# 14" />
-        <field name="Unknown 4" type="int" />
-        <field name="Unknown 5" type="float" />
-        <field name="Unknown 6" type="int" />
+        <field name="Unknown 4" type="int" vercond="#USER# #GT# 3" />
+        <field name="Unknown 5" type="float" vercond="#USER# #GT# 3" />
+        <field name="Unknown 6" type="int" vercond="#USER# #GT# 3" />
     </struct>
 
-    <struct name="WeightDataEpicMickey" size="24" versions="V20_6_5_0_DEM">
+    <struct name="WeightDataEpicMickey" size="24" module="NiMesh" versions="V20_6_5_0_DEM">
         <field name="Bone Indices" type="int" length="3" />
         <field name="Weights" type="float" length="3" />
     </struct>
 
-    <struct name="PartitionDataEpicMickey" size="28" versions="V20_6_5_0_DEM">
+    <struct name="PartitionDataEpicMickey" size="28" module="NiMesh" versions="V20_6_5_0_DEM">
         <field name="Start" type="int" />
         <field name="End" type="int" />
         <field name="Weight Indices" type="ushort" length="10" />
     </struct>
 
-    <struct name="ExtraMeshDataEpicMickey" versions="V20_6_5_0_DEM">
+    <struct name="ExtraMeshDataEpicMickey" module="NiMesh" versions="V20_6_5_0_DEM">
         <field name="Unknown 1" type="uint" />
         <field name="Num Unknown Floats" type="uint" />
         <field name="Unknown Floats 1" type="float" length="Num Unknown Floats" />
@@ -7209,7 +7256,7 @@
         <field name="Target Names" type="NiFixedString" length="Num Targets" />
     </niobject>
 
-    <struct name="ElementReference" size="12" since="V20_5_0_0">
+    <struct name="ElementReference" size="12" module="NiMesh" since="V20_5_0_0">
         <field name="Semantic" type="SemanticData">The element semantic.</field>
         <field name="Normalize Flag" type="uint">Whether or not to normalize the data.</field>
     </struct>
@@ -7260,7 +7307,7 @@
         <field name="Instance Nodes" type="Ref" template="NiMeshHWInstance" length="Num Instance Nodes" cond="Has Instance Nodes" />
     </niobject>
 
-    <struct name="LODInfo">
+    <struct name="LODInfo" module="NiAnimation">
         <field name="Num Bones" type="uint" />
         <field name="Num Active Skins" type="uint" />
         <field name="Skin Indices" type="uint" length="Num Active Skins" />
@@ -7280,7 +7327,7 @@
 
     <!-- NiPS Particle System -->
 
-    <struct name="PSSpawnRateKey" size="8" since="V20_5_0_0">
+    <struct name="PSSpawnRateKey" size="8" module="NiPSParticle" since="V20_5_0_0">
         <field name="Value" type="float" />
         <field name="Time" type="float" />
     </struct>
@@ -7317,9 +7364,9 @@
         <field name="Living Spawner" type="Ref" template="NiPSSpawner" since="20.6.1.0" />
         <field name="Num Spawn Rate Keys" type="byte" since="20.6.1.0" />
         <field name="Spawn Rate Keys" type="PSSpawnRateKey" length="Num Spawn Rate Keys" since="20.6.1.0" />
-        <field name="Pre RPI" type="bool" since="20.6.1.0" />
-        <field name="DEM Unknown Int" type="uint" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
-        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="Pre RPI" type="bool" since="20.6.1.0" vercond="#USER# #EQ# 0 #OR# (#VER# #EQ# 20.6.5.0 #AND# #USER# #GTE# 11)" />
+        <field name="DEM Unknown Int" type="uint" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 11" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 11" />
     </niobject>
 
     <niobject name="NiPSMeshParticleSystem" inherit="NiPSParticleSystem" module="NiPSParticle" since="V20_5_0_0">
@@ -7370,7 +7417,7 @@
         Abstract base class for a single step in the particle system simulation process.  It has no seralized data.
     </niobject>
 
-    <enum name="PSLoopBehavior" since="20.5.0.0" storage="uint" since="V20_5_0_0">
+    <enum name="PSLoopBehavior" storage="uint" since="V20_5_0_0">
         <option name="PS_LOOP_CLAMP_BIRTH" value="0">Key times map such that the first key occurs at the birth of the particle, and times later than the last key get the last key value.</option>
         <option name="PS_LOOP_CLAMP_DEATH" value="1">Key times map such that the last key occurs at the death of the particle, and times before the initial key time get the value of the initial key.</option>
         <option name="PS_LOOP_AGESCALE" value="2">Scale the animation to fit the particle lifetime, so that the first key is age zero, and the last key comes at the particle death.</option>
@@ -7393,7 +7440,7 @@
         <field name="Shrink Time" type="float">The the amount of time over which a particle's size is ramped from 1.0 to 0.0 in seconds</field>
         <field name="Grow Generation" type="ushort">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</field>
         <field name="Shrink Generation" type="ushort">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system, so that particles will shrink immediately before getting killed.</field>
-        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 14" />
     </niobject>
 
     <niobject name="NiPSSimulatorForcesStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
@@ -7508,9 +7555,9 @@
 
     <niobject name="NiPSGravityFieldForce" inherit="NiPSFieldForce" module="NiPSParticle" since="V20_5_0_0">
         Inside a field, updates particle velocity to simulate the effects of directional gravity.
-        <field name="DEM Unknown Short" type="ushort" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Short" type="ushort" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 14" />
         <field name="Direction" type="Vector3" default="#X_AXIS#" />
-        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 14" />
     </niobject>
 
     <niobject name="NiPSDragFieldForce" inherit="NiPSFieldForce" module="NiPSParticle" since="V20_5_0_0">
@@ -7522,6 +7569,7 @@
     <niobject name="NiPSRadialFieldForce" inherit="NiPSFieldForce" module="NiPSParticle" since="V20_5_0_0">
         Inside a field, updates particle velocity to simulate the effects of point gravity.
         <field name="Radial Factor" type="float" />
+        <field name="DEM Unknown Int" type="uint" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 14" />
     </niobject>
 
     <niobject name="NiPSTurbulenceFieldForce" inherit="NiPSFieldForce" module="NiPSParticle" since="V20_5_0_0">
@@ -7563,7 +7611,7 @@
 
     <niobject name="NiPSVolumeEmitter" abstract="true" inherit="NiPSEmitter" module="NiPSParticle" since="V20_5_0_0">
         Abstract base class for particle emitters that emit particles from a volume.
-        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GTE# 11" />
         <field name="Emitter Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
@@ -8128,11 +8176,11 @@
         <field name="Shader Property" type="Ref" template="BSShaderProperty" />
         <field name="Alpha Property" type="Ref" template="NiAlphaProperty" />
         <field name="Vertex Desc" type="BSVertexDesc" />
-        <field name="Num Triangles" type="uint" vercond="#BS_GTE_FO4#" />
+        <field name="Num Triangles" type="uint" vercond="#BS_GTE_130#" />
         <field name="Num Triangles" type="ushort" vercond="#NI_BS_LT_FO4#" />
         <field name="Num Vertices" type="ushort" />
         <field name="Data Size" type="uint" calc="((Vertex Desc #BITAND# 0xF) #MUL# Num Vertices #MUL# 4) #ADD# (Num Triangles #MUL# 6)" />
-        <field name="Vertex Data" type="BSVertexData" length="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_GTE_FO4#" />
+        <field name="Vertex Data" type="BSVertexData" length="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_GTE_130#" />
         <field name="Vertex Data" type="BSVertexDataSSE" length="Num Vertices" arg="Vertex Desc #RSH# 44" cond="Data Size #GT# 0" vercond="#BS_SSE#" />
         <field name="Triangles" type="Triangle" length="Num Triangles" cond="Data Size #GT# 0" />
         <field name="Particle Data Size" type="uint" calc="(Num Vertices #MUL# 6) #ADD# (Num Triangles #MUL# 3)" vercond="#BS_SSE#" />
@@ -8148,14 +8196,14 @@
         <field name="LOD2 Size" type="uint" />
     </niobject>
     
-    <struct name="BSGeometryPerSegmentSharedData" size="16" versions="#FO4# #F76#">
+    <struct name="BSGeometryPerSegmentSharedData" size="16" module="BSMain" versions="#FO4# #F76#">
         <field name="User Index" type="uint">If Bone ID is 0xffffffff, this value refers to the Segment at the listed index. Otherwise this is the "Biped Object", which is like the body part types in Skyrim and earlier.</field>
         <field name="Bone ID" type="uint" default="#UINT_MAX#">A hash of the bone name string.</field>
         <field name="Num Cut Offsets" type="uint" range="0:8">Maximum of 8.</field>
         <field name="Cut Offsets" type="float" length="Num Cut Offsets" />
     </struct>
 
-    <struct name="BSGeometrySegmentSharedData" versions="#FO4# #F76#">
+    <struct name="BSGeometrySegmentSharedData" module="BSMain" versions="#FO4# #F76#">
         <field name="Num Segments" type="uint" />
         <field name="Total Segments" type="uint" />
         <field name="Segment Starts" type="uint" length="Num Segments" />
@@ -8165,11 +8213,11 @@
 
     <niobject name="BSSubIndexTriShape" inherit="BSTriShape" module="BSMain" versions="#SSE# #FO4# #F76#">
         Fallout 4 Sub-Index Tri Shape
-		<field name="Num Primitives" type="uint" calc="#LEN[Triangles]#" vercond="#BS_GTE_FO4#" cond="Data Size #GT# 0" />
-		<field name="Num Segments" type="uint" vercond="#BS_GTE_FO4#" cond="Data Size #GT# 0" />
-		<field name="Total Segments" type="uint" vercond="#BS_GTE_FO4#" cond="Data Size #GT# 0" />
-		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_GTE_FO4#" length="Num Segments" cond="Data Size #GT# 0" />
-		<field name="Segment Data" type="BSGeometrySegmentSharedData" vercond="#BS_GTE_FO4#" cond="(Num Segments #LT# Total Segments) #AND# (Data Size #GT# 0)" />
+		<field name="Num Primitives" type="uint" calc="#LEN[Triangles]#" vercond="#BS_GTE_130#" cond="Data Size #GT# 0" />
+		<field name="Num Segments" type="uint" vercond="#BS_GTE_130#" cond="Data Size #GT# 0" />
+		<field name="Total Segments" type="uint" vercond="#BS_GTE_130#" cond="Data Size #GT# 0" />
+		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_GTE_130#" length="Num Segments" cond="Data Size #GT# 0" />
+		<field name="Segment Data" type="BSGeometrySegmentSharedData" vercond="#BS_GTE_130#" cond="(Num Segments #LT# Total Segments) #AND# (Data Size #GT# 0)" />
 		<field name="Num Segments" type="uint" vercond="#BS_SSE#" />
 		<field name="Segment" type="BSGeometrySegmentData" vercond="#BS_SSE#" length="Num Segments" />
     </niobject>
@@ -8210,7 +8258,7 @@
     
     <!-- Fallout 4 Skeleton -->
 
-    <struct name="BSSkinBoneTrans" size="68" versions="#FO4# #F76#">
+    <struct name="BSSkinBoneTrans" size="68" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Bone Transform
         <field name="Bounding Sphere" type="NiBound" />
         <field name="Rotation" type="Matrix33" />
@@ -8240,7 +8288,7 @@
         <field name="Data" type="hfloat" length="Num Data" />
     </niobject>
 
-    <struct name="BSConnectPoint" versions="#FO4# #F76#">
+    <struct name="BSConnectPoint" module="BSMain" versions="#FO4# #F76#">
         <field name="Parent" type="SizedString" default="WorkshopConnectPoints" />
         <field name="Name" type="SizedString" />
         <field name="Rotation" type="Quaternion" />
@@ -8267,13 +8315,13 @@
         <field name="Data" type="float" length="Num Data" />
     </niobject>
 	
-    <struct name="BSPackedGeomDataCombined" size="72" versions="#FO4# #F76#">
+    <struct name="BSPackedGeomDataCombined" size="72" module="BSMain" versions="#FO4# #F76#">
         <field name="Grayscale to Palette Scale" type="float" />
         <field name="Transform" type="NiTransform" />
         <field name="Bounding Sphere" type="NiBound" />
     </struct>
 
-    <struct name="BSPackedGeomData" versions="#FO4# #F76#">
+    <struct name="BSPackedGeomData" module="BSMain" versions="#FO4# #F76#">
         <field name="Num Verts" type="uint" />
         <field name="LOD Levels" type="uint" />
         <field name="Tri Count LOD0" type="uint" />
@@ -8289,7 +8337,7 @@
         <field name="Triangles" type="Triangle" length="Tri Count LOD0 + Tri Count LOD1 + Tri Count LOD2" />
     </struct>
 
-    <struct name="BSPackedSharedGeomData" versions="#FO4# #F76#">
+    <struct name="BSPackedSharedGeomData" module="BSMain" versions="#FO4# #F76#">
         <field name="Num Verts" type="uint" />
         <field name="LOD Levels" type="uint" />
         <field name="Tri Count LOD0" type="uint" />
@@ -8303,7 +8351,7 @@
         <field name="Vertex Desc" type="BSVertexDesc" />
     </struct>
 
-    <struct name="BSPackedGeomObject" size="8" versions="#FO4# #F76#">
+    <struct name="BSPackedGeomObject" size="8" module="BSMain" versions="#FO4# #F76#">
         This is the data necessary to access the shared geometry in a PSG/CSG file.
         <field name="Filename Hash" type="uint">BSCRC32 of the filename without the PSG/CSG extension.</field>
         <field name="Data Offset" type="uint">Offset of the geometry data in the PSG/CSG file.</field>
@@ -8357,15 +8405,28 @@
         <field name="Distant Object Flags" type="uint" />
     </niobject>
 
-    <struct name="BSDistantObjectInstance" module="BSMain" versions="#F76#">
-        <field name="Unknown Bytes 1" type="byte" length="12" />
-        <field name="Num Unknown 1" type="uint" />
-        <field name="Unknown Ints 1" type="uint" length="3 #MUL# Num Unknown 1" />
-        <field name="Num Unknown 2" type="uint" />
-        <field name="Unknown Bytes 2" type="byte" binary="true" length="64 #MUL# Num Unknown 2" />
+    <!-- FO76 -->
+
+    <struct name="BSResourceID" module="BSMain" size="12" versions="#F76#">
+        <field name="File Hash" type="uint" />
+        <field name="Extension" type="char" length="4" />
+        <field name="Directory Hash" type="uint" />
     </struct>
 
-    <struct name="BSDistantObjectTextureArray" module="BSMain" versions="#F76#">
+    <struct name="BSDistantObjectUnknown" module="BSMain" size="12" versions="#F76#">
+        <field name="Unknown 1" type="uint64" />
+        <field name="Unknown 2" type="uint" />
+    </struct>
+
+    <struct name="BSDistantObjectInstance" module="BSMain" versions="#F76#">
+        <field name="Resource ID" type="BSResourceID" />
+        <field name="Num Unknown Data" type="uint" />
+        <field name="Unknown Data" type="BSDistantObjectUnknown" length="Num Unknown Data" />
+        <field name="Num Transforms" type="uint" />
+        <field name="Transforms" type="Matrix44" length="Num Transforms" />
+    </struct>
+
+    <struct name="BSShaderTextureArray" module="BSMain" versions="#F76#">
         <field name="Unknown Byte" type="byte" default="1" />
         <field name="Num Texture Arrays" type="uint" />
         <field name="Texture Arrays" type="BSTextureArray" length="Num Texture Arrays" />
@@ -8374,7 +8435,12 @@
     <niobject name="BSDistantObjectInstancedNode" inherit="BSMultiBoundNode" module="BSMain" versions="#F76#">
         <field name="Num Instances" type="uint" />
         <field name="Instances" type="BSDistantObjectInstance" length="Num Instances" />
-        <field name="Texture Arrays" type="BSDistantObjectTextureArray" length="3" />
+        <field name="Texture Arrays" type="BSShaderTextureArray" length="3" />
+    </niobject>
+
+    <niobject name="BSCollisionQueryProxyExtraData" inherit="BSExtraData" module="BSMain" versions="#F76#">
+        Fallout 76 Collision Query Proxy Data
+        <field name="Binary Data" type="ByteArray" />
     </niobject>
 
 </niftoolsxml>

--- a/nif.xml
+++ b/nif.xml
@@ -128,7 +128,7 @@
     </token>
 
     <token name="verset" attrs="versions">
-        The set of versions that any Basic, Compound, NiObject, Enum, or Bitflags is restricted to.
+        The set of versions that any Basic, Struct, NiObject, Enum, or Bitflags is restricted to.
         <verset token="#BETHESDA#" string="V10_0_1_2 V10_1_0_101 V10_1_0_106 V10_2_0_0__10 V20_0_0_4__10 V20_0_0_4__11 V20_0_0_5_OBL V20_2_0_7__11_1 V20_2_0_7__11_2 V20_2_0_7__11_3 V20_2_0_7__11_4 V20_2_0_7__11_5 V20_2_0_7__11_6 V20_2_0_7__11_7 V20_2_0_7__11_8 V20_2_0_7_FO3 V20_2_0_7_SKY V20_2_0_7_SSE V20_2_0_7_FO4 V20_2_0_7_F76" />
         <verset token="#FO3#" string="V20_0_0_4__11 V20_2_0_7__11_1 V20_2_0_7__11_2 V20_2_0_7__11_3 V20_2_0_7__11_4 V20_2_0_7__11_5 V20_2_0_7__11_6 V20_2_0_7__11_7 V20_2_0_7__11_8 V20_2_0_7_FO3" />
         <verset token="#SKY#" string="V20_2_0_7_SKY" />
@@ -319,7 +319,7 @@
     
     <!--Enumerations
         These are like C enums and consist of a list of options.  They can appear
-        as parts of compounds or niobjects.-->
+        as parts of structs or niobjects.-->
 
     <bitflags name="AccumFlags" storage="uint">
         Describes the options for the accum root on NiControllerSequence.
@@ -1568,163 +1568,163 @@
     </bitfield>
 
 
-    <!--Compounds
+    <!--Structs
         These are like C structures and are used as sub-parts of more complex
         classes when there are multiple pieces of data repeated in an array.-->
 
-    <compound name="SizedString">
+    <struct name="SizedString">
         A string of given length.
         <field name="Length" type="uint">The string length.</field>
         <field name="Value" type="char" arr1="Length">The string itself.</field>
-    </compound>
+    </struct>
 
-    <compound name="SizedString16">
+    <struct name="SizedString16">
         A string of given length, using a ushort to store string length.
         <field name="Length" type="ushort">The string length.</field>
         <field name="Value" type="char" arr1="Length">The string itself.</field>
-    </compound>
+    </struct>
 
-    <compound name="string">
+    <struct name="string">
         A string type.
         <field name="String" type="SizedString" until="20.0.0.5">The normal string.</field>
         <field name="Index" type="NiFixedString" since="20.1.0.3">The string index.</field>
-    </compound>
+    </struct>
 
-    <compound name="NiTFixedStringMapItem" generic="true">
+    <struct name="NiTFixedStringMapItem" generic="true">
         Currently, #T# must be a basic type due to nif.xml restrictions.
         <field name="String" type="NiFixedString" />
         <field name="Value" type="#T#" />
-    </compound>
+    </struct>
 
-    <compound name="NiTFixedStringMap" generic="true">
+    <struct name="NiTFixedStringMap" generic="true">
         A mapping or hash table between NiFixedString keys and a generic value.
         Currently, #T# must be a basic type due to nif.xml restrictions.
         <field name="Num Strings" type="uint" />
         <field name="Strings" type="NiTFixedStringMapItem" template="#T#" arr1="Num Strings" />
-    </compound>
+    </struct>
 
-    <compound name="ByteArray">
+    <struct name="ByteArray">
         An array of bytes.
         <field name="Data Size" type="uint">The number of bytes in this array</field>
         <field name="Data" type="byte" arr1="Data Size">The bytes which make up the array</field>
-    </compound>
+    </struct>
 
-    <compound name="ByteMatrix">
+    <struct name="ByteMatrix">
         An array of bytes.
         <field name="Data Size 1" type="uint">The number of bytes in this array</field>
         <field name="Data Size 2" type="uint">The number of bytes in this array</field>
         <field name="Data" type="byte" arr1="Data Size 2" arr2="Data Size 1">The bytes which make up the array</field>
-    </compound>
+    </struct>
 
-    <compound name="Color3" size="12">
+    <struct name="Color3" size="12">
         A color without alpha (red, green, blue).
         <field name="r" type="float">Red color component.</field>
         <field name="g" type="float">Green color component.</field>
         <field name="b" type="float">Blue color component.</field>
-    </compound>
+    </struct>
 
-    <compound name="ByteColor3" size="3" convertible="Color3">
+    <struct name="ByteColor3" size="3" convertible="Color3">
         A color without alpha (red, green, blue).
         <field name="r" type="byte">Red color component.</field>
         <field name="g" type="byte">Green color component.</field>
         <field name="b" type="byte">Blue color component.</field>
-    </compound>
+    </struct>
 
-    <compound name="Color4" size="16">
+    <struct name="Color4" size="16">
         A color with alpha (red, green, blue, alpha).
         <field name="r" type="float">Red component.</field>
         <field name="g" type="float">Green component.</field>
         <field name="b" type="float">Blue component.</field>
         <field name="a" type="float">Alpha.</field>
-    </compound>
+    </struct>
 
-    <compound name="ByteColor4" size="4" convertible="Color4">
+    <struct name="ByteColor4" size="4" convertible="Color4">
         A color with alpha (red, green, blue, alpha).
         <field name="r" type="byte">Red color component.</field>
         <field name="g" type="byte">Green color component.</field>
         <field name="b" type="byte">Blue color component.</field>
         <field name="a" type="byte">Alpha color component.</field>
-    </compound>
+    </struct>
 
-    <compound name="FilePath">
+    <struct name="FilePath">
         A string that contains the path to a file.
         <field name="String" type="SizedString" until="20.0.0.5">The normal string.</field>
         <field name="Index" type="NiFixedString" since="20.1.0.3">The string index.</field>
-    </compound>
+    </struct>
 
-    <compound name="Footer">
+    <struct name="Footer">
         The NIF file footer.
         <field name="Num Roots" type="uint" since="3.3.0.13">The number of root references.</field>
         <field name="Roots" type="Ref" template="NiObject" arr1="Num Roots" since="3.3.0.13">List of root NIF objects. If there is a camera, for 1st person view, then this NIF object is referred to as well in this list, even if it is not a root object (usually we want the camera to be attached to the Bip Head node).</field>
-    </compound>
+    </struct>
 
-    <compound name="LODRange">
+    <struct name="LODRange">
         The distance range where a specific level of detail applies.
         <field name="Near Extent" type="float">Begining of range.</field>
         <field name="Far Extent" type="float">End of Range.</field>
         <field name="Unknown Ints" type="uint" arr1="3" until="3.1" />
-    </compound>
+    </struct>
 
-    <compound name="MatchGroup">
+    <struct name="MatchGroup">
         Group of vertex indices of vertices that match.
         <field name="Num Vertices" type="ushort">Number of vertices in this group.</field>
         <field name="Vertex Indices" type="ushort" arr1="Num Vertices">The vertex indices.</field>
-    </compound>
+    </struct>
     
-    <compound name="Vector3" size="12">
+    <struct name="Vector3" size="12">
         A vector in 3D space (x,y,z).
         <field name="x" type="float">First coordinate.</field>
         <field name="y" type="float">Second coordinate.</field>
         <field name="z" type="float">Third coordinate.</field>
-    </compound>
+    </struct>
     
-    <compound name="HalfVector3" size="6" convertible="Vector3">
+    <struct name="HalfVector3" size="6" convertible="Vector3">
         A vector in 3D space (x,y,z).
         <field name="x" type="hfloat">First coordinate.</field>
         <field name="y" type="hfloat">Second coordinate.</field>
         <field name="z" type="hfloat">Third coordinate.</field>
-    </compound>
+    </struct>
 
-    <compound name="ByteVector3" size="3" convertible="Vector3">
+    <struct name="ByteVector3" size="3" convertible="Vector3">
         A vector in 3D space (x,y,z).
         <field name="x" type="byte">First coordinate.</field>
         <field name="y" type="byte">Second coordinate.</field>
         <field name="z" type="byte">Third coordinate.</field>
-    </compound>
+    </struct>
 
-    <compound name="Vector4" size="16">
+    <struct name="Vector4" size="16">
         A 4-dimensional vector.
         <field name="x" type="float">First coordinate.</field>
         <field name="y" type="float">Second coordinate.</field>
         <field name="z" type="float">Third coordinate.</field>
         <field name="w" type="float">Fourth coordinate.</field>
-    </compound>
+    </struct>
 
-    <compound name="Quaternion" size="16">
+    <struct name="Quaternion" size="16">
         A quaternion.
         <field name="w" type="float" default="1.0">The w-coordinate.</field>
         <field name="x" type="float" default="0.0">The x-coordinate.</field>
         <field name="y" type="float" default="0.0">The y-coordinate.</field>
         <field name="z" type="float" default="0.0">The z-coordinate.</field>
-    </compound>
+    </struct>
 
-    <compound name="hkQuaternion" size="16" versions="#BETHESDA#">
+    <struct name="hkQuaternion" size="16" versions="#BETHESDA#">
         A quaternion as it appears in the havok objects.
         <field name="x" type="float" default="0.0">The x-coordinate.</field>
         <field name="y" type="float" default="0.0">The y-coordinate.</field>
         <field name="z" type="float" default="0.0">The z-coordinate.</field>
         <field name="w" type="float" default="1.0">The w-coordinate.</field>
-    </compound>
+    </struct>
 
-    <compound name="Matrix22" size="16">
+    <struct name="Matrix22" size="16">
         A 2x2 matrix of float values.  Stored in OpenGL column-major format.
         <field name="m11" type="float" default="1.0">Member 1,1 (top left)</field>
         <field name="m21" type="float" default="0.0">Member 2,1 (bottom left)</field>
         <field name="m12" type="float" default="0.0">Member 1,2 (top right)</field>
         <field name="m22" type="float" default="1.0">Member 2,2 (bottom right)</field>
-    </compound>
+    </struct>
 
-    <compound name="Matrix33" size="36">
+    <struct name="Matrix33" size="36">
         A 3x3 rotation matrix; M^T M=identity, det(M)=1.    Stored in OpenGL column-major format.
         <field name="m11" type="float" default="1.0">Member 1,1 (top left)</field>
         <field name="m21" type="float" default="0.0">Member 2,1</field>
@@ -1735,9 +1735,9 @@
         <field name="m13" type="float" default="0.0">Member 1,3 (top right)</field>
         <field name="m23" type="float" default="0.0">Member 2,3</field>
         <field name="m33" type="float" default="1.0">Member 3,3 (bottom left)</field>
-    </compound>
+    </struct>
 
-    <compound name="Matrix34" size="48">
+    <struct name="Matrix34" size="48">
         A 3x4 transformation matrix.
         <field name="m11" type="float" default="1.0">The (1,1) element.</field>
         <field name="m21" type="float" default="0.0">The (2,1) element.</field>
@@ -1751,9 +1751,9 @@
         <field name="m14" type="float" default="0.0">The (1,4) element.</field>
         <field name="m24" type="float" default="0.0">The (2,4) element.</field>
         <field name="m34" type="float" default="0.0">The (3,4) element.</field>
-    </compound>
+    </struct>
 
-    <compound name="Matrix44" size="64">
+    <struct name="Matrix44" size="64">
         A 4x4 transformation matrix.
         <field name="m11" type="float" default="1.0">The (1,1) element.</field>
         <field name="m21" type="float" default="0.0">The (2,1) element.</field>
@@ -1771,9 +1771,9 @@
         <field name="m24" type="float" default="0.0">The (2,4) element.</field>
         <field name="m34" type="float" default="0.0">The (3,4) element.</field>
         <field name="m44" type="float" default="1.0">The (4,4) element.</field>
-    </compound>
+    </struct>
 
-    <compound name="hkMatrix3" size="48" versions="#BETHESDA#">
+    <struct name="hkMatrix3" size="48" versions="#BETHESDA#">
         A 3x3 Havok matrix stored in 4x3 due to memory alignment.
         <field name="m11" type="float" default="1.0" />
         <field name="m12" type="float" />
@@ -1787,52 +1787,52 @@
         <field name="m32" type="float" />
         <field name="m33" type="float" default="1.0" />
         <field name="m34" type="float">Unused</field>
-    </compound>
+    </struct>
 
-    <compound name="MipMap" size="12">
+    <struct name="MipMap" size="12">
         Description of a mipmap within an NiPixelData object.
         <field name="Width" type="uint">Width of the mipmap image.</field>
         <field name="Height" type="uint">Height of the mipmap image.</field>
         <field name="Offset" type="uint">Offset into the pixel data array where this mipmap starts.</field>
-    </compound>
+    </struct>
 
-    <compound name="NodeSet">
+    <struct name="NodeSet">
         A set of NiNode references.
         <field name="Num Nodes" type="uint">Number of node references that follow.</field>
         <field name="Nodes" type="Ptr" template="NiNode" arr1="Num Nodes">The list of NiNode references.</field>
-    </compound>
+    </struct>
 
-    <compound name="ExportString">
+    <struct name="ExportString">
         Specific to Bethesda-specific header export strings.
         <field name="Length" type="byte">The string length.</field>
         <field name="Value" type="char" arr1="Length">The string itself, null terminated (the null terminator is taken into account in the length byte).</field>
-    </compound>
+    </struct>
 
-    <compound name="SkinInfo" size="8" since="V4_2_2_0">
+    <struct name="SkinInfo" size="8" since="V4_2_2_0">
         NiBoneLODController::SkinInfo. Reference to shape and skin instance.
         <field name="Shape" type="Ptr" template="NiTriBasedGeom" />
         <field name="Skin Instance" type="Ref" template="NiSkinInstance" />
-    </compound>
+    </struct>
 
-    <compound name="SkinInfoSet" since="V4_2_2_0">
+    <struct name="SkinInfoSet" since="V4_2_2_0">
         A set of NiBoneLODController::SkinInfo.
         <field name="Num Skin Info" type="uint" />
         <field name="Skin Info" type="SkinInfo" arr1="Num Skin Info" />
-    </compound>
+    </struct>
 
-    <compound name="BoneVertData" size="6">
+    <struct name="BoneVertData" size="6">
         NiSkinData::BoneVertData. A vertex and its weight.
         <field name="Index" type="ushort">The vertex index, in the mesh.</field>
         <field name="Weight" type="float" range="#F0_1#">The vertex weight - between 0.0 and 1.0</field>
-    </compound>
+    </struct>
 
-    <compound name="AVObject">
+    <struct name="AVObject">
         Used in NiDefaultAVObjectPalette.
         <field name="Name" type="SizedString">Object name.</field>
         <field name="AV Object" type="Ptr" template="NiAVObject">Object reference.</field>
-    </compound>
+    </struct>
 
-    <compound name="ControlledBlock">
+    <struct name="ControlledBlock">
         In a .kf file, this links to a controllable object, via its name (or for version 10.2.0.0 and up, a link and offset to a NiStringPalette that contains the name), and a sequence of interpolators that apply to this controllable object, via links.
         For Controller ID, NiInterpController::GetCtlrID() virtual function returns a string formatted specifically for the derived type.
         For Interpolator ID, NiInterpController::GetInterpolatorID() virtual function returns a string formatted specifically for the derived type.
@@ -1863,9 +1863,9 @@
         <field name="Controller Type" type="string" since="20.1.0.1">The RTTI type of the NiTimeController.</field>
         <field name="Controller ID" type="string" since="20.1.0.1">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
         <field name="Interpolator ID" type="string" since="20.1.0.1">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
-    </compound>
+    </struct>
 
-    <compound name="BSStreamHeader" versions="#BETHESDA#">
+    <struct name="BSStreamHeader" versions="#BETHESDA#">
     	Information about how the file was exported
         <field name="BS Version" type="ulittle32" />
         <field name="Author" type="ExportString" />
@@ -1873,10 +1873,10 @@
         <field name="Process Script" type="ExportString" />
         <field name="Export Script" type="ExportString" />
         <field name="Max Filepath" type="ExportString" cond="BS Version == 130" />
-    </compound>
+    </struct>
 
     <!-- Don't use vercond in Header, it breaks niflib -->
-    <compound name="Header">
+    <struct name="Header">
         The NIF file header.
         <field name="Header String" type="HeaderString">'NetImmerse File Format x.x.x.x' (versions &lt;= 10.0.1.2) or 'Gamebryo File Format x.x.x.x' (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</field>
         <field name="Copyright" type="LineString" arr1="3" until="3.1.0.0" />
@@ -1896,56 +1896,56 @@
         <field name="Strings" type="SizedString" arr1="Num Strings" since="20.1.0.1">Strings.</field>
         <field name="Num Groups" type="uint" default="0" since="5.0.0.6" />
         <field name="Groups" type="uint" arr1="Num Groups" since="5.0.0.6" />
-    </compound>
+    </struct>
 
-    <compound name="StringPalette">
+    <struct name="StringPalette">
         A list of \\0 terminated strings.
         <field name="Palette" type="SizedString">A bunch of 0x00 seperated strings.</field>
         <field name="Length" type="uint">Length of the palette string is repeated here.</field>
-    </compound>
+    </struct>
 
-    <compound name="TBC" size="12">
+    <struct name="TBC" size="12">
         Tension, bias, continuity.
         <field name="t" type="float">Tension.</field>
         <field name="b" type="float">Bias.</field>
         <field name="c" type="float">Continuity.</field>
-    </compound>
+    </struct>
 
-    <compound name="Key" generic="true">
+    <struct name="Key" generic="true">
         A generic key with support for interpolation. Type 1 is normal linear interpolation, type 2 has forward and backward tangents, and type 3 has tension, bias and continuity arguments. Note that color4 and byte always seem to be of type 1.
         <field name="Time" type="float">Time of the key.</field>
         <field name="Value" type="#T#">The key value.</field>
         <field name="Forward" type="#T#" cond="#ARG# == 2">Key forward tangent.</field>
         <field name="Backward" type="#T#" cond="#ARG# == 2">The key backward tangent.</field>
         <field name="TBC" type="TBC" cond="#ARG# == 3">The TBC of the key.</field>
-    </compound>
+    </struct>
 
-    <compound name="KeyGroup" generic="true">
+    <struct name="KeyGroup" generic="true">
         Array of vector keys (anything that can be interpolated, except rotations).
         <field name="Num Keys" type="uint">Number of keys in the array.</field>
         <field name="Interpolation" type="KeyType" cond="Num Keys != 0">The key type.</field>
         <field name="Keys" type="Key" arg="Interpolation" template="#T#" arr1="Num Keys">The keys.</field>
-    </compound>
+    </struct>
 
-    <compound name="QuatKey" generic="true">
+    <struct name="QuatKey" generic="true">
         A special version of the key type used for quaternions. Never has tangents. #T# should always be Quaternion.
         <field name="Time" type="float" until="10.1.0.0">Time the key applies.</field>
         <field name="Time" type="float" cond="#ARG# != 4" since="10.1.0.106">Time the key applies.</field>
         <field name="Value" type="#T#" cond="#ARG# != 4">Value of the key.</field>
         <field name="TBC" type="TBC" cond="#ARG# == 3">The TBC of the key.</field>
-    </compound>
+    </struct>
 
-    <compound name="TexCoord" size="8">
+    <struct name="TexCoord" size="8">
         Texture coordinates (u,v). As in OpenGL; image origin is in the lower left corner.
         <field name="u" type="float" range="#FPM_100#">First coordinate.</field>
         <field name="v" type="float" range="#FPM_100#">Second coordinate.</field>
-    </compound>
+    </struct>
     
-    <compound name="HalfTexCoord" size="4">
+    <struct name="HalfTexCoord" size="4">
         Texture coordinates (u,v).
         <field name="u" type="hfloat" range="#FPM_10#">First coordinate.</field>
         <field name="v" type="hfloat" range="#FPM_10#">Second coordinate.</field>
-    </compound>
+    </struct>
     
     <enum name="TransformMethod" storage="uint" prefix="TM">
         Describes the order of scaling and rotation matrices. Translate, Scale, Rotation, Center are from TexDesc.
@@ -1955,7 +1955,7 @@
         <option value="2" name="Maya">Center * Rotation * Back * FromMaya * Translate * Scale</option>
     </enum>
 
-    <compound name="TexDesc">
+    <struct name="TexDesc">
         NiTexturingProperty::Map. Texture description.
         <field name="Image" type="Ref" template="NiImage" until="3.1">Link to the texture image.</field>
         <field name="Source" type="Ref" template="NiSourceTexture" since="3.3.0.13">NiSourceTexture object index.</field>
@@ -1974,21 +1974,21 @@
         <field name="Rotation" type="float" default="0.0" cond="Has Texture Transform" since="10.1.0.0">The W axis rotation in texture space.</field>
         <field name="Transform Method" type="TransformMethod" cond="Has Texture Transform" since="10.1.0.0">Depending on the source, scaling can occur before or after rotation.</field>
         <field name="Center" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0">The origin around which the texture rotates.</field>
-    </compound>
+    </struct>
 
-    <compound name="ShaderTexDesc">
+    <struct name="ShaderTexDesc">
         NiTexturingProperty::ShaderMap. Shader texture description.
         <field name="Has Map" type="bool" />
         <field name="Map" type="TexDesc" cond="Has Map" />
         <field name="Map ID" type="uint" cond="Has Map">Unique identifier for the Gamebryo shader system.</field>
-    </compound>
+    </struct>
 
-    <compound name="Triangle" size="6">
+    <struct name="Triangle" size="6">
         List of three vertex indices.
         <field name="v1" type="ushort">First vertex index.</field>
         <field name="v2" type="ushort">Second vertex index.</field>
         <field name="v3" type="ushort">Third vertex index.</field>
-    </compound>
+    </struct>
 
     <bitflags name="VertexAttribute" storage="ushort" prefix="VF" versions="#SSE# #FO4# #F76#">
         The bits of BSVertexDesc that describe the enabled vertex attributes.
@@ -2020,7 +2020,7 @@
         <member width="12" pos="44" mask="0xFFF00000000000" name="Vertex Attributes" type="VertexAttribute" />
     </bitfield>
 
-	<compound name="BSVertexData" versions="#SSE# #FO4# #F76#">
+	<struct name="BSVertexData" versions="#SSE# #FO4# #F76#">
 		<field name="Vertex" type="Vector3" cond="(#ARG# #BITAND# 0x401) == 0x401" />
 		<field name="Bitangent X" type="float" cond="(#ARG# #BITAND# 0x411) == 0x411" />
 		<field name="Unused W" type="uint" cond="(#ARG# #BITAND# 0x411) == 0x401" />
@@ -2038,9 +2038,9 @@
 		<field name="Bone Weights" type="hfloat" arr1="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Bone Indices" type="byte" arr1="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Eye Data" type="float" cond="#ARG# #BITAND# 0x100" />
-	</compound>
+	</struct>
 
-	<compound name="BSVertexDataSSE" versions="#SSE# #FO4#">
+	<struct name="BSVertexDataSSE" versions="#SSE# #FO4#">
 		<field name="Vertex" type="Vector3" cond="#ARG# #BITAND# 0x1" />
 		<field name="Bitangent X" type="float" cond="(#ARG# #BITAND# 0x11) == 0x11" />
 		<field name="Unused W" type="uint" cond="(#ARG# #BITAND# 0x11) == 0x1" />
@@ -2053,9 +2053,9 @@
 		<field name="Bone Weights" type="hfloat" arr1="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Bone Indices" type="byte" arr1="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Eye Data" type="float" cond="#ARG# #BITAND# 0x100" />
-	</compound>
+	</struct>
 
-    <compound name="SkinPartition" since="V4_2_1_0">
+    <struct name="SkinPartition" since="V4_2_1_0">
         Skinning data for a submesh, optimized for hardware skinning. Part of NiSkinPartition.
         <field name="Num Vertices" type="ushort">Number of vertices in this submesh.</field>
         <field name="Num Triangles" type="ushort" calc="(#LEN2[Strips]# #GT# 0) #THEN# (#LEN2[Strips]# - 2) #ELSE# (#LEN[Triangles]#)">Number of triangles in this submesh.</field>
@@ -2081,48 +2081,48 @@
         <field name="Global VB" type="bool" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
 		<field name="Vertex Desc" type="BSVertexDesc" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
 		<field name="Triangles Copy" type="Triangle" arr1="Num Triangles" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
-    </compound>
+    </struct>
 
-    <compound name="NiPlane" size="16">
+    <struct name="NiPlane" size="16">
         A plane.
         <field name="Normal" type="Vector3">The plane normal.</field>
         <field name="Constant" type="float">The plane constant.</field>
-    </compound>
+    </struct>
 
-    <compound name="NiBoundAABB" size="26">
+    <struct name="NiBoundAABB" size="26">
         Divinity 2 specific NiBound extension.
         <field name="Num Corners" type="ushort" default="2" />
         <field name="Corners" type="Vector3" arr1="2">Corners are only non-zero if Num Corners is 2. Hardcoded to 2.</field>
-    </compound>
+    </struct>
 
-    <compound name="NiBound">
+    <struct name="NiBound">
         A sphere.
         <field name="Center" type="Vector3">The sphere's center.</field>
         <field name="Radius" type="float">The sphere's radius.</field>
         <field name="DIV2 AABB" type="NiBoundAABB" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
-    </compound>
+    </struct>
 
-    <compound name="NiCurve3">
+    <struct name="NiCurve3">
         A 3D curve made up of control points and knots.
         <field name="Degree" type="uint" />
         <field name="Num Control Points" type="uint" />
         <field name="Control Points" type="Vector3" arr1="Num Control Points" />
         <field name="Num Knots" type="uint" />
         <field name="Knots" type="float" arr1="Num Knots" />
-    </compound>
+    </struct>
 
-    <compound name="NiQuatTransform">
+    <struct name="NiQuatTransform">
         <field name="Translation" type="Vector3" />
         <field name="Rotation" type="Quaternion" />
         <field name="Scale" type="float" default="1.0" />
         <field name="TRS Valid" type="bool" arr1="3" until="10.1.0.109">Whether each transform component is valid.</field>
-    </compound>
+    </struct>
 
-    <compound name="NiTransform" size="52">
+    <struct name="NiTransform" size="52">
         <field name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</field>
         <field name="Translation" type="Vector3">The translation vector.</field>
         <field name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</field>
-    </compound>
+    </struct>
 
 	<bitflags name="FurnitureEntryPoints" storage="ushort" versions="#BETHESDA#">
 		Bethesda Animation. Furniture entry points. It specifies the direction(s) from where the actor is able to enter (and leave) the position.
@@ -2140,7 +2140,7 @@
 		<option value="4" name="Lean">Used for lean animations?</option>
 	</enum>
 
-    <compound name="FurniturePosition" versions="#BETHESDA#">
+    <struct name="FurniturePosition" versions="#BETHESDA#">
         Bethesda Animation. Describes a furniture position?
         <field name="Offset" type="Vector3">Offset of furniture marker.</field>
         <field name="Orientation" type="ushort" vercond="#NI_BS_LTE_FO3#">Furniture marker orientation.</field>
@@ -2149,16 +2149,16 @@
         <field name="Heading" type="float" vercond="#BS_GT_FO3#">Similar to Orientation, in float form.</field>
         <field name="Animation Type" type="AnimationType" vercond="#BS_GT_FO3#" />
         <field name="Entry Properties" type="FurnitureEntryPoints" vercond="#BS_GT_FO3#" />
-    </compound>
+    </struct>
 
-    <compound name="TriangleData" versions="#BETHESDA#">
+    <struct name="TriangleData" versions="#BETHESDA#">
         Bethesda Havok. A triangle with extra data used for physics.
         <field name="Triangle" type="Triangle">The triangle.</field>
         <field name="Welding Info" type="ushort">Additional havok information on how triangles are welded.</field>
         <field name="Normal" type="Vector3" until="20.0.0.5">This is the triangle's normal.</field>
-    </compound>
+    </struct>
 
-    <compound name="Morph">
+    <struct name="Morph">
         Geometry morphing data component.
         <field name="Frame Name" type="string" since="10.1.0.106">Name of the frame.</field>
         <field name="Num Keys" type="uint" until="10.1.0.0">The number of morph keys that follow.</field>
@@ -2166,9 +2166,9 @@
         <field name="Keys" type="Key" arg="Interpolation" template="float" arr1="Num Keys" until="10.1.0.0">The morph key frames.</field>
         <field name="Legacy Weight" type="float" since="10.1.0.104" until="20.1.0.2" vercond="#BSVER# #LT# 10" />
         <field name="Vectors" type="Vector3" arr1="#ARG#">Morph vectors.</field>
-    </compound>
+    </struct>
 
-    <compound name="NiParticleInfo" size="40">
+    <struct name="NiParticleInfo" size="40">
         Called NiPerParticleData in NiOldParticles.
         Holds the state of a particle at the time the system was saved.
         <field name="Velocity" type="Vector3">Particle direction and speed.</field>
@@ -2178,46 +2178,46 @@
         <field name="Last Update" type="float">Timestamp of the last update.</field>
         <field name="Spawn Generation" type="ushort" default="0" />
         <field name="Code" type="ushort">Usually matches array index</field>
-    </compound>
+    </struct>
 
-    <compound name="BoneData">
+    <struct name="BoneData">
         NiSkinData::BoneData. Skinning data component.
         <field name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</field>
         <field name="Bounding Sphere" type="NiBound">Note that its a Sphere Containing Axis Aligned Box not a minimum volume Sphere</field>
         <field name="Num Vertices" type="ushort">Number of weighted vertices.</field>
         <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" until="4.2.1.0">The vertex weights.</field>
         <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" since="4.2.2.0" cond="#ARG# != 0">The vertex weights.</field>
-    </compound>
+    </struct>
 
-    <compound name="HavokFilter" size="4" versions="#BETHESDA#">
+    <struct name="HavokFilter" size="4" versions="#BETHESDA#">
         Bethesda Havok. Collision filter info representing Layer, Flags, Part Number, and Group all combined into one uint.
         <field name="Layer" suffix="OB" type="OblivionLayer" default="OL_STATIC" until="20.0.0.5" vercond="#BSVER# #LT# 16">The layer the collision belongs to.</field>
         <field name="Layer" suffix="FO" type="Fallout3Layer" default="FOL_STATIC" vercond="(#VER# == 20.2.0.7) #AND# #NI_BS_LTE_FO3#">The layer the collision belongs to.</field>
         <field name="Layer" suffix="SK" type="SkyrimLayer" default="SKYL_STATIC" vercond="(#VER# == 20.2.0.7) #AND# #BS_GT_FO3#">The layer the collision belongs to.</field>
         <field name="Flags" type="CollisionFilterFlags" default="0" />
         <field name="Group" type="ushort" />
-    </compound>
+    </struct>
 
-    <compound name="HavokMaterial" versions="#BETHESDA#">
+    <struct name="HavokMaterial" versions="#BETHESDA#">
         Bethesda Havok. Material wrapper for varying material enums by game.
         <field name="Unknown Int" type="uint" until="10.0.1.2" />
         <field name="Material" suffix="OB" type="OblivionHavokMaterial" until="20.0.0.5" vercond="#BSVER# #LT# 16">The material of the shape.</field>
         <field name="Material" suffix="FO" type="Fallout3HavokMaterial" vercond="(#VER# == 20.2.0.7) #AND# #NI_BS_LTE_FO3#">The material of the shape.</field>
         <field name="Material" suffix="SK" type="SkyrimHavokMaterial" vercond="(#VER# == 20.2.0.7) #AND# #BS_GT_FO3#">The material of the shape.</field>
-    </compound>
+    </struct>
 
-    <compound name="hkSubPartData" versions="#BETHESDA#">
+    <struct name="hkSubPartData" versions="#BETHESDA#">
         Bethesda Havok. Havok Information for packed TriStrip shapes.
         <field name="Havok Filter" type="HavokFilter" />
         <field name="Num Vertices" type="uint">The number of vertices that form this sub shape.</field>
         <field name="Material" type="HavokMaterial">The material of the subshape.</field>
-    </compound>
+    </struct>
 
-    <compound name="hkAabb" versions="#BETHESDA#">
+    <struct name="hkAabb" versions="#BETHESDA#">
         Havok AABB using min/max coordinates instead of center/half extents.
         <field name="Min" type="Vector4">Coordinates of the corner with the lowest numerical values.</field>
         <field name="Max" type="Vector4">Coordinates of the corner with the highest numerical values.</field>
-    </compound>
+    </struct>
 
     <enum name="ConstraintPriority" storage="uint" versions="#BETHESDA#">
         hkpConstraintInstance::ConstraintPriority. Priority used for the constraint.
@@ -2227,22 +2227,22 @@
         <option value="3" name="PRIORITY_TOI">Constraint is also solved at time of impact events.</option>
     </enum>
 
-    <compound name="bhkConstraintCInfo" size="16" versions="#BETHESDA#">
+    <struct name="bhkConstraintCInfo" size="16" versions="#BETHESDA#">
         Bethesda extension of hkpConstraintInstance.
         <field name="Num Entities" type="uint" default="2">Always 2 (Hardcoded). Number of bodies affected by this constraint.</field>
         <field name="Entity A" type="Ptr" template="bhkEntity">The entity affected by this constraint.</field>
         <field name="Entity B" type="Ptr" template="bhkEntity">The entity affected by this constraint.</field>
         <field name="Priority" type="ConstraintPriority" default="PRIORITY_PSI">Either PSI or TOI priority. TOI is higher priority.</field>
-    </compound>
+    </struct>
 
-    <compound name="bhkConstraintChainCInfo" versions="#BETHESDA#">
+    <struct name="bhkConstraintChainCInfo" versions="#BETHESDA#">
         Bethesda extension of hkpConstraintChainInstance.
         <field name="Num Chained Entities" type="uint" />
         <field name="Chained Entities" type="Ptr" template="bhkRigidBody" arr1="Num Chained Entities" />
         <field name="Constraint Info" type="bhkConstraintCInfo" />
-    </compound>
+    </struct>
 
-    <compound name="bhkPositionConstraintMotor" size="25" versions="#BETHESDA#">
+    <struct name="bhkPositionConstraintMotor" size="25" versions="#BETHESDA#">
         Bethesda extension of hkpPositionConstraintMotor.
         A motor which tries to reach a desired position/angle given a max force and recovery speed.
         This motor is a good choice for driving a ragdoll to a given pose.
@@ -2253,9 +2253,9 @@
         <field name="Proportional Recovery Velocity" type="float" default="2.0">A factor of the current error to calculate the recovery velocity</field>
         <field name="Constant Recovery Velocity" type="float" default="1.0">A constant velocity which is used to recover from errors</field>
         <field name="Motor Enabled" type="bool" default="0">Is Motor enabled</field>
-    </compound>
+    </struct>
 
-    <compound name="bhkVelocityConstraintMotor" size="18" versions="#BETHESDA#">
+    <struct name="bhkVelocityConstraintMotor" size="18" versions="#BETHESDA#">
         Bethesda extension of hkpVelocityConstraintMotor. Tries to reach and keep a desired target velocity.
         <field name="Min Force" type="float" default="-1000000.0">Minimum motor force</field>
         <field name="Max Force" type="float" default="1000000.0">Maximum motor force</field>
@@ -2263,9 +2263,9 @@
         <field name="Target Velocity" type="float" default="0.0" />
         <field name="Use Velocity Target" type="bool" default="0" />
         <field name="Motor Enabled" type="bool" default="0">Is Motor enabled</field>
-    </compound>
+    </struct>
 
-    <compound name="bhkSpringDamperConstraintMotor" size="17" versions="#BETHESDA#">
+    <struct name="bhkSpringDamperConstraintMotor" size="17" versions="#BETHESDA#">
         Bethesda extension of hkpSpringDamperConstraintMotor.
         Tries to reach a given target position using an angular spring which has a spring constant.
         <field name="Min Force" type="float" default="-1000000.0">Minimum motor force</field>
@@ -2273,7 +2273,7 @@
         <field name="Spring Constant" type="float" default="0.0">The spring constant in N/m</field>
         <field name="Spring Damping" type="float" default="0.0">The spring damping in Nsec/m</field>
         <field name="Motor Enabled" type="bool" default="0">Is Motor enabled</field>
-    </compound>
+    </struct>
     
     <enum name="hkMotorType" storage="byte" versions="#BETHESDA#">
         <option value="0" name="MOTOR_NONE" />
@@ -2282,15 +2282,15 @@
         <option value="3" name="MOTOR_SPRING" />
     </enum>
 
-    <compound name="bhkConstraintMotorCInfo" versions="#BETHESDA#">
+    <struct name="bhkConstraintMotorCInfo" versions="#BETHESDA#">
         hkConstraintCinfo::SaveMotor(). Not a Bethesda extension of hkpConstraintMotor, but a wrapper for its serialization function. 
         <field name="Type" type="hkMotorType" default="MOTOR_NONE" />
         <field name="Position Motor" type="bhkPositionConstraintMotor" cond="Type == 1" />
         <field name="Velocity Motor" type="bhkVelocityConstraintMotor" cond="Type == 2" />
         <field name="Spring Damper Motor" type="bhkSpringDamperConstraintMotor" cond="Type == 3" />
-    </compound>
+    </struct>
 
-    <compound name="bhkRagdollConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkRagdollConstraintCInfo" versions="#BETHESDA#">
         Serialization data for bhkRagdollConstraint.
         The area of movement can be represented as a main cone + 2 orthogonal cones which may subtract from the main cone volume depending on limits.
         <!-- Oblivion and Fallout 3, Havok 550 -->
@@ -2319,9 +2319,9 @@
         <field name="Max Friction" type="float">Maximum friction, typically 0 or 10. In Fallout 3, typically 100.</field>
 
         <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
-    </compound>
+    </struct>
 
-    <compound name="bhkLimitedHingeConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkLimitedHingeConstraintCInfo" versions="#BETHESDA#">
         Serialization data for bhkLimitedHingeConstraint.
         This constraint allows rotation about a specified axis, limited by specified boundaries.
     
@@ -2350,9 +2350,9 @@
         <field name="Max Friction" type="float">Maximum friction, typically either 0 or 10. In Fallout 3, typically 100.</field>
 
         <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
-    </compound>
+    </struct>
 
-    <compound name="bhkHingeConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkHingeConstraintCInfo" versions="#BETHESDA#">
         Serialization data for bhkHingeConstraint. A basic hinge with no angular limits or motor.
         <!-- Oblivion -->
         <field name="Pivot A" type="Vector4" until="20.0.0.5">Pivot point around which the object will rotate.</field>
@@ -2370,16 +2370,16 @@
         <field name="Perp Axis In B1" type="Vector4" since="20.2.0.7">Perp Axis In A1 in second entity coordinate system.</field>
         <field name="Perp Axis In B2" type="Vector4" since="20.2.0.7">Perp Axis In A2 in second entity coordinate system.</field>
         <field name="Pivot B" type="Vector4" since="20.2.0.7">Pivot A in second entity coordinate system.</field>
-    </compound>
+    </struct>
 
-    <compound name="bhkBallAndSocketConstraintCInfo" size="32" versions="#BETHESDA#">
+    <struct name="bhkBallAndSocketConstraintCInfo" size="32" versions="#BETHESDA#">
         Serialization data for bhkBallAndSocketConstraint.
         Point-to-point constraint that attempts to keep the pivot point of two bodies in the same space.
         <field name="Pivot A" type="Vector4">Constraint pivot in Entity A space.</field>
         <field name="Pivot B" type="Vector4">Constraint pivot in Entity B space.</field>
-    </compound>
+    </struct>
 
-    <compound name="bhkPrismaticConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkPrismaticConstraintCInfo" versions="#BETHESDA#">
         Serialization data for bhkPrismaticConstraint.
         Creates a rail between two bodies that allows translation along a single axis with linear limits and a motor.
         All three rotation axes and the remaining two translation axes are fixed.
@@ -2409,21 +2409,21 @@
         <field name="Friction" type="float">Friction.</field>
 
         <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
-    </compound>
+    </struct>
 
-    <compound name="bhkStiffSpringConstraintCInfo" size="36" versions="#BETHESDA#">
+    <struct name="bhkStiffSpringConstraintCInfo" size="36" versions="#BETHESDA#">
         bhkStiffSpringConstraint serialization data. Holds two bodies at a specified distance from one another.
         <field name="Pivot A" type="Vector4" />
         <field name="Pivot B" type="Vector4" />
         <field name="Length" type="float" />
-    </compound>
+    </struct>
 
-    <compound name="OldSkinData" size="18">
+    <struct name="OldSkinData" size="18">
         Used to store skin weights in NiTriShapeSkinController.
         <field name="Vertex Weight" type="float">The amount that this bone affects the vertex.</field>
         <field name="Vertex Index" type="ushort">The index of the vertex that this weight applies to.</field>
         <field name="Unknown Vector" type="Vector3" />
-    </compound>
+    </struct>
 
     <enum name="ImageType" storage="uint">
         Determines how the raw image data is stored in NiRawImageData.
@@ -2431,64 +2431,64 @@
         <option value="2" name="RGBA">Colors store red, blue, green, and alpha components.</option>
     </enum>
 
-    <compound name="BoxBV" size="60">
+    <struct name="BoxBV" size="60">
         Box Bounding Volume
         <field name="Center" type="Vector3" />
         <field name="Axis" type="Vector3" arr1="3" />
         <field name="Extent" type="Vector3" />
-    </compound>
+    </struct>
 
-    <compound name="CapsuleBV" size="32">
+    <struct name="CapsuleBV" size="32">
         Capsule Bounding Volume
         <field name="Center" type="Vector3" />
         <field name="Origin" type="Vector3" />
         <field name="Extent" type="float" />
         <field name="Radius" type="float" />
-    </compound>
+    </struct>
 
-    <compound name="HalfSpaceBV" size="28">
+    <struct name="HalfSpaceBV" size="28">
         <field name="Plane" type="NiPlane" />
         <field name="Center" type="Vector3" />
-    </compound>
+    </struct>
 
-    <compound name="BoundingVolume">
+    <struct name="BoundingVolume">
         <field name="Collision Type" type="BoundVolumeType">Type of collision data.</field>
         <field name="Sphere" type="NiBound" cond="Collision Type == 0" />
         <field name="Box" type="BoxBV" cond="Collision Type == 1" />
         <field name="Capsule" type="CapsuleBV" cond="Collision Type == 2" />
         <!--<field name="Union BV" type="UnionBV" cond="Collision Type == 4" />-->
         <field name="Half Space" type="HalfSpaceBV" cond="Collision Type == 5" />
-    </compound>
+    </struct>
 
-    <compound name="UnionBV">
+    <struct name="UnionBV">
         <field name="Num BV" type="uint" />
         <field name="Bounding Volumes" type="BoundingVolume" arr1="Num BV" />
-    </compound>
+    </struct>
 
-    <compound name="MorphWeight" size="8">
+    <struct name="MorphWeight" size="8">
         <field name="Interpolator" type="Ref" template="NiInterpolator" />
         <field name="Weight" type="float" />
-    </compound>
+    </struct>
 
-    <compound name="BoneTransform" size="40">
+    <struct name="BoneTransform" size="40">
         Transformation data for the bone at this index in bhkPoseArray.
         <field name="Translation" type="Vector3" />
         <field name="Rotation" type="hkQuaternion" />
         <field name="Scale" type="Vector3" />
-    </compound>
+    </struct>
 
-    <compound name="BonePose" versions="#FO3_AND_LATER#">
+    <struct name="BonePose" versions="#FO3_AND_LATER#">
         A list of transforms for each bone in bhkPoseArray.
         <field name="Num Transforms" type="uint" />
         <field name="Transforms" type="BoneTransform" arr1="Num Transforms" />
-    </compound>
+    </struct>
 
-    <compound name="DecalVectorArray" versions="#FO3_AND_LATER#">
+    <struct name="DecalVectorArray" versions="#FO3_AND_LATER#">
         Array of Vectors for Decal placement in BSDecalPlacementVectorExtraData.
         <field name="Num Vectors" type="ushort" />
         <field name="Points" type="Vector3" arr1="Num Vectors">Vector XYZ coords</field>
         <field name="Normals" type="Vector3" arr1="Num Vectors">Vector Normals</field>
-    </compound>
+    </struct>
 
     <bitflags name="BSPartFlag" storage="ushort" versions="#BETHESDA#">
         Editor flags for the Body Partitions. 
@@ -2496,38 +2496,38 @@
         <option bit="8" name="PF_START_NET_BONESET">Start a new shared boneset.  It is expected this BoneSet and the following sets in the Skin Partition will have the same bones.</option>
     </bitflags>
 
-    <compound name="BodyPartList" size="4" versions="#BETHESDA#">
+    <struct name="BodyPartList" size="4" versions="#BETHESDA#">
         Body part list for DismemberSkinInstance
         <field name="Part Flag" type="BSPartFlag" default="257">Flags related to the Body Partition</field>
         <field name="Body Part" type="BSDismemberBodyPartType">Body Part Index</field>
-    </compound>
+    </struct>
     
-    <compound name="BoneLOD" size="8" versions="#SKY_AND_LATER#">
+    <struct name="BoneLOD" size="8" versions="#SKY_AND_LATER#">
         Stores Bone Level of Detail info in a BSBoneLODExtraData
         <field name="Distance" type="uint" />
         <field name="Bone Name" type="NiFixedString" />
-    </compound>
+    </struct>
 
-    <compound name="bhkMeshMaterial" size="8" versions="#SKY_AND_LATER#">
+    <struct name="bhkMeshMaterial" size="8" versions="#SKY_AND_LATER#">
         hkpBSMaterial, a subclass of hkpMeshMaterial. hkpMeshMaterial is a base class for material info for hkMeshShapes.
         <field name="Material" type="SkyrimHavokMaterial" />
         <field name="Filter" type="HavokFilter" />
-    </compound>
+    </struct>
 
-    <compound name="bhkCMSBigTri" size="12" versions="#SKY_AND_LATER#">
+    <struct name="bhkCMSBigTri" size="12" versions="#SKY_AND_LATER#">
         Bethesda extension of hkpCompressedMeshShape::BigTriangle. Triangles that don't fit the maximum size.
         <field name="Triangle" type="Triangle" />
         <field name="Material" type="uint" />
         <field name="Welding Info" type="ushort" />
-    </compound>
+    </struct>
     
-    <compound name="bhkQsTransform" size="32" versions="#SKY_AND_LATER#">
+    <struct name="bhkQsTransform" size="32" versions="#SKY_AND_LATER#">
         Bethesda extension of hkQsTransform. The scale vector is not serialized.
         <field name="Translation" type="Vector4">A vector that moves the chunk by the specified amount. W is not used.</field>
         <field name="Rotation" type="hkQuaternion">Rotation. Reference point for rotation is bhkRigidBody translation.</field>
-    </compound>
+    </struct>
     
-    <compound name="bhkCMSChunk" versions="#SKY_AND_LATER#">
+    <struct name="bhkCMSChunk" versions="#SKY_AND_LATER#">
         Bethesda extension of hkpCompressedMeshShape::Chunk. A compressed chunk of hkpCompressedMeshShape geometry.
         <field name="Translation" type="Vector4" />
         <field name="Material Index" type="uint">Index of material in bhkCompressedMeshShapeData::Chunk Materials</field>
@@ -2541,9 +2541,9 @@
         <field name="Strips" type="ushort" arr1="Num Strips" />
         <field name="Num Welding Info" type="uint" />
         <field name="Welding Info" type="ushort" arr1="Num Welding Info" />
-    </compound>
+    </struct>
 
-    <compound name="bhkMalleableConstraintCInfo" versions="#BETHESDA#">
+    <struct name="bhkMalleableConstraintCInfo" versions="#BETHESDA#">
         bhkMalleableConstraint serialization data. A constraint wrapper used to soften or harden constraints.
         <field name="Type" type="hkConstraintType">Type of constraint.</field>
         <field name="Constraint Info" type="bhkConstraintCInfo" />
@@ -2556,9 +2556,9 @@
         <field name="Tau" type="float" until="20.0.0.5" />
         <field name="Damping" type="float" until="20.0.0.5" />
         <field name="Strength" type="float" since="20.2.0.7" />
-    </compound>
+    </struct>
 
-    <compound name="bhkWrappedConstraintData" versions="#BETHESDA#">
+    <struct name="bhkWrappedConstraintData" versions="#BETHESDA#">
         A constraint wrapper for polymorphic hkpConstraintData serialization.
         <field name="Type" type="hkConstraintType">Type of constraint.</field>
         <field name="Constraint Info" type="bhkConstraintCInfo" />
@@ -2569,12 +2569,12 @@
         <field name="Ragdoll" type="bhkRagdollConstraintCInfo" cond="Type == 7" />
         <field name="Stiff Spring" type="bhkStiffSpringConstraintCInfo" cond="Type == 8" />
         <field name="Malleable" type="bhkMalleableConstraintCInfo" cond="Type == 13" />
-    </compound>
+    </struct>
 
     <!-- NIF Objects
          These are the main units of data that NIF files are arranged in.
          They are like C classes and can contain many pieces of data.
-         The only differences between these and compounds is that these
+         The only differences between these and structs is that these
          are treated as object types by the NIF format and can inherit
          from other classes.-->
 
@@ -2656,19 +2656,19 @@
         Bethesda class to combine NiObject and hkReferencedObject so that Havok classes can be read/written with NiStream.
     </niobject>
 
-    <compound name="bhkWorldObjCInfoProperty" size="12" versions="#BETHESDA#">
+    <struct name="bhkWorldObjCInfoProperty" size="12" versions="#BETHESDA#">
         hkWorldObjectCinfo::Property struct
         <field name="Data" type="uint" default="0" />
         <field name="Size" type="uint" default="0" />
         <field name="Capacity and Flags" type="uint" default="0x80000000" />
-    </compound>
+    </struct>
 
-    <compound name="bhkWorldObjectCInfo">
+    <struct name="bhkWorldObjectCInfo">
         <field name="Unused 01" type="byte" arr1="4" binary="true" />
         <field name="Broad Phase Type" type="BroadPhaseType" default="BROAD_PHASE_ENTITY" />
         <field name="Unused 02" type="byte" arr1="3" binary="true" />
         <field name="Property" type="bhkWorldObjCInfoProperty" />
-    </compound>
+    </struct>
 
     <niobject name="bhkWorldObject" abstract="true" inherit="bhkSerializable" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpWorldObject, the base class for hkpEntity and hkpPhantom.
@@ -2702,18 +2702,18 @@
         <field name="Transform" type="Matrix44" />
     </niobject>
 
-    <compound name="bhkEntityCInfo">
+    <struct name="bhkEntityCInfo">
         <field name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT">How the body reacts to collisions. See hkResponseType for hkpWorld default implementations.</field>
         <field name="Unused 01" type="byte" />
         <field name="Process Contact Callback Delay" type="ushort" default="0xffff">Lowers the frequency for processContactCallbacks. A value of 5 means that a callback is raised every 5th frame. The default is once every 65535 frames.</field>
-    </compound>
+    </struct>
 
     <niobject name="bhkEntity" abstract="true" inherit="bhkWorldObject" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpEntity. An Entity is the core physical object in the system.
         <field name="Entity Info" type="bhkEntityCInfo" />
     </niobject>
 
-    <compound name="bhkRigidBodyCInfo550_660">
+    <struct name="bhkRigidBodyCInfo550_660">
         <field name="Unused 01" type="byte" arr1="4" binary="true" since="10.1.0.0" />
         <field name="Havok Filter" type="HavokFilter" since="10.1.0.0" />
         <field name="Unused 02" type="byte" arr1="4" binary="true" since="10.1.0.0" />
@@ -2747,9 +2747,9 @@
         <field name="Solver Deactivation" type="hkSolverDeactivation" default="SOLVER_DEACTIVATION_OFF">How aggressively the engine will try to zero the velocity for slow objects. This does not save CPU.</field>
         <field name="Quality Type" type="hkQualityType" default="MO_QUAL_FIXED">The type of interaction with other objects.</field>
         <field name="Unused 05" type="byte" arr1="12" binary="true" />
-    </compound>
+    </struct>
 
-    <compound name="bhkRigidBodyCInfo2010">
+    <struct name="bhkRigidBodyCInfo2010">
         <field name="Unused 01" type="byte" arr1="4" binary="true" />
         <field name="Havok Filter" type="HavokFilter" />
         <field name="Unused 02" type="byte" arr1="4" binary="true" />
@@ -2790,9 +2790,9 @@
         <field name="Num Shape Keys in Contact Point" type="byte" default="3" />
         <field name="Force Collided Onto PPU" type="bool" />
         <field name="Unused 04" type="byte" arr1="12" binary="true" />
-    </compound>
+    </struct>
 
-    <compound name="bhkRigidBodyCInfo2014">
+    <struct name="bhkRigidBodyCInfo2014">
         <field name="Unused 01" type="byte" arr1="4" binary="true" />
         <field name="Havok Filter" type="HavokFilter" />
         <field name="Unused 02" type="byte" arr1="12" binary="true" />
@@ -2834,7 +2834,7 @@
         <field name="Num Shape Keys in Contact Point" type="byte" default="3" />
         <field name="Force Collided Onto PPU" type="bool" />
         <field name="Unused 06" type="byte" arr1="3" binary="true" />
-    </compound>
+    </struct>
 
     <niobject name="bhkRigidBody" inherit="bhkEntity" module="BSHavok" versions="#BETHESDA#">
         This is the default body type for all "normal" usable and static world objects. The "T" suffix
@@ -3045,7 +3045,7 @@
         <field name="Shape" type="Ref" template="bhkShape">The shape.</field>
     </niobject>
 
-    <compound name="hkpMoppCode" versions="#BETHESDA#">
+    <struct name="hkpMoppCode" versions="#BETHESDA#">
         <field name="Data Size" type="uint">Number of bytes for MOPP data.</field>
         <field name="Offset" type="Vector4" since="10.1.0.0">
             XYZ: Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus 0.1.
@@ -3054,7 +3054,7 @@
         </field>
         <field name="Build Type" type="hkMoppCodeBuildType" vercond="#BS_GT_FO3#">Tells if MOPP Data was organized into smaller chunks (PS3) or not (PC)</field>
         <field name="Data" type="byte" binary="true" arr1="Data Size">The tree of bounding volume data.</field>
-    </compound>
+    </struct>
 
     <niobject name="bhkMoppBvTreeShape" inherit="bhkBvTreeShape" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpMoppBvTreeShape. hkpMoppBvTreeShape is a bounding volume tree using Havok-proprietary MOPP code.
@@ -3199,7 +3199,7 @@
         <option value="1" name="MANAGER_CONTROLLED">MANAGER_CONTROLLED</option>
     </enum>
 
-    <compound name="InterpBlendItem">
+    <struct name="InterpBlendItem">
         Interpolator item for array in NiBlendInterpolator.
         <field name="Interpolator" type="Ref" template="NiInterpolator">Reference to an interpolator.</field>
         <field name="Weight" type="float" />
@@ -3207,7 +3207,7 @@
         <field name="Priority" type="int" until="10.1.0.109" />
         <field name="Priority" type="byte" since="10.1.0.110" />
         <field name="Ease Spinner" type="float" />
-    </compound>
+    </struct>
 
     <niobject name="NiBlendInterpolator" abstract="true" inherit="NiInterpolator" module="NiAnimation">
         Abstract base class for all NiInterpolators that blend the results of sub-interpolators together to compute a final weighted value.
@@ -3251,14 +3251,14 @@
         <field name="Basis Data" type="Ref" template="NiBSplineBasisData" />
     </niobject>
 
-    <compound name="LegacyExtraData" until="V2_3">
+    <struct name="LegacyExtraData" until="V2_3">
         Extra Data for pre-3.0 versions
         <field name="Has Extra Data" type="bool" />
         <field name="Extra Prop Name" cond="Has Extra Data" type="SizedString" />
         <field name="Extra Ref ID" cond="Has Extra Data" type="uint" />
         <field name="Extra String" cond="Has Extra Data" type="SizedString" />
         <field name="Unknown Byte 1" type="byte" />
-    </compound>
+    </struct>
 
     <niobject name="NiObjectNET" abstract="true" inherit="NiObject" module="NiMain">
         Abstract base class for NiObjects that support names, extra data, and time controllers.
@@ -3740,7 +3740,7 @@
         A simple LOD controller for bones.
     </niobject>
     
-    <compound name="MaterialData">
+    <struct name="MaterialData">
         <field name="Has Shader" type="bool" since="10.0.1.0" until="20.1.0.3">Shader.</field>
         <field name="Shader Name" type="string" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">The shader name.</field>
         <field name="Shader Extra Data" type="int" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">Extra data associated with the shader. A value of -1 means the shader is the default implementation.</field>
@@ -3751,7 +3751,7 @@
         <field name="Cyanide Unknown" type="byte" default="255" since="10.2.0.0" until="10.2.0.0" vercond="#USER# == 1">Cyanide extension (Blood Bowl).</field>
         <field name="WorldShift Unknown" type="int" since="10.3.0.1" until="10.4.0.1" />
         <field name="Material Needs Update" type="bool" since="20.2.0.7">Whether the materials for this object always needs to be updated before rendering with them.</field>
-    </compound>
+    </struct>
 
     <niobject name="NiGeometry" abstract="true" inherit="NiAVObject" module="NiMain">
         Describes a visible scene element with vertices like a mesh, a particle system, lines, etc.
@@ -4527,12 +4527,12 @@
         <field name="Percent Data" type="Ref" template="NiFloatData" />
     </niobject>
 
-    <compound name="PixelFormatComponent">
+    <struct name="PixelFormatComponent">
         <field name="Type" type="PixelComponent">Component Type</field>
         <field name="Convention" type="PixelRepresentation">Data Storage Convention</field>
         <field name="Bits Per Channel" type="byte">Bits per component</field>
         <field name="Is Signed" type="bool" />
-    </compound>
+    </struct>
 
     <niobject name="NiPixelFormat" abstract="true" inherit="NiObject" module="NiMain">
         NiPixelFormat is not the parent to NiPixelData/NiPersistentSrcTextureRendererData,
@@ -5005,12 +5005,12 @@
         A texture.
     </niobject>
 
-    <compound name="FormatPrefs" size="12">
+    <struct name="FormatPrefs" size="12">
         NiTexture::FormatPrefs. These preferences are a request to the renderer to use a format the most closely matches the settings and may be ignored.
         <field name="Pixel Layout" type="PixelLayout">Requests the way the image will be stored.</field>
         <field name="Use Mipmaps" type="MipMapFormat" default="MIP_FMT_DEFAULT">Requests if mipmaps are used or not.</field>
         <field name="Alpha Format" type="AlphaFormat" default="ALPHA_DEFAULT">Requests no alpha, 1-bit alpha, or </field>
-    </compound>
+    </struct>
 
     <niobject name="NiSourceTexture" inherit="NiTexture" module="NiMain">
         Describes texture source and properties.
@@ -5473,18 +5473,18 @@
         <option bit="11" name="ENERGY_SLEEP_TEST" />
     </bitflags>
 
-    <compound name="NiPhysXMaterialDescMap" size="6" since="V20_2_0_8">
+    <struct name="NiPhysXMaterialDescMap" size="6" since="V20_2_0_8">
         <field name="Key" type="ushort" />
         <field name="Material" type="Ref" template="NiPhysXMaterialDesc" />
-    </compound>
+    </struct>
 
-    <compound name="NxCompartmentDescMap" size="20" since="V20_2_0_8">
+    <struct name="NxCompartmentDescMap" size="20" since="V20_2_0_8">
         <field name="ID" type="uint" />
         <field name="Type" type="NxCompartmentType" default="SCT_RIGIDBODY" />
         <field name="Device Code" type="NxDeviceCode" default="CPU" />
         <field name="Grid Hash Cell Size" type="float" default="100.0" />
         <field name="Grid Hash Table Power" type="uint" default="8" />
-    </compound>
+    </struct>
 
     <niobject name="NiPhysXSceneDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         Object which caches the properties of NxScene, stored as a snapshot in a NiPhysXScene.
@@ -5590,11 +5590,11 @@
         <field name="Dest" type="Ref" template="NiPhysXRigidBodyDest" />
     </niobject>
 
-    <compound name="PhysXBodyStoredVels" since="V20_2_0_8">
+    <struct name="PhysXBodyStoredVels" since="V20_2_0_8">
         <field name="Linear Velocity" type="Vector3" />
         <field name="Angular Velocity" type="Vector3" />
         <field name="Sleep" type="bool" since="30.2.0.3" />
-    </compound>
+    </struct>
 
     <niobject name="NiPhysXBodyDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         For serializing NxBodyDesc objects.
@@ -5647,32 +5647,32 @@
         <option value="2" name="JPM_LINEAR_MINDIST" />
     </enum>
 
-    <compound name="NiPhysXJointActor" size="40" since="V20_2_0_8">
+    <struct name="NiPhysXJointActor" size="40" since="V20_2_0_8">
         <field name="Actor" type="Ref" template="NiPhysXActorDesc" />
         <field name="Local Normal" type="Vector3" />
         <field name="Local Axis" type="Vector3" />
         <field name="Local Anchor" type="Vector3" />
-    </compound>
+    </struct>
 
-    <compound name="NxJointLimitSoftDesc" size="16" since="V20_2_0_8">
+    <struct name="NxJointLimitSoftDesc" size="16" since="V20_2_0_8">
         <field name="Value" type="float" />
         <field name="Restitution" type="float" />
         <field name="Spring" type="float" />
         <field name="Damping" type="float" />
-    </compound>
+    </struct>
 
-    <compound name="NxJointDriveDesc" size="16" since="V20_2_0_8">
+    <struct name="NxJointDriveDesc" size="16" since="V20_2_0_8">
         <field name="Drive Type" type="NxD6JointDriveType" />
         <field name="Spring" type="float" />
         <field name="Damping" type="float" />
         <field name="Force Limit" type="float" default="#FLT_MAX#" />
-    </compound>
+    </struct>
 
-    <compound name="NiPhysXJointLimit" since="V20_2_0_8">
+    <struct name="NiPhysXJointLimit" since="V20_2_0_8">
         <field name="Limit Plane Normal" type="Vector3" />
         <field name="Limit Plane D" type="float" />
         <field name="Limit Plane R" type="float" since="20.4.0.0" />
-    </compound>
+    </struct>
 
     <niobject name="NiPhysXJointDesc" abstract="true" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         A PhysX Joint abstract base class.
@@ -5755,16 +5755,16 @@
         <option bit="20" name="SOFTBODY_TWOWAY" />
     </bitflags>
 
-    <compound name="NxPlane" size="16" since="V20_2_0_8">
+    <struct name="NxPlane" size="16" since="V20_2_0_8">
         <field name="Val 1" type="float" />
         <field name="Point 1" type="Vector3" />
-    </compound>
+    </struct>
 
-    <compound name="NxCapsule" size="12" since="V20_2_0_8">
+    <struct name="NxCapsule" size="12" since="V20_2_0_8">
         <field name="Val 1" type="float" />
         <field name="Val 2" type="float" />
         <field name="Capsule Flags" type="uint" />
-    </compound>
+    </struct>
 
     <niobject name="NiPhysXShapeDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         For serializing NxShapeDesc objects
@@ -5805,11 +5805,11 @@
         <option bit="5" name="DISABLE_STRONG_FRICTION" />
     </bitflags>
 
-    <compound name="NxSpringDesc" size="12" since="V20_2_0_8">
+    <struct name="NxSpringDesc" size="12" since="V20_2_0_8">
         <field name="Spring" type="float" />
         <field name="Damper" type="float" />
         <field name="Target Value" type="float" />
-    </compound>
+    </struct>
 
     <enum name="NxCombineMode" storage="uint" prefix="NX_CM" since="V20_2_0_8">
         <option value="0" name="AVERAGE" />
@@ -5818,7 +5818,7 @@
         <option value="3" name="MAX" />
     </enum>
 
-    <compound name="NxMaterialDesc" since="V20_2_0_8">
+    <struct name="NxMaterialDesc" since="V20_2_0_8">
         <field name="Dynamic Friction" type="float" />
         <field name="Static Friction" type="float" />
         <field name="Restitution" type="float" />
@@ -5830,7 +5830,7 @@
         <field name="Restitution Combine Mode" type="NxCombineMode" />
         <field name="Has Spring" type="bool" until="20.2.3.0" />
         <field name="Spring" type="NxSpringDesc" until="20.2.3.0" cond="Has Spring" />
-    </compound>
+    </struct>
 
     <niobject name="NiPhysXMaterialDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         For serializing NxMaterialDesc objects.
@@ -5860,27 +5860,27 @@
         <option bit="18" name="ADHERE" />
     </bitflags>
 
-    <compound name="PhysXClothState" since="V20_2_0_8">
+    <struct name="PhysXClothState" since="V20_2_0_8">
         <field name="Pose" type="Matrix34" />
         <field name="Num Vertex Positions" type="ushort" />
         <field name="Vertex Positions" type="Vector3" arr1="Num Vertex Positions" />
         <field name="Num Tear Indices" type="ushort" />
         <field name="Tear Indices" type="ushort" arr1="Num Tear Indices" />
         <field name="Tear Split Planes" type="Vector3" arr1="Num Tear Indices" />
-    </compound>
+    </struct>
 
-    <compound name="PhysXClothAttachmentPosition" since="V20_2_0_8">
+    <struct name="PhysXClothAttachmentPosition" since="V20_2_0_8">
         <field name="Vertex ID" type="uint" />
         <field name="Position" type="Vector3" />
         <field name="Flags" type="uint" />
-    </compound>
+    </struct>
 
-    <compound name="PhysXClothAttachment" since="V20_2_0_8">
+    <struct name="PhysXClothAttachment" since="V20_2_0_8">
         <field name="Shape" type="Ref" template="NiPhysXShapeDesc" />
         <field name="Num Vertices" type="uint" />
         <field name="Flags" type="uint" cond="Num Vertices == 0" />
         <field name="Positions" type="PhysXClothAttachmentPosition" cond="Num Vertices #GT# 0" arr1="Num Vertices" />
-    </compound>
+    </struct>
 
     <niobject name="NiPhysXClothDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         For serializing NxClothDesc objects.
@@ -5968,13 +5968,13 @@
         <field name="Lines" type="bool" arr1="Num Vertices">Is vertex connected to other (next?) vertex?</field>
     </niobject>
 
-    <compound name="Polygon" size="8">
+    <struct name="Polygon" size="8">
         Two dimensional screen elements.
         <field name="Num Vertices" type="ushort" />
         <field name="Vertex Offset" type="ushort">Offset in vertex array.</field>
         <field name="Num Triangles" type="ushort" />
         <field name="Triangle Offset" type="ushort">Offset in indices array.</field>
-    </compound>
+    </struct>
 
     <niobject name="NiScreenElementsData" inherit="NiTriShapeData" module="NiMain">
         DEPRECATED (20.5), functionality included in NiMeshScreenElements.
@@ -6412,10 +6412,10 @@
         <option bit="31" name="Refraction_Writes_Depth" />
     </bitflags>
 
-    <compound name="BSTextureArray" versions="#F76#">
+    <struct name="BSTextureArray" versions="#F76#">
         <field name="Texture Array Width" type="uint" />
         <field name="Texture Array" type="SizedString" arr1="Texture Array Width" />
-    </compound>
+    </struct>
 
     <enum name="BSShaderCRC32" storage="uint" prefix="SF" versions="#F76#">
         <option name="CAST_SHADOWS" value="1563274220" />
@@ -6451,7 +6451,7 @@
         <option name="LOD_OBJECTS" value="2896726515" />
     </enum>
 
-    <compound name="BSSPWetnessParams" module="BSMain" versions="#FO4# #F76#">
+    <struct name="BSSPWetnessParams" module="BSMain" versions="#FO4# #F76#">
         <field name="Spec Scale" type="float" default="-1.0" />
         <field name="Spec Power" type="float" default="-1.0" />
         <field name="Min Var" type="float" default="-1.0" />
@@ -6460,22 +6460,22 @@
         <field name="Metalness" type="float" default="-1.0" />
         <field name="Unknown 1" type="float" default="-1.0" vercond="#BS_F76#" />
         <field name="Unknown 2" type="float" default="-1.0" vercond="#BS_F76#" />
-    </compound>
+    </struct>
 
-    <compound name="BSSPLuminanceParams" module="BSMain" versions="#F76#">
+    <struct name="BSSPLuminanceParams" module="BSMain" versions="#F76#">
         <field name="Lum Emittance" type="float" default="100.0" range="#F_POS#" />
         <field name="Exposure Offset" type="float" default="13.5" range="#F_POS#" />
         <field name="Final Exposure Min" type="float" default="2.0" range="#F_POS#" />
         <field name="Final Exposure Max" type="float" default="3.0" range="#F_POS#" />
-    </compound>
+    </struct>
 
-    <compound name="BSSPTranslucencyParams" module="BSMain" versions="#F76#">
+    <struct name="BSSPTranslucencyParams" module="BSMain" versions="#F76#">
         <field name="Subsurface Color" type="Color3" />
         <field name="Transmissive Scale" type="float"/>
         <field name="Turbulence" type="float" />
         <field name="Thick Object" type="bool" />
         <field name="Mix Albedo" type="bool" />
-    </compound>
+    </struct>
 
     <niobject name="BSLightingShaderProperty" inherit="BSShaderProperty" module="BSMain" versions="#SKY_AND_LATER#">
         Bethesda shader property for Skyrim and later.
@@ -6753,12 +6753,12 @@
         <field name="Closest Point Min Distance" type="float">A distance which is used for getClosestPoint(). If the object being tested is closer, the children are recursed. Otherwise it returns this value.</field>
     </niobject>
 
-    <compound name="BSTreadTransform" size="68" versions="#FO3_AND_LATER#">
-        Bethesda-specific compound.
+    <struct name="BSTreadTransform" size="68" versions="#FO3_AND_LATER#">
+        Bethesda-specific struct.
         <field name="Name" type="NiFixedString" />
         <field name="Transform 1" type="NiQuatTransform" />
         <field name="Transform 2" type="NiQuatTransform" />
-    </compound>
+    </struct>
 
     <niobject name="BSTreadTransfInterpolator" inherit="NiInterpolator" module="BSAnimation" versions="#FO3_AND_LATER#">
         Bethesda-specific interpolator.
@@ -6835,15 +6835,15 @@
         <field name="Radius" type="float" />
     </niobject>
 
-    <compound name="BSGeometrySubSegment" size="16" versions="#FO3_AND_LATER#">
+    <struct name="BSGeometrySubSegment" size="16" versions="#FO3_AND_LATER#">
         This is only defined because of recursion issues.
         <field name="Start Index" type="uint" />
         <field name="Num Primitives" type="uint" />
         <field name="Parent Array Index" type="uint" />
         <field name="Unused" type="uint" />
-    </compound>
+    </struct>
 
-    <compound name="BSGeometrySegmentData" versions="#FO3_AND_LATER#">
+    <struct name="BSGeometrySegmentData" versions="#FO3_AND_LATER#">
         Bethesda-specific. Describes groups of triangles either segmented in a grid (for LOD) or by body part for skinned FO4 meshes.
         <field name="Flags" type="byte" vercond="#NI_BS_LT_FO4#" />
         <field name="Start Index" type="uint">Index = previous Index + previous Num Tris in Segment * 3</field>
@@ -6851,7 +6851,7 @@
         <field name="Parent Array Index" type="uint" vercond="#BS_GTE_FO4#" />
         <field name="Num Sub Segments" type="uint" vercond="#BS_GTE_FO4#" />
         <field name="Sub Segment" type="BSGeometrySubSegment" arr1="Num Sub Segments" vercond="#BS_GTE_FO4#" />
-    </compound>
+    </struct>
 
     <niobject name="BSSegmentedTriShape" inherit="NiTriShape" module="BSMain" versions="#FO3_AND_LATER#">
         Bethesda-specific AV object.
@@ -6865,7 +6865,7 @@
         <field name="Extent" type="Vector3">Extent of the AABB in all directions</field>
     </niobject>
 
-    <compound name="NiAGDDataStream">
+    <struct name="NiAGDDataStream">
         <field name="Type" type="uint">Type of data in this channel</field>
         <field name="Unit Size" type="uint">Number of bytes per element of this channel</field>
         <field name="Total Size" type="uint">Total number of bytes of this channel (num vertices times num bytes per element)</field>
@@ -6873,9 +6873,9 @@
         <field name="Block Index" type="uint">Unsure. The block in which this channel is stored? Usually there is only one block, and so this is zero.</field>
         <field name="Block Offset" type="uint">Offset (in bytes) of this channel. Sum of all num channel bytes per element of all preceeding block infos.</field>
         <field name="Flags" type="NiAGDDataStreamFlags" default="2" />
-    </compound>
+    </struct>
 
-    <compound name="NiAGDDataBlock">
+    <struct name="NiAGDDataBlock">
         <field name="Block Size" type="uint" />
         <field name="Num Blocks" type="uint" />
         <field name="Block Offsets" type="uint" arr1="Num Blocks" />
@@ -6885,12 +6885,12 @@
         <!-- NiBSPackedAGDDataBlock -->
         <field name="Shader Index" type="uint" cond="#ARG# == 1" />
         <field name="Total Size" type="uint" cond="#ARG# == 1" />
-    </compound>
+    </struct>
 
-    <compound name="NiAGDDataBlocks">
+    <struct name="NiAGDDataBlocks">
         <field name="Has Data" type="bool" />
         <field name="Data Block" type="NiAGDDataBlock" cond="Has Data" arg="#ARG#" />
-    </compound>
+    </struct>
 
     <niobject name="NiAdditionalGeometryData" inherit="AbstractAdditionalGeometryData" module="NiMain">
         <field name="Num Vertices" type="ushort" />
@@ -6969,11 +6969,11 @@
         <field name="Constraint" type="bhkWrappedConstraintData" arr1="Num Constraints" />
     </niobject>
 
-    <compound name="Region" size="8" since="V20_5_0_0">
+    <struct name="Region" size="8" since="V20_5_0_0">
         A range of indices, which make up a region (such as a submesh).
         <field name="Start Index" type="uint" />
         <field name="Num Indices" type="uint" />
-    </compound>
+    </struct>
 
     <enum name="CloningBehavior" storage="uint" since="V20_5_0_0">
         Sets how objects are to be cloned.
@@ -7082,7 +7082,7 @@
         <field name="Streamable" type="bool" default="1" />
     </niobject>
 
-    <compound name="SemanticData" size="8" since="V20_5_0_0">
+    <struct name="SemanticData" size="8" since="V20_5_0_0">
         <field name="Name" type="NiFixedString">
             Type of data (POSITION, POSITION_BP, INDEX, NORMAL, NORMAL_BP,
             TEXCOORD, BLENDINDICES, BLENDWEIGHT, BONE_PALETTE, COLOR, DISPLAYLIST,
@@ -7093,16 +7093,16 @@
             then the corresponding TEXCOORD data components would have indices
             0, 1, and 2, respectively.
         </field>
-    </compound>
+    </struct>
 
-    <compound name="DataStreamRef" since="V20_5_0_0">
+    <struct name="DataStreamRef" since="V20_5_0_0">
         <field name="Stream" type="Ref" template="NiDataStream">Reference to a data stream object which holds the data used by this reference.</field>
         <field name="Is Per Instance" type="bool" default="0">Sets whether this stream data is per-instance data for use in hardware instancing.</field>
         <field name="Num Submeshes" type="ushort" default="1">The number of submesh-to-region mappings that this data stream has.</field>
         <field name="Submesh To Region Map" type="ushort" arr1="Num Submeshes">A lookup table that maps submeshes to regions.</field>
         <field name="Num Components" type="uint" default="1" />
         <field name="Component Semantics" type="SemanticData" arr1="Num Components">Describes the semantic of each component.</field>
-    </compound>
+    </struct>
 
     <niobject name="NiRenderObject" abstract="true" inherit="NiAVObject" module="NiMain" since="V20_5_0_0">
         An object that can be rendered.
@@ -7139,27 +7139,27 @@
         <field name="Complete Points" type="SyncPoint" arr1="Num Complete Points">The sync points supported by this mesh modifier for CompleteTasks.</field>
     </niobject>
 
-    <compound name="MeshDataEpicMickey" versions="V20_6_5_0_DEM">
+    <struct name="MeshDataEpicMickey" versions="V20_6_5_0_DEM">
         <field name="Unknown 1" type="int" />
         <field name="Unknown 2" type="int" />
         <field name="Unknown 3" type="int" vercond="#USER# #GT# 14" />
         <field name="Unknown 4" type="int" />
         <field name="Unknown 5" type="float" />
         <field name="Unknown 6" type="int" />
-    </compound>
+    </struct>
 
-    <compound name="WeightDataEpicMickey" size="24" versions="V20_6_5_0_DEM">
+    <struct name="WeightDataEpicMickey" size="24" versions="V20_6_5_0_DEM">
         <field name="Bone Indices" type="int" arr1="3" />
         <field name="Weights" type="float" arr1="3" />
-    </compound>
+    </struct>
 
-    <compound name="PartitionDataEpicMickey" size="28" versions="V20_6_5_0_DEM">
+    <struct name="PartitionDataEpicMickey" size="28" versions="V20_6_5_0_DEM">
         <field name="Start" type="int" />
         <field name="End" type="int" />
         <field name="Weight Indices" type="ushort" arr1="10" />
-    </compound>
+    </struct>
 
-    <compound name="ExtraMeshDataEpicMickey" versions="V20_6_5_0_DEM">
+    <struct name="ExtraMeshDataEpicMickey" versions="V20_6_5_0_DEM">
         <field name="Unknown 1" type="uint" />
         <field name="Num Unknown Floats" type="uint" />
         <field name="Unknown Floats 1" type="float" arr1="Num Unknown Floats" />
@@ -7177,7 +7177,7 @@
         <field name="Partition Size" type="uint" />
         <field name="Partitions" type="PartitionDataEpicMickey" arr1="Partition Size" />
         <field name="Max Primitive Map Index" type="uint">The max value to appear in the Mapped Primitives array.</field>
-    </compound>
+    </struct>
 
     <niobject name="NiMesh" inherit="NiRenderObject" module="NiMesh" since="V20_5_0_0">
         <field name="Primitive Type" type="MeshPrimitiveType">The primitive type of the mesh, such as triangles or lines.</field>
@@ -7202,10 +7202,10 @@
         <field name="Target Names" type="NiFixedString" arr1="Num Targets" />
     </niobject>
 
-    <compound name="ElementReference" size="12" since="V20_5_0_0">
+    <struct name="ElementReference" size="12" since="V20_5_0_0">
         <field name="Semantic" type="SemanticData">The element semantic.</field>
         <field name="Normalize Flag" type="uint">Whether or not to normalize the data.</field>
-    </compound>
+    </struct>
 
     <niobject name="NiMorphMeshModifier" inherit="NiMeshModifier" module="NiMesh" since="V20_5_0_0">
         Performs linear-weighted blending between a set of target data streams.
@@ -7253,11 +7253,11 @@
         <field name="Instance Nodes" type="Ref" template="NiMeshHWInstance" arr1="Num Instance Nodes" cond="Has Instance Nodes" />
     </niobject>
 
-    <compound name="LODInfo">
+    <struct name="LODInfo">
         <field name="Num Bones" type="uint" />
         <field name="Num Active Skins" type="uint" />
         <field name="Skin Indices" type="uint" arr1="Num Active Skins" />
-    </compound>
+    </struct>
 
     <niobject name="NiSkinningLODController" inherit="NiTimeController" module="NiAnimation" since="V20_5_0_0">
         Defines the levels of detail for a given character and dictates the character's current LOD.
@@ -7273,10 +7273,10 @@
 
     <!-- NiPS Particle System -->
 
-    <compound name="PSSpawnRateKey" size="8" since="V20_5_0_0">
+    <struct name="PSSpawnRateKey" size="8" since="V20_5_0_0">
         <field name="Value" type="float" />
         <field name="Time" type="float" />
-    </compound>
+    </struct>
 
     <enum name="AlignMethod" storage="uint" since="V20_5_0_0">
         Describes the various methods that may be used to specify the orientation of the particles.
@@ -8141,20 +8141,20 @@
         <field name="LOD2 Size" type="uint" />
     </niobject>
     
-    <compound name="BSGeometryPerSegmentSharedData" size="16" versions="#FO4# #F76#">
+    <struct name="BSGeometryPerSegmentSharedData" size="16" versions="#FO4# #F76#">
         <field name="User Index" type="uint">If Bone ID is 0xffffffff, this value refers to the Segment at the listed index. Otherwise this is the "Biped Object", which is like the body part types in Skyrim and earlier.</field>
         <field name="Bone ID" type="uint" default="#UINT_MAX#">A hash of the bone name string.</field>
         <field name="Num Cut Offsets" type="uint" range="0:8">Maximum of 8.</field>
         <field name="Cut Offsets" type="float" arr1="Num Cut Offsets" />
-    </compound>
+    </struct>
 
-    <compound name="BSGeometrySegmentSharedData" versions="#FO4# #F76#">
+    <struct name="BSGeometrySegmentSharedData" versions="#FO4# #F76#">
         <field name="Num Segments" type="uint" />
         <field name="Total Segments" type="uint" />
         <field name="Segment Starts" type="uint" arr1="Num Segments" />
         <field name="Per Segment Data" type="BSGeometryPerSegmentSharedData" arr1="Total Segments" />>
         <field name="SSF File" type="SizedString16" />
-    </compound>
+    </struct>
 
     <niobject name="BSSubIndexTriShape" inherit="BSTriShape" module="BSMain" versions="#SSE# #FO4# #F76#">
         Fallout 4 Sub-Index Tri Shape
@@ -8203,13 +8203,13 @@
     
     <!-- Fallout 4 Skeleton -->
 
-    <compound name="BSSkinBoneTrans" size="68" versions="#FO4# #F76#">
+    <struct name="BSSkinBoneTrans" size="68" versions="#FO4# #F76#">
         Fallout 4 Bone Transform
         <field name="Bounding Sphere" type="NiBound" />
         <field name="Rotation" type="Matrix33" />
         <field name="Translation" type="Vector3" />
         <field name="Scale" type="float" />
-    </compound>
+    </struct>
 
     <niobject name="BSSkin::Instance" inherit="NiObject" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Skin Instance
@@ -8233,13 +8233,13 @@
         <field name="Data" type="hfloat" arr1="Num Data" />
     </niobject>
 
-    <compound name="BSConnectPoint" versions="#FO4# #F76#">
+    <struct name="BSConnectPoint" versions="#FO4# #F76#">
         <field name="Parent" type="SizedString" default="WorkshopConnectPoints" />
         <field name="Name" type="SizedString" />
         <field name="Rotation" type="Quaternion" />
         <field name="Translation" type="Vector3" />
         <field name="Scale" type="float" default="1.0" />
-    </compound>
+    </struct>
 
     <niobject name="BSConnectPoint::Parents" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Item Slot Parent
@@ -8260,13 +8260,13 @@
         <field name="Data" type="float" arr1="Num Data" />
     </niobject>
 	
-    <compound name="BSPackedGeomDataCombined" size="72" versions="#FO4# #F76#">
+    <struct name="BSPackedGeomDataCombined" size="72" versions="#FO4# #F76#">
         <field name="Grayscale to Palette Scale" type="float" />
         <field name="Transform" type="NiTransform" />
         <field name="Bounding Sphere" type="NiBound" />
-    </compound>
+    </struct>
 
-    <compound name="BSPackedGeomData" versions="#FO4# #F76#">
+    <struct name="BSPackedGeomData" versions="#FO4# #F76#">
         <field name="Num Verts" type="uint" />
         <field name="LOD Levels" type="uint" />
         <field name="Tri Count LOD0" type="uint" />
@@ -8280,9 +8280,9 @@
         <field name="Vertex Desc" type="BSVertexDesc" />
         <field name="Vertex Data" type="BSVertexData" arr1="Num Verts" arg="Vertex Desc #RSH# 44" />
         <field name="Triangles" type="Triangle" arr1="Tri Count LOD0 + Tri Count LOD1 + Tri Count LOD2" />
-    </compound>
+    </struct>
 
-    <compound name="BSPackedSharedGeomData" versions="#FO4# #F76#">
+    <struct name="BSPackedSharedGeomData" versions="#FO4# #F76#">
         <field name="Num Verts" type="uint" />
         <field name="LOD Levels" type="uint" />
         <field name="Tri Count LOD0" type="uint" />
@@ -8294,13 +8294,13 @@
         <field name="Num Combined" type="uint" />
         <field name="Combined" type="BSPackedGeomDataCombined" arr1="Num Combined" />
         <field name="Vertex Desc" type="BSVertexDesc" />
-    </compound>
+    </struct>
 
-    <compound name="BSPackedGeomObject" size="8" versions="#FO4# #F76#">
+    <struct name="BSPackedGeomObject" size="8" versions="#FO4# #F76#">
         This is the data necessary to access the shared geometry in a PSG/CSG file.
         <field name="Filename Hash" type="uint">BSCRC32 of the filename without the PSG/CSG extension.</field>
         <field name="Data Offset" type="uint">Offset of the geometry data in the PSG/CSG file.</field>
-    </compound>
+    </struct>
 
     <niobject name="BSPackedCombinedGeomDataExtra" inherit="NiExtraData" module="BSMain" versions="#FO4# #F76#">
         Fallout 4 Packed Combined Geometry Data.
@@ -8350,19 +8350,19 @@
         <field name="Distant Object Flags" type="uint" />
     </niobject>
 
-    <compound name="BSDistantObjectInstance" module="BSMain" versions="#F76#">
+    <struct name="BSDistantObjectInstance" module="BSMain" versions="#F76#">
         <field name="Unknown Bytes 1" type="byte" arr1="12" />
         <field name="Num Unknown 1" type="uint" />
         <field name="Unknown Ints 1" type="uint" arr1="3 #MUL# Num Unknown 1" />
         <field name="Num Unknown 2" type="uint" />
         <field name="Unknown Bytes 2" type="byte" binary="true" arr1="64 #MUL# Num Unknown 2" />
-    </compound>
+    </struct>
 
-    <compound name="BSDistantObjectTextureArray" module="BSMain" versions="#F76#">
+    <struct name="BSDistantObjectTextureArray" module="BSMain" versions="#F76#">
         <field name="Unknown Byte" type="byte" default="1" />
         <field name="Num Texture Arrays" type="uint" />
         <field name="Texture Arrays" type="BSTextureArray" arr1="Num Texture Arrays" />
-    </compound>
+    </struct>
 
     <niobject name="BSDistantObjectInstancedNode" inherit="BSMultiBoundNode" module="BSMain" versions="#F76#">
         <field name="Num Instances" type="uint" />

--- a/nif.xml
+++ b/nif.xml
@@ -3377,14 +3377,14 @@
         <field name="Flags" type="bhkCOFlags" default="1">
             OB-FO3: Add 0x28 (SET_LOCAL | USE_VEL) for ANIM_STATIC layer objects.
             Post-FO3: Always add 0x80 (SYNC_ON_UPDATE).
-            <default type="bhkCollisionObject" value="0x81" />
-            <default type="bhkCollisionObject" value="0x1" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
-            <default type="bhkPCollisionObject" value="0x81" />
-            <default type="bhkPCollisionObject" value="0x1" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
-            <default type="bhkSPCollisionObject" value="0x81" />
-            <default type="bhkSPCollisionObject" value="0x1" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
-            <default type="bhkBlendCollisionObject" value="0x89" />
-            <default type="bhkBlendCollisionObject" value="0x9" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
+            <default onlyT="bhkCollisionObject" value="0x81" />
+            <default onlyT="bhkCollisionObject" value="0x1" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
+            <default onlyT="bhkPCollisionObject" value="0x81" />
+            <default onlyT="bhkPCollisionObject" value="0x1" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
+            <default onlyT="bhkSPCollisionObject" value="0x81" />
+            <default onlyT="bhkSPCollisionObject" value="0x1" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
+            <default onlyT="bhkBlendCollisionObject" value="0x89" />
+            <default onlyT="bhkBlendCollisionObject" value="0x9" versions="V20_2_0_7_FO3 V20_0_0_5_OBL" />
         </field>
         <field name="Body" type="Ref" template="bhkWorldObject" />
     </niobject>
@@ -3417,40 +3417,40 @@
             BSTreeNode: 0x8080E (pre-FO4), 0x400E (FO4)
             BSLeafAnimNode: 0x808000E (pre-FO4), 0x500E (FO4)
             BSDamageStage, BSBlastNode: 0x8000F (pre-FO4), 0x2000000F (FO4)
-            <default type="NiNode" value="0xE" />
-            <default type="NiNode" value="0x8000E" versions="V20_2_0_7_FO3" />
-            <default type="NiLight" value="0xE" />
-            <default type="NiLight" value="0x8000E" versions="V20_2_0_7_FO3" />
-            <default type="BSMultiBoundNode" value="0xE" />
-            <default type="BSMultiBoundNode" value="0x8080E" versions="V20_2_0_7_FO3" />
-            <default type="BSTriShape" value="0xE" />
-            <default type="BSTriShape" value="0x8000E" versions="V20_2_0_7_SSE" />
-            <default type="BSSubIndexTriShape" value="0xE" />
-            <default type="BSMeshLODTriShape" value="0x100E" />
-            <default type="BSFadeNode" value="0x8000E" />
-            <default type="NiParticleSystem" value="0x8000E" />
-            <default type="BSMasterParticleSystem" value="0x8000E" />
-            <default type="NiParticleSystem" value="0xE" versions="V20_2_0_7_FO4" />
-            <default type="BSMasterParticleSystem" value="0xE" versions="V20_2_0_7_FO4" />
-            <default type="BSStripParticleSystem" value="0x8000E" />
-            <default type="NiTriShape" value="0x8000E" />
-            <default type="NiTriStrips" value="0x8000E" />
-            <default type="BSSegmentedTriShape" value="0xE" />
-            <default type="BSSegmentedTriShape" value="0x8000E" versions="V20_2_0_7_FO3" />
-            <default type="BSLeafAnimNode" value="0x808000E" />
-            <default type="BSLeafAnimNode" value="0x500E" versions="V20_2_0_7_FO4" />
-            <default type="BSTreeNode" value="0x8080E" />
-            <default type="BSTreeNode" value="0x400E" versions="V20_2_0_7_FO4" />
-            <default type="BSDebrisNode" value="0x8000F" />
-            <default type="BSBlastNode" value="0x8000F" />
-            <default type="BSBlastNode" value="0x2000000F" versions="V20_2_0_7_FO4" />
-            <default type="BSDamageStage" value="0x8000F" />
-            <default type="BSDamageStage" value="0x2000000F" versions="V20_2_0_7_FO4" />
-            <default type="BSOrderedNode" value="0x8200E" />
-            <default type="BSOrderedNode" value="0x200E" versions="V20_2_0_7_FO4" />
-            <default type="BSOrderedNode" value="0x8000E" versions="V20_2_0_7_FO3" />
-            <default type="BSLODTriShape" value="0x800000E" versions="V20_2_0_7_SSE" />
-            <default type="BSLODTriShape" value="0x808000E" versions="V20_2_0_7_SKY" />
+            <default onlyT="NiNode" value="0xE" />
+            <default onlyT="NiNode" value="0x8000E" versions="V20_2_0_7_FO3" />
+            <default onlyT="NiLight" value="0xE" />
+            <default onlyT="NiLight" value="0x8000E" versions="V20_2_0_7_FO3" />
+            <default onlyT="BSMultiBoundNode" value="0xE" />
+            <default onlyT="BSMultiBoundNode" value="0x8080E" versions="V20_2_0_7_FO3" />
+            <default onlyT="BSTriShape" value="0xE" />
+            <default onlyT="BSTriShape" value="0x8000E" versions="V20_2_0_7_SSE" />
+            <default onlyT="BSSubIndexTriShape" value="0xE" />
+            <default onlyT="BSMeshLODTriShape" value="0x100E" />
+            <default onlyT="BSFadeNode" value="0x8000E" />
+            <default onlyT="NiParticleSystem" value="0x8000E" />
+            <default onlyT="BSMasterParticleSystem" value="0x8000E" />
+            <default onlyT="NiParticleSystem" value="0xE" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSMasterParticleSystem" value="0xE" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSStripParticleSystem" value="0x8000E" />
+            <default onlyT="NiTriShape" value="0x8000E" />
+            <default onlyT="NiTriStrips" value="0x8000E" />
+            <default onlyT="BSSegmentedTriShape" value="0xE" />
+            <default onlyT="BSSegmentedTriShape" value="0x8000E" versions="V20_2_0_7_FO3" />
+            <default onlyT="BSLeafAnimNode" value="0x808000E" />
+            <default onlyT="BSLeafAnimNode" value="0x500E" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSTreeNode" value="0x8080E" />
+            <default onlyT="BSTreeNode" value="0x400E" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSDebrisNode" value="0x8000F" />
+            <default onlyT="BSBlastNode" value="0x8000F" />
+            <default onlyT="BSBlastNode" value="0x2000000F" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSDamageStage" value="0x8000F" />
+            <default onlyT="BSDamageStage" value="0x2000000F" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSOrderedNode" value="0x8200E" />
+            <default onlyT="BSOrderedNode" value="0x200E" versions="V20_2_0_7_FO4" />
+            <default onlyT="BSOrderedNode" value="0x8000E" versions="V20_2_0_7_FO3" />
+            <default onlyT="BSLODTriShape" value="0x800000E" versions="V20_2_0_7_SSE" />
+            <default onlyT="BSLODTriShape" value="0x808000E" versions="V20_2_0_7_SKY" />
         </field>
         <field name="Flags" type="ushort" since="3.0" vercond="#BSVER# #LTE# 26">Basic flags for AV objects.</field>
         <field name="Translation" type="Vector3">The translation vector.</field>
@@ -3517,32 +3517,32 @@
         <field name="Name" type="string">Used to locate the modifier.</field>
         <field name="Order" type="NiPSysModifierOrder" default="ORDER_GENERAL">
             Modifier's priority in the particle modifier chain.
-            <default type="NiPSysAgeDeathModifier" value="ORDER_KILLOLDPARTICLES" />
-            <default type="NiPSysMeshEmitter" value="ORDER_EMITTER" />
-            <default type="NiPSysVolumeEmitter" value="ORDER_EMITTER" />
-            <default type="NiPSysSpawnModifier" value="ORDER_EMITTER" />
-            <default type="NiPSysColorModifier" value="ORDER_GENERAL" />
-            <default type="NiPSysGrowFadeModifier" value="ORDER_GENERAL" />
-            <default type="NiPSysRotationModifier" value="ORDER_GENERAL" />
-            <default type="NiPSysBombModifier" value="ORDER_FORCE" />
-            <default type="NiPSysDragModifier" value="ORDER_FORCE" />
-            <default type="NiPSysFieldModifier" value="ORDER_FORCE" />
-            <default type="NiPSysGravityModifier" value="ORDER_FORCE" />
-            <default type="NiPSysColliderManager" value="ORDER_COLLIDER" />
-            <default type="NiPSysPositionModifier" value="ORDER_POS_UPDATE" />
-            <default type="NiPSysMeshUpdateModifier" value="ORDER_POSTPOS_UPDATE" />
-            <default type="NiPSysBoundUpdateModifier" value="ORDER_BOUND_UPDATE" />
-            <default type="BSPSysInheritVelocityModifier" value="ORDER_EMITTER" />
-            <default type="BSPSysScaleModifier" value="ORDER_GENERAL" />
-            <default type="BSPSysSimpleColorModifier" value="ORDER_GENERAL" />
-            <default type="BSPSysSubTexModifier" value="ORDER_GENERAL" />
-            <default type="BSParentVelocityModifier" value="ORDER_GENERAL" />
-            <default type="BSWindModifier" value="ORDER_FORCE" />
-            <default type="BSPSysRecycleBoundModifier" value="ORDER_POSTPOS_UPDATE" />
-            <default type="BSPSysLODModifier" value="ORDER_BSLOD" />
-            <default type="BSPSysStripUpdateModifier" value="ORDER_FO3_BSSTRIPUPDATE" versions="V20_2_0_7_FO3" />
-            <default type="BSPSysStripUpdateModifier" value="ORDER_SK_BSSTRIPUPDATE" versions="V20_2_0_7_SKY V20_2_0_7_SSE" />
-            <default type="NiPSysPartSpawnModifier" value="ORDER_WORLDSHIFT_PARTSPAWN" />
+            <default onlyT="NiPSysAgeDeathModifier" value="ORDER_KILLOLDPARTICLES" />
+            <default onlyT="NiPSysMeshEmitter" value="ORDER_EMITTER" />
+            <default onlyT="NiPSysVolumeEmitter" value="ORDER_EMITTER" />
+            <default onlyT="NiPSysSpawnModifier" value="ORDER_EMITTER" />
+            <default onlyT="NiPSysColorModifier" value="ORDER_GENERAL" />
+            <default onlyT="NiPSysGrowFadeModifier" value="ORDER_GENERAL" />
+            <default onlyT="NiPSysRotationModifier" value="ORDER_GENERAL" />
+            <default onlyT="NiPSysBombModifier" value="ORDER_FORCE" />
+            <default onlyT="NiPSysDragModifier" value="ORDER_FORCE" />
+            <default onlyT="NiPSysFieldModifier" value="ORDER_FORCE" />
+            <default onlyT="NiPSysGravityModifier" value="ORDER_FORCE" />
+            <default onlyT="NiPSysColliderManager" value="ORDER_COLLIDER" />
+            <default onlyT="NiPSysPositionModifier" value="ORDER_POS_UPDATE" />
+            <default onlyT="NiPSysMeshUpdateModifier" value="ORDER_POSTPOS_UPDATE" />
+            <default onlyT="NiPSysBoundUpdateModifier" value="ORDER_BOUND_UPDATE" />
+            <default onlyT="BSPSysInheritVelocityModifier" value="ORDER_EMITTER" />
+            <default onlyT="BSPSysScaleModifier" value="ORDER_GENERAL" />
+            <default onlyT="BSPSysSimpleColorModifier" value="ORDER_GENERAL" />
+            <default onlyT="BSPSysSubTexModifier" value="ORDER_GENERAL" />
+            <default onlyT="BSParentVelocityModifier" value="ORDER_GENERAL" />
+            <default onlyT="BSWindModifier" value="ORDER_FORCE" />
+            <default onlyT="BSPSysRecycleBoundModifier" value="ORDER_POSTPOS_UPDATE" />
+            <default onlyT="BSPSysLODModifier" value="ORDER_BSLOD" />
+            <default onlyT="BSPSysStripUpdateModifier" value="ORDER_FO3_BSSTRIPUPDATE" versions="V20_2_0_7_FO3" />
+            <default onlyT="BSPSysStripUpdateModifier" value="ORDER_SK_BSSTRIPUPDATE" versions="V20_2_0_7_SKY V20_2_0_7_SSE" />
+            <default onlyT="NiPSysPartSpawnModifier" value="ORDER_WORLDSHIFT_PARTSPAWN" />
         </field>
         <field name="Target" type="Ptr" template="NiParticleSystem">NiParticleSystem parent of this modifier.</field>
         <field name="Active" type="bool" default="1">Whether or not the modifier is active.</field>
@@ -7508,15 +7508,15 @@
         <field name="Name" type="NiFixedString" />
         <field name="Type" type="PSForceType">
             The force type is set by each derived class and cannot be changed.
-            <default type="NiPSBombForce" value="FORCE_BOMB" />
-            <default type="NiPSDragForce" value="FORCE_DRAG" />
-            <default type="NiPSAirFieldForce" value="FORCE_AIR_FIELD" />
-            <default type="NiPSDragFieldForce" value="FORCE_DRAG_FIELD" />
-            <default type="NiPSGravityFieldForce" value="FORCE_GRAVITY_FIELD" />
-            <default type="NiPSRadialFieldForce" value="FORCE_RADIAL_FIELD" />
-            <default type="NiPSTurbulenceFieldForce" value="FORCE_TURBULENCE_FIELD" />
-            <default type="NiPSVortexFieldForce" value="FORCE_VORTEX_FIELD" />
-            <default type="NiPSGravityForce" value="FORCE_GRAVITY" />
+            <default onlyT="NiPSBombForce" value="FORCE_BOMB" />
+            <default onlyT="NiPSDragForce" value="FORCE_DRAG" />
+            <default onlyT="NiPSAirFieldForce" value="FORCE_AIR_FIELD" />
+            <default onlyT="NiPSDragFieldForce" value="FORCE_DRAG_FIELD" />
+            <default onlyT="NiPSGravityFieldForce" value="FORCE_GRAVITY_FIELD" />
+            <default onlyT="NiPSRadialFieldForce" value="FORCE_RADIAL_FIELD" />
+            <default onlyT="NiPSTurbulenceFieldForce" value="FORCE_TURBULENCE_FIELD" />
+            <default onlyT="NiPSVortexFieldForce" value="FORCE_VORTEX_FIELD" />
+            <default onlyT="NiPSGravityForce" value="FORCE_GRAVITY" />
         </field>
         <field name="Active" type="bool" />
     </niobject>

--- a/nif.xml
+++ b/nif.xml
@@ -28,6 +28,10 @@
             Note: A unique game name should only have `{{}}` around it once.
     -->
 
+    <verattr name="num" access="#VER#" index="0" />
+    <verattr name="user" access="#USER#" index="1" />
+    <verattr name="bsver" access="#BSVER#" index="2" />
+
     <version id="V2_3" num="2.3" supported="false">Dark Age of Camelot</version>
     <version id="V3_0" num="3.0" supported="false">Star Trek: Bridge Commander</version>
     <version id="V3_03" num="3.03" supported="false">Dark Age of Camelot</version>
@@ -199,7 +203,7 @@
         <range token="#FPM_1000#" string="-1000.0:1000.0" />
     </token>
 
-    <token name="global" attrs="vercond">
+    <token name="global" attrs="vercond access">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#VER#" string="Version" />
@@ -2208,7 +2212,7 @@
         <field name="Entry Properties" type="FurnitureEntryPoints" vercond="#BS_GT_FO3#" />
     </struct>
 
-    <bitfield name="bhkWeldInfo" storage="ushort">
+    <bitfield name="bhkWeldInfo" storage="ushort" module="BSHavok">
         <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
         <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
         <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
@@ -3355,7 +3359,7 @@
         <field name="Bounding Volume" type="BoundingVolume" cond="Use ABV == 1" />
     </niobject>
 
-    <bitflags name="bhkCOFlags" storage="ushort" prefix="BHKCO" versions="#BETHESDA#">
+    <bitflags name="bhkCOFlags" storage="ushort" prefix="BHKCO" versions="#BETHESDA#" module="BSHavok">
         bhkNiCollisionObject flags.
         0x100 and 0x200 are only for bhkBlendCollisionObject
         <option bit="0" name="ACTIVE" />
@@ -8088,7 +8092,7 @@
         <!--<option value="6" name="NONE" />-->
     </enum>
 
-    <enum name="bhkCMSMatType" storage="byte" prefix="CMS">
+    <enum name="bhkCMSMatType" storage="byte" prefix="CMS" module="BSHavok">
         hkpCompressedMeshShape::MaterialType
         <option value="1" name="SINGLE_VALUE_PER_CHUNK">Chunk builder makes sure that only chunks with the same material are created.</option>
         <!--<option value="2" name="ONE_BYTE_PER_TRIANGLE" />-->

--- a/nif.xml
+++ b/nif.xml
@@ -1586,8 +1586,8 @@
 
     <compound name="string">
         A string type.
-        <field name="String" type="SizedString" ver2="20.0.0.5">The normal string.</field>
-        <field name="Index" type="NiFixedString" ver1="20.1.0.3">The string index.</field>
+        <field name="String" type="SizedString" until="20.0.0.5">The normal string.</field>
+        <field name="Index" type="NiFixedString" since="20.1.0.3">The string index.</field>
     </compound>
 
     <compound name="NiTFixedStringMapItem" generic="true">
@@ -1648,21 +1648,21 @@
 
     <compound name="FilePath">
         A string that contains the path to a file.
-        <field name="String" type="SizedString" ver2="20.0.0.5">The normal string.</field>
-        <field name="Index" type="NiFixedString" ver1="20.1.0.3">The string index.</field>
+        <field name="String" type="SizedString" until="20.0.0.5">The normal string.</field>
+        <field name="Index" type="NiFixedString" since="20.1.0.3">The string index.</field>
     </compound>
 
     <compound name="Footer">
         The NIF file footer.
-        <field name="Num Roots" type="uint" ver1="3.3.0.13">The number of root references.</field>
-        <field name="Roots" type="Ref" template="NiObject" arr1="Num Roots" ver1="3.3.0.13">List of root NIF objects. If there is a camera, for 1st person view, then this NIF object is referred to as well in this list, even if it is not a root object (usually we want the camera to be attached to the Bip Head node).</field>
+        <field name="Num Roots" type="uint" since="3.3.0.13">The number of root references.</field>
+        <field name="Roots" type="Ref" template="NiObject" arr1="Num Roots" since="3.3.0.13">List of root NIF objects. If there is a camera, for 1st person view, then this NIF object is referred to as well in this list, even if it is not a root object (usually we want the camera to be attached to the Bip Head node).</field>
     </compound>
 
     <compound name="LODRange">
         The distance range where a specific level of detail applies.
         <field name="Near Extent" type="float">Begining of range.</field>
         <field name="Far Extent" type="float">End of Range.</field>
-        <field name="Unknown Ints" type="uint" arr1="3" ver2="3.1" />
+        <field name="Unknown Ints" type="uint" arr1="3" until="3.1" />
     </compound>
 
     <compound name="MatchGroup">
@@ -1837,32 +1837,32 @@
         For Controller ID, NiInterpController::GetCtlrID() virtual function returns a string formatted specifically for the derived type.
         For Interpolator ID, NiInterpController::GetInterpolatorID() virtual function returns a string formatted specifically for the derived type.
         The string formats are documented on the relevant niobject blocks.
-        <field name="Target Name" type="SizedString" ver2="10.1.0.103">Name of a controllable object in another NIF file.</field>
+        <field name="Target Name" type="SizedString" until="10.1.0.103">Name of a controllable object in another NIF file.</field>
         <!-- NiControllerSequence::InterpArrayItem -->
-        <field name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.106" />
-        <field name="Controller" type="Ref" template="NiTimeController" ver2="20.5.0.0" />
-        <field name="Blend Interpolator" type="Ref" template="NiBlendInterpolator" ver1="10.1.0.104" ver2="10.1.0.110" />
-        <field name="Blend Index" type="ushort" ver1="10.1.0.104" ver2="10.1.0.110" />
-        <field name="Priority" type="byte" ver1="10.1.0.106" vercond="#BSSTREAM#">Idle animations tend to have low values for this, and high values tend to correspond with the important parts of the animations.</field>
+        <field name="Interpolator" type="Ref" template="NiInterpolator" since="10.1.0.106" />
+        <field name="Controller" type="Ref" template="NiTimeController" until="20.5.0.0" />
+        <field name="Blend Interpolator" type="Ref" template="NiBlendInterpolator" since="10.1.0.104" until="10.1.0.110" />
+        <field name="Blend Index" type="ushort" since="10.1.0.104" until="10.1.0.110" />
+        <field name="Priority" type="byte" since="10.1.0.106" vercond="#BSSTREAM#">Idle animations tend to have low values for this, and high values tend to correspond with the important parts of the animations.</field>
         <!-- NiControllerSequence::IDTag, post-10.1.0.104 only -->
-        <field name="Node Name" type="string" ver1="10.1.0.104" ver2="10.1.0.113">The name of the animated NiAVObject.</field>
-        <field name="Property Type" type="string" ver1="10.1.0.104" ver2="10.1.0.113">The RTTI type of the NiProperty the controller is attached to, if applicable.</field>
-        <field name="Controller Type" type="string" ver1="10.1.0.104" ver2="10.1.0.113">The RTTI type of the NiTimeController.</field>
-        <field name="Controller ID" type="string" ver1="10.1.0.104" ver2="10.1.0.113">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
-        <field name="Interpolator ID" type="string" ver1="10.1.0.104" ver2="10.1.0.113">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
+        <field name="Node Name" type="string" since="10.1.0.104" until="10.1.0.113">The name of the animated NiAVObject.</field>
+        <field name="Property Type" type="string" since="10.1.0.104" until="10.1.0.113">The RTTI type of the NiProperty the controller is attached to, if applicable.</field>
+        <field name="Controller Type" type="string" since="10.1.0.104" until="10.1.0.113">The RTTI type of the NiTimeController.</field>
+        <field name="Controller ID" type="string" since="10.1.0.104" until="10.1.0.113">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
+        <field name="Interpolator ID" type="string" since="10.1.0.104" until="10.1.0.113">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
         <!-- From 10.2 to 20.1 -->
-        <field name="String Palette" type="Ref" template="NiStringPalette" ver1="10.2.0.0" ver2="20.1.0.0">Refers to the NiStringPalette which contains the name of the controlled NIF object.</field>
-        <field name="Node Name Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to the name of the animated NiAVObject.</field>
-        <field name="Property Type Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to the RTTI type of the NiProperty the controller is attached to, if applicable.</field>
-        <field name="Controller Type Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to the RTTI type of the NiTimeController.</field>
-        <field name="Controller ID Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to an ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
-        <field name="Interpolator ID Offset" type="StringOffset" ver1="10.2.0.0" ver2="20.1.0.0">Offset in NiStringPalette to an ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
+        <field name="String Palette" type="Ref" template="NiStringPalette" since="10.2.0.0" until="20.1.0.0">Refers to the NiStringPalette which contains the name of the controlled NIF object.</field>
+        <field name="Node Name Offset" type="StringOffset" since="10.2.0.0" until="20.1.0.0">Offset in NiStringPalette to the name of the animated NiAVObject.</field>
+        <field name="Property Type Offset" type="StringOffset" since="10.2.0.0" until="20.1.0.0">Offset in NiStringPalette to the RTTI type of the NiProperty the controller is attached to, if applicable.</field>
+        <field name="Controller Type Offset" type="StringOffset" since="10.2.0.0" until="20.1.0.0">Offset in NiStringPalette to the RTTI type of the NiTimeController.</field>
+        <field name="Controller ID Offset" type="StringOffset" since="10.2.0.0" until="20.1.0.0">Offset in NiStringPalette to an ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
+        <field name="Interpolator ID Offset" type="StringOffset" since="10.2.0.0" until="20.1.0.0">Offset in NiStringPalette to an ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
         <!-- After 20.1 -->
-        <field name="Node Name" type="string" ver1="20.1.0.1">The name of the animated NiAVObject.</field>
-        <field name="Property Type" type="string" ver1="20.1.0.1">The RTTI type of the NiProperty the controller is attached to, if applicable.</field>
-        <field name="Controller Type" type="string" ver1="20.1.0.1">The RTTI type of the NiTimeController.</field>
-        <field name="Controller ID" type="string" ver1="20.1.0.1">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
-        <field name="Interpolator ID" type="string" ver1="20.1.0.1">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
+        <field name="Node Name" type="string" since="20.1.0.1">The name of the animated NiAVObject.</field>
+        <field name="Property Type" type="string" since="20.1.0.1">The RTTI type of the NiProperty the controller is attached to, if applicable.</field>
+        <field name="Controller Type" type="string" since="20.1.0.1">The RTTI type of the NiTimeController.</field>
+        <field name="Controller ID" type="string" since="20.1.0.1">An ID that can uniquely identify the controller among others of the same type on the same NiObjectNET.</field>
+        <field name="Interpolator ID" type="string" since="20.1.0.1">An ID that can uniquely identify the interpolator among others of the same type on the same NiObjectNET.</field>
     </compound>
 
     <compound name="BSStreamHeader" versions="#BETHESDA#">
@@ -1879,23 +1879,23 @@
     <compound name="Header">
         The NIF file header.
         <field name="Header String" type="HeaderString">'NetImmerse File Format x.x.x.x' (versions &lt;= 10.0.1.2) or 'Gamebryo File Format x.x.x.x' (versions &gt;= 10.1.0.0), with x.x.x.x the version written out. Ends with a newline character (0x0A).</field>
-        <field name="Copyright" type="LineString" arr1="3" ver2="3.1.0.0" />
-        <field name="Version" type="FileVersion" default="0x04000002" ver1="3.1.0.1">The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002, 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...</field>
-        <field name="Endian Type" type="EndianType" default="ENDIAN_LITTLE" ver1="20.0.0.3">Determines the endianness of the data in the file.</field>
-        <field name="User Version" type="ulittle32" ver1="10.0.1.8">An extra version number, for companies that decide to modify the file format.</field>
-        <field name="Num Blocks" type="ulittle32" ver1="3.1.0.1">Number of file objects.</field>
+        <field name="Copyright" type="LineString" arr1="3" until="3.1.0.0" />
+        <field name="Version" type="FileVersion" default="0x04000002" since="3.1.0.1">The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002, 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...</field>
+        <field name="Endian Type" type="EndianType" default="ENDIAN_LITTLE" since="20.0.0.3">Determines the endianness of the data in the file.</field>
+        <field name="User Version" type="ulittle32" since="10.0.1.8">An extra version number, for companies that decide to modify the file format.</field>
+        <field name="Num Blocks" type="ulittle32" since="3.1.0.1">Number of file objects.</field>
         <field name="BS Header" type="BSStreamHeader" cond="#BSSTREAMHEADER#" />
-        <field name="Metadata" type="ByteArray" ver1="30.0.0.0" />
-        <field name="Num Block Types" type="ushort" ver1="5.0.0.1">Number of object types in this NIF file.</field>
-        <field name="Block Types" type="SizedString" arr1="Num Block Types" ver1="5.0.0.1" cond="Version != 20.3.1.2">List of all object types used in this NIF file.</field>
-        <field name="Block Type Hashes" type="uint" arr1="Num Block Types" ver1="20.3.1.2" ver2="20.3.1.2">List of all object types used in this NIF file.</field>
-        <field name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" ver1="5.0.0.1">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</field>
-        <field name="Block Size" type="uint" arr1="Num Blocks" ver1="20.2.0.5">Array of block sizes</field>
-        <field name="Num Strings" type="uint" ver1="20.1.0.1">Number of strings.</field>
-        <field name="Max String Length" type="uint" ver1="20.1.0.1">Maximum string length.</field>
-        <field name="Strings" type="SizedString" arr1="Num Strings" ver1="20.1.0.1">Strings.</field>
-        <field name="Num Groups" type="uint" default="0" ver1="5.0.0.6" />
-        <field name="Groups" type="uint" arr1="Num Groups" ver1="5.0.0.6" />
+        <field name="Metadata" type="ByteArray" since="30.0.0.0" />
+        <field name="Num Block Types" type="ushort" since="5.0.0.1">Number of object types in this NIF file.</field>
+        <field name="Block Types" type="SizedString" arr1="Num Block Types" since="5.0.0.1" cond="Version != 20.3.1.2">List of all object types used in this NIF file.</field>
+        <field name="Block Type Hashes" type="uint" arr1="Num Block Types" since="20.3.1.2" until="20.3.1.2">List of all object types used in this NIF file.</field>
+        <field name="Block Type Index" type="BlockTypeIndex" arr1="Num Blocks" since="5.0.0.1">Maps file objects on their corresponding type: first file object is of type object_types[object_type_index[0]], the second of object_types[object_type_index[1]], etc.</field>
+        <field name="Block Size" type="uint" arr1="Num Blocks" since="20.2.0.5">Array of block sizes</field>
+        <field name="Num Strings" type="uint" since="20.1.0.1">Number of strings.</field>
+        <field name="Max String Length" type="uint" since="20.1.0.1">Maximum string length.</field>
+        <field name="Strings" type="SizedString" arr1="Num Strings" since="20.1.0.1">Strings.</field>
+        <field name="Num Groups" type="uint" default="0" since="5.0.0.6" />
+        <field name="Groups" type="uint" arr1="Num Groups" since="5.0.0.6" />
     </compound>
 
     <compound name="StringPalette">
@@ -1929,8 +1929,8 @@
 
     <compound name="QuatKey" generic="true">
         A special version of the key type used for quaternions. Never has tangents. #T# should always be Quaternion.
-        <field name="Time" type="float" ver2="10.1.0.0">Time the key applies.</field>
-        <field name="Time" type="float" cond="#ARG# != 4" ver1="10.1.0.106">Time the key applies.</field>
+        <field name="Time" type="float" until="10.1.0.0">Time the key applies.</field>
+        <field name="Time" type="float" cond="#ARG# != 4" since="10.1.0.106">Time the key applies.</field>
         <field name="Value" type="#T#" cond="#ARG# != 4">Value of the key.</field>
         <field name="TBC" type="TBC" cond="#ARG# == 3">The TBC of the key.</field>
     </compound>
@@ -1957,23 +1957,23 @@
 
     <compound name="TexDesc">
         NiTexturingProperty::Map. Texture description.
-        <field name="Image" type="Ref" template="NiImage" ver2="3.1">Link to the texture image.</field>
-        <field name="Source" type="Ref" template="NiSourceTexture" ver1="3.3.0.13">NiSourceTexture object index.</field>
-        <field name="Clamp Mode" type="TexClampMode" default="WRAP_S_WRAP_T" ver2="20.0.0.5">0=clamp S clamp T, 1=clamp S wrap T, 2=wrap S clamp T, 3=wrap S wrap T</field>
-        <field name="Filter Mode" type="TexFilterMode" default="FILTER_TRILERP" ver2="20.0.0.5">0=nearest, 1=bilinear, 2=trilinear, 3=..., 4=..., 5=...</field>
-        <field name="Flags" type="TexturingMapFlags" ver1="20.1.0.3">Texture mode flags; clamp and filter mode stored in upper byte with 0xYZ00 = clamp mode Y, filter mode Z.</field>
-        <field name="Max Anisotropy" type="ushort" ver1="20.5.0.4" />
-        <field name="UV Set" type="uint" default="0" ver2="20.0.0.5">The texture coordinate set in NiGeometryData that this texture slot will use.</field>
-        <field name="PS2 L" type="short" default="0" ver2="10.4.0.1">L can range from 0 to 3 and are used to specify how fast a texture gets blurry.</field>
-        <field name="PS2 K" type="short" default="-75" ver2="10.4.0.1">K is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.</field>
-        <field name="Unknown Short 1" type="ushort" ver2="4.1.0.12" />
+        <field name="Image" type="Ref" template="NiImage" until="3.1">Link to the texture image.</field>
+        <field name="Source" type="Ref" template="NiSourceTexture" since="3.3.0.13">NiSourceTexture object index.</field>
+        <field name="Clamp Mode" type="TexClampMode" default="WRAP_S_WRAP_T" until="20.0.0.5">0=clamp S clamp T, 1=clamp S wrap T, 2=wrap S clamp T, 3=wrap S wrap T</field>
+        <field name="Filter Mode" type="TexFilterMode" default="FILTER_TRILERP" until="20.0.0.5">0=nearest, 1=bilinear, 2=trilinear, 3=..., 4=..., 5=...</field>
+        <field name="Flags" type="TexturingMapFlags" since="20.1.0.3">Texture mode flags; clamp and filter mode stored in upper byte with 0xYZ00 = clamp mode Y, filter mode Z.</field>
+        <field name="Max Anisotropy" type="ushort" since="20.5.0.4" />
+        <field name="UV Set" type="uint" default="0" until="20.0.0.5">The texture coordinate set in NiGeometryData that this texture slot will use.</field>
+        <field name="PS2 L" type="short" default="0" until="10.4.0.1">L can range from 0 to 3 and are used to specify how fast a texture gets blurry.</field>
+        <field name="PS2 K" type="short" default="-75" until="10.4.0.1">K is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.</field>
+        <field name="Unknown Short 1" type="ushort" until="4.1.0.12" />
         <!-- NiTextureTransform -->
-        <field name="Has Texture Transform" type="bool" default="false" ver1="10.1.0.0">Whether or not the texture coordinates are transformed.</field>
-        <field name="Translation" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The UV translation.</field>
-        <field name="Scale" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0" default="#VEC2_ONE#">The UV scale.</field>
-        <field name="Rotation" type="float" default="0.0" cond="Has Texture Transform" ver1="10.1.0.0">The W axis rotation in texture space.</field>
-        <field name="Transform Method" type="TransformMethod" cond="Has Texture Transform" ver1="10.1.0.0">Depending on the source, scaling can occur before or after rotation.</field>
-        <field name="Center" type="TexCoord" cond="Has Texture Transform" ver1="10.1.0.0">The origin around which the texture rotates.</field>
+        <field name="Has Texture Transform" type="bool" default="false" since="10.1.0.0">Whether or not the texture coordinates are transformed.</field>
+        <field name="Translation" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0">The UV translation.</field>
+        <field name="Scale" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0" default="#VEC2_ONE#">The UV scale.</field>
+        <field name="Rotation" type="float" default="0.0" cond="Has Texture Transform" since="10.1.0.0">The W axis rotation in texture space.</field>
+        <field name="Transform Method" type="TransformMethod" cond="Has Texture Transform" since="10.1.0.0">Depending on the source, scaling can occur before or after rotation.</field>
+        <field name="Center" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0">The origin around which the texture rotates.</field>
     </compound>
 
     <compound name="ShaderTexDesc">
@@ -2063,24 +2063,24 @@
         <field name="Num Strips" type="ushort">Number of strips in this submesh (zero if not stripped).</field>
         <field name="Num Weights Per Vertex" type="ushort" default="4">Number of weight coefficients per vertex. The Gamebryo engine seems to work well only if this number is equal to 4, even if there are less than 4 influences per vertex.</field>
         <field name="Bones" type="ushort" arr1="Num Bones">List of bones.</field>
-        <field name="Has Vertex Map" type="bool" ver1="10.1.0.0">Do we have a vertex map?</field>
-        <field name="Vertex Map" type="ushort" arr1="Num Vertices" ver2="10.0.1.2">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
-        <field name="Vertex Map" type="ushort" arr1="Num Vertices" cond="Has Vertex Map" ver1="10.1.0.0">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
-        <field name="Has Vertex Weights" type="bool" ver1="10.1.0.0">Do we have vertex weights?</field>
-        <field name="Vertex Weights" type="float" arr1="Num Vertices" arr2="Num Weights Per Vertex" ver2="10.0.1.2">The vertex weights.</field>
-        <field name="Vertex Weights" type="float" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Vertex Weights" ver1="10.1.0.0">The vertex weights.</field>
+        <field name="Has Vertex Map" type="bool" since="10.1.0.0">Do we have a vertex map?</field>
+        <field name="Vertex Map" type="ushort" arr1="Num Vertices" until="10.0.1.2">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
+        <field name="Vertex Map" type="ushort" arr1="Num Vertices" cond="Has Vertex Map" since="10.1.0.0">Maps the weight/influence lists in this submesh to the vertices in the shape being skinned.</field>
+        <field name="Has Vertex Weights" type="bool" since="10.1.0.0">Do we have vertex weights?</field>
+        <field name="Vertex Weights" type="float" arr1="Num Vertices" arr2="Num Weights Per Vertex" until="10.0.1.2">The vertex weights.</field>
+        <field name="Vertex Weights" type="float" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Vertex Weights" since="10.1.0.0">The vertex weights.</field>
         <field name="Strip Lengths" type="ushort" arr1="Num Strips">The strip lengths.</field>
-        <field name="Has Faces" type="bool" calc="(#LEN[Strips]# #ADD# #LEN[Triangles]# #GT# 0) #THEN# 1 #ELSE# 0" ver1="10.1.0.0">Do we have triangle or strip data?</field>
-        <field name="Strips" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="Num Strips != 0" ver2="10.0.1.2">The strips.</field>
-        <field name="Strips" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="(Has Faces) #AND# (Num Strips != 0)" ver1="10.1.0.0">The strips.</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Num Strips == 0" ver2="10.0.1.2">The triangles.</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="(Has Faces) #AND# (Num Strips == 0)" ver1="10.1.0.0">The triangles.</field>
+        <field name="Has Faces" type="bool" calc="(#LEN[Strips]# #ADD# #LEN[Triangles]# #GT# 0) #THEN# 1 #ELSE# 0" since="10.1.0.0">Do we have triangle or strip data?</field>
+        <field name="Strips" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="Num Strips != 0" until="10.0.1.2">The strips.</field>
+        <field name="Strips" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="(Has Faces) #AND# (Num Strips != 0)" since="10.1.0.0">The strips.</field>
+        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Num Strips == 0" until="10.0.1.2">The triangles.</field>
+        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="(Has Faces) #AND# (Num Strips == 0)" since="10.1.0.0">The triangles.</field>
         <field name="Has Bone Indices" type="bool">Do we have bone indices?</field>
         <field name="Bone Indices" type="byte" arr1="Num Vertices" arr2="Num Weights Per Vertex" cond="Has Bone Indices">Bone indices, they index into 'Bones'.</field>
-        <field name="LOD Level" type="byte" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
-        <field name="Global VB" type="bool" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
-		<field name="Vertex Desc" type="BSVertexDesc" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Triangles Copy" type="Triangle" arr1="Num Triangles" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_SSE#" />
+        <field name="LOD Level" type="byte" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Global VB" type="bool" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
+		<field name="Vertex Desc" type="BSVertexDesc" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Triangles Copy" type="Triangle" arr1="Num Triangles" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
     </compound>
 
     <compound name="NiPlane" size="16">
@@ -2099,7 +2099,7 @@
         A sphere.
         <field name="Center" type="Vector3">The sphere's center.</field>
         <field name="Radius" type="float">The sphere's radius.</field>
-        <field name="DIV2 AABB" type="NiBoundAABB" ver1="20.3.0.9" ver2="20.3.0.9" vercond="#DIVINITY2#" />
+        <field name="DIV2 AABB" type="NiBoundAABB" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
     </compound>
 
     <compound name="NiCurve3">
@@ -2115,7 +2115,7 @@
         <field name="Translation" type="Vector3" />
         <field name="Rotation" type="Quaternion" />
         <field name="Scale" type="float" default="1.0" />
-        <field name="TRS Valid" type="bool" arr1="3" ver2="10.1.0.109">Whether each transform component is valid.</field>
+        <field name="TRS Valid" type="bool" arr1="3" until="10.1.0.109">Whether each transform component is valid.</field>
     </compound>
 
     <compound name="NiTransform" size="52">
@@ -2155,16 +2155,16 @@
         Bethesda Havok. A triangle with extra data used for physics.
         <field name="Triangle" type="Triangle">The triangle.</field>
         <field name="Welding Info" type="ushort">Additional havok information on how triangles are welded.</field>
-        <field name="Normal" type="Vector3" ver2="20.0.0.5">This is the triangle's normal.</field>
+        <field name="Normal" type="Vector3" until="20.0.0.5">This is the triangle's normal.</field>
     </compound>
 
     <compound name="Morph">
         Geometry morphing data component.
-        <field name="Frame Name" type="string" ver1="10.1.0.106">Name of the frame.</field>
-        <field name="Num Keys" type="uint" ver2="10.1.0.0">The number of morph keys that follow.</field>
-        <field name="Interpolation" type="KeyType" ver2="10.1.0.0">Unlike most objects, the presense of this value is not conditional on there being keys.</field>
-        <field name="Keys" type="Key" arg="Interpolation" template="float" arr1="Num Keys" ver2="10.1.0.0">The morph key frames.</field>
-        <field name="Legacy Weight" type="float" ver1="10.1.0.104" ver2="20.1.0.2" vercond="#BSVER# #LT# 10" />
+        <field name="Frame Name" type="string" since="10.1.0.106">Name of the frame.</field>
+        <field name="Num Keys" type="uint" until="10.1.0.0">The number of morph keys that follow.</field>
+        <field name="Interpolation" type="KeyType" until="10.1.0.0">Unlike most objects, the presense of this value is not conditional on there being keys.</field>
+        <field name="Keys" type="Key" arg="Interpolation" template="float" arr1="Num Keys" until="10.1.0.0">The morph key frames.</field>
+        <field name="Legacy Weight" type="float" since="10.1.0.104" until="20.1.0.2" vercond="#BSVER# #LT# 10" />
         <field name="Vectors" type="Vector3" arr1="#ARG#">Morph vectors.</field>
     </compound>
 
@@ -2172,7 +2172,7 @@
         Called NiPerParticleData in NiOldParticles.
         Holds the state of a particle at the time the system was saved.
         <field name="Velocity" type="Vector3">Particle direction and speed.</field>
-        <field name="Rotation Axis" type="Vector3" ver2="10.4.0.1" />
+        <field name="Rotation Axis" type="Vector3" until="10.4.0.1" />
         <field name="Age" type="float" />
         <field name="Life Span" type="float" />
         <field name="Last Update" type="float">Timestamp of the last update.</field>
@@ -2185,13 +2185,13 @@
         <field name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</field>
         <field name="Bounding Sphere" type="NiBound">Note that its a Sphere Containing Axis Aligned Box not a minimum volume Sphere</field>
         <field name="Num Vertices" type="ushort">Number of weighted vertices.</field>
-        <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" ver2="4.2.1.0">The vertex weights.</field>
-        <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" ver1="4.2.2.0" cond="#ARG# != 0">The vertex weights.</field>
+        <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" until="4.2.1.0">The vertex weights.</field>
+        <field name="Vertex Weights" type="BoneVertData" arr1="Num Vertices" since="4.2.2.0" cond="#ARG# != 0">The vertex weights.</field>
     </compound>
 
     <compound name="HavokFilter" size="4" versions="#BETHESDA#">
         Bethesda Havok. Collision filter info representing Layer, Flags, Part Number, and Group all combined into one uint.
-        <field name="Layer" suffix="OB" type="OblivionLayer" default="OL_STATIC" ver2="20.0.0.5" vercond="#BSVER# #LT# 16">The layer the collision belongs to.</field>
+        <field name="Layer" suffix="OB" type="OblivionLayer" default="OL_STATIC" until="20.0.0.5" vercond="#BSVER# #LT# 16">The layer the collision belongs to.</field>
         <field name="Layer" suffix="FO" type="Fallout3Layer" default="FOL_STATIC" vercond="(#VER# == 20.2.0.7) #AND# #NI_BS_LTE_FO3#">The layer the collision belongs to.</field>
         <field name="Layer" suffix="SK" type="SkyrimLayer" default="SKYL_STATIC" vercond="(#VER# == 20.2.0.7) #AND# #BS_GT_FO3#">The layer the collision belongs to.</field>
         <field name="Flags" type="CollisionFilterFlags" default="0" />
@@ -2200,8 +2200,8 @@
 
     <compound name="HavokMaterial" versions="#BETHESDA#">
         Bethesda Havok. Material wrapper for varying material enums by game.
-        <field name="Unknown Int" type="uint" ver2="10.0.1.2" />
-        <field name="Material" suffix="OB" type="OblivionHavokMaterial" ver2="20.0.0.5" vercond="#BSVER# #LT# 16">The material of the shape.</field>
+        <field name="Unknown Int" type="uint" until="10.0.1.2" />
+        <field name="Material" suffix="OB" type="OblivionHavokMaterial" until="20.0.0.5" vercond="#BSVER# #LT# 16">The material of the shape.</field>
         <field name="Material" suffix="FO" type="Fallout3HavokMaterial" vercond="(#VER# == 20.2.0.7) #AND# #NI_BS_LTE_FO3#">The material of the shape.</field>
         <field name="Material" suffix="SK" type="SkyrimHavokMaterial" vercond="(#VER# == 20.2.0.7) #AND# #BS_GT_FO3#">The material of the shape.</field>
     </compound>
@@ -2318,7 +2318,7 @@
         <field name="Twist Max Angle" type="float">Maximum angle the object can rotate around Twist A, relative to Plane A.</field>
         <field name="Max Friction" type="float">Maximum friction, typically 0 or 10. In Fallout 3, typically 100.</field>
 
-        <field name="Motor" type="bhkConstraintMotorCInfo" ver1="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
+        <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
     </compound>
 
     <compound name="bhkLimitedHingeConstraintCInfo" versions="#BETHESDA#">
@@ -2349,27 +2349,27 @@
         <field name="Max Angle" type="float">Maximum rotation angle.</field>
         <field name="Max Friction" type="float">Maximum friction, typically either 0 or 10. In Fallout 3, typically 100.</field>
 
-        <field name="Motor" type="bhkConstraintMotorCInfo" ver1="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
+        <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
     </compound>
 
     <compound name="bhkHingeConstraintCInfo" versions="#BETHESDA#">
         Serialization data for bhkHingeConstraint. A basic hinge with no angular limits or motor.
         <!-- Oblivion -->
-        <field name="Pivot A" type="Vector4" ver2="20.0.0.5">Pivot point around which the object will rotate.</field>
-        <field name="Perp Axis In A1" type="Vector4" ver2="20.0.0.5">Vector in the rotation plane which defines the zero angle.</field>
-        <field name="Perp Axis In A2" type="Vector4" ver2="20.0.0.5">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation.</field>
-        <field name="Pivot B" type="Vector4" ver2="20.0.0.5">Pivot A in second entity coordinate system.</field>
-        <field name="Axis B" type="Vector4" ver2="20.0.0.5">Axis A (vector orthogonal on Perp Axes) in second entity coordinate system.</field>
+        <field name="Pivot A" type="Vector4" until="20.0.0.5">Pivot point around which the object will rotate.</field>
+        <field name="Perp Axis In A1" type="Vector4" until="20.0.0.5">Vector in the rotation plane which defines the zero angle.</field>
+        <field name="Perp Axis In A2" type="Vector4" until="20.0.0.5">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation.</field>
+        <field name="Pivot B" type="Vector4" until="20.0.0.5">Pivot A in second entity coordinate system.</field>
+        <field name="Axis B" type="Vector4" until="20.0.0.5">Axis A (vector orthogonal on Perp Axes) in second entity coordinate system.</field>
 
         <!-- Fallout 3 -->
-        <field name="Axis A" type="Vector4" ver1="20.2.0.7">Axis of rotation.</field>
-        <field name="Perp Axis In A1" type="Vector4" ver1="20.2.0.7">Vector in the rotation plane which defines the zero angle.</field>
-        <field name="Perp Axis In A2" type="Vector4" ver1="20.2.0.7">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axis A and Perp Axis In A1.</field>
-        <field name="Pivot A" type="Vector4" ver1="20.2.0.7">Pivot point around which the object will rotate.</field>
-        <field name="Axis B" type="Vector4" ver1="20.2.0.7">Axis A in second entity coordinate system.</field>
-        <field name="Perp Axis In B1" type="Vector4" ver1="20.2.0.7">Perp Axis In A1 in second entity coordinate system.</field>
-        <field name="Perp Axis In B2" type="Vector4" ver1="20.2.0.7">Perp Axis In A2 in second entity coordinate system.</field>
-        <field name="Pivot B" type="Vector4" ver1="20.2.0.7">Pivot A in second entity coordinate system.</field>
+        <field name="Axis A" type="Vector4" since="20.2.0.7">Axis of rotation.</field>
+        <field name="Perp Axis In A1" type="Vector4" since="20.2.0.7">Vector in the rotation plane which defines the zero angle.</field>
+        <field name="Perp Axis In A2" type="Vector4" since="20.2.0.7">Vector in the rotation plane, orthogonal on the previous one, which defines the positive direction of rotation. This is always the vector product of Axis A and Perp Axis In A1.</field>
+        <field name="Pivot A" type="Vector4" since="20.2.0.7">Pivot point around which the object will rotate.</field>
+        <field name="Axis B" type="Vector4" since="20.2.0.7">Axis A in second entity coordinate system.</field>
+        <field name="Perp Axis In B1" type="Vector4" since="20.2.0.7">Perp Axis In A1 in second entity coordinate system.</field>
+        <field name="Perp Axis In B2" type="Vector4" since="20.2.0.7">Perp Axis In A2 in second entity coordinate system.</field>
+        <field name="Pivot B" type="Vector4" since="20.2.0.7">Pivot A in second entity coordinate system.</field>
     </compound>
 
     <compound name="bhkBallAndSocketConstraintCInfo" size="32" versions="#BETHESDA#">
@@ -2384,31 +2384,31 @@
         Creates a rail between two bodies that allows translation along a single axis with linear limits and a motor.
         All three rotation axes and the remaining two translation axes are fixed.
         <!-- Oblivion -->
-        <field name="Pivot A" type="Vector4" ver2="20.0.0.5">Pivot.</field>
-        <field name="Rotation A" type="Vector4" ver2="20.0.0.5">Rotation axis.</field>
-        <field name="Plane A" type="Vector4" ver2="20.0.0.5">Plane normal. Describes the plane the object is able to move on.</field>
-        <field name="Sliding A" type="Vector4" ver2="20.0.0.5">Describes the axis the object is able to travel along. Unit vector.</field>
-        <field name="Sliding B" type="Vector4" ver2="20.0.0.5">Describes the axis the object is able to travel along in B coordinates. Unit vector.</field>
-        <field name="Pivot B" type="Vector4" ver2="20.0.0.5">Pivot in B coordinates.</field>
-        <field name="Rotation B" type="Vector4" ver2="20.0.0.5">Rotation axis.</field>
-        <field name="Plane B" type="Vector4" ver2="20.0.0.5">Plane normal. Describes the plane the object is able to move on in B coordinates.</field>
+        <field name="Pivot A" type="Vector4" until="20.0.0.5">Pivot.</field>
+        <field name="Rotation A" type="Vector4" until="20.0.0.5">Rotation axis.</field>
+        <field name="Plane A" type="Vector4" until="20.0.0.5">Plane normal. Describes the plane the object is able to move on.</field>
+        <field name="Sliding A" type="Vector4" until="20.0.0.5">Describes the axis the object is able to travel along. Unit vector.</field>
+        <field name="Sliding B" type="Vector4" until="20.0.0.5">Describes the axis the object is able to travel along in B coordinates. Unit vector.</field>
+        <field name="Pivot B" type="Vector4" until="20.0.0.5">Pivot in B coordinates.</field>
+        <field name="Rotation B" type="Vector4" until="20.0.0.5">Rotation axis.</field>
+        <field name="Plane B" type="Vector4" until="20.0.0.5">Plane normal. Describes the plane the object is able to move on in B coordinates.</field>
         
         <!-- Fallout 3 and later, Havok 660 and 2010
              In reality Havok loads these as Transform A and Transform B using hkTransform -->
-        <field name="Sliding A" type="Vector4" ver1="20.2.0.7">Describes the axis the object is able to travel along. Unit vector.</field>
-        <field name="Rotation A" type="Vector4" ver1="20.2.0.7">Rotation axis.</field>
-        <field name="Plane A" type="Vector4" ver1="20.2.0.7">Plane normal. Describes the plane the object is able to move on.</field>
-        <field name="Pivot A" type="Vector4" ver1="20.2.0.7">Pivot.</field>
-        <field name="Sliding B" type="Vector4" ver1="20.2.0.7">Describes the axis the object is able to travel along in B coordinates. Unit vector.</field>
-        <field name="Rotation B" type="Vector4" ver1="20.2.0.7">Rotation axis.</field>
-        <field name="Plane B" type="Vector4" ver1="20.2.0.7">Plane normal. Describes the plane the object is able to move on in B coordinates.</field>
-        <field name="Pivot B" type="Vector4" ver1="20.2.0.7">Pivot in B coordinates.</field>
+        <field name="Sliding A" type="Vector4" since="20.2.0.7">Describes the axis the object is able to travel along. Unit vector.</field>
+        <field name="Rotation A" type="Vector4" since="20.2.0.7">Rotation axis.</field>
+        <field name="Plane A" type="Vector4" since="20.2.0.7">Plane normal. Describes the plane the object is able to move on.</field>
+        <field name="Pivot A" type="Vector4" since="20.2.0.7">Pivot.</field>
+        <field name="Sliding B" type="Vector4" since="20.2.0.7">Describes the axis the object is able to travel along in B coordinates. Unit vector.</field>
+        <field name="Rotation B" type="Vector4" since="20.2.0.7">Rotation axis.</field>
+        <field name="Plane B" type="Vector4" since="20.2.0.7">Plane normal. Describes the plane the object is able to move on in B coordinates.</field>
+        <field name="Pivot B" type="Vector4" since="20.2.0.7">Pivot in B coordinates.</field>
 
         <field name="Min Distance" type="float">Describe the min distance the object is able to travel.</field>
         <field name="Max Distance" type="float">Describe the max distance the object is able to travel.</field>
         <field name="Friction" type="float">Friction.</field>
 
-        <field name="Motor" type="bhkConstraintMotorCInfo" ver1="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
+        <field name="Motor" type="bhkConstraintMotorCInfo" since="20.2.0.7" vercond="!#NI_BS_LTE_16#" />
     </compound>
 
     <compound name="bhkStiffSpringConstraintCInfo" size="36" versions="#BETHESDA#">
@@ -2553,9 +2553,9 @@
         <field name="Prismatic" type="bhkPrismaticConstraintCInfo" cond="Type == 6" />
         <field name="Ragdoll" type="bhkRagdollConstraintCInfo" cond="Type == 7" />
         <field name="Stiff Spring" type="bhkStiffSpringConstraintCInfo" cond="Type == 8" />
-        <field name="Tau" type="float" ver2="20.0.0.5" />
-        <field name="Damping" type="float" ver2="20.0.0.5" />
-        <field name="Strength" type="float" ver1="20.2.0.7" />
+        <field name="Tau" type="float" until="20.0.0.5" />
+        <field name="Damping" type="float" until="20.0.0.5" />
+        <field name="Strength" type="float" since="20.2.0.7" />
     </compound>
 
     <compound name="bhkWrappedConstraintData" versions="#BETHESDA#">
@@ -2627,7 +2627,7 @@
     <niobject name="NiParticleModifier" abstract="true" inherit="NiObject" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1). Abstract base class for particle system modifiers.
         <field name="Next Modifier" type="Ref" template="NiParticleModifier">Next particle modifier.</field>
-        <field name="Controller" type="Ptr" template="NiParticleSystemController" ver1="3.3.0.13">Points to the particle system controller parent.</field>
+        <field name="Controller" type="Ptr" template="NiParticleSystemController" since="3.3.0.13">Points to the particle system controller parent.</field>
     </niobject>
 
     <niobject name="NiPSysCollider" abstract="true" inherit="NiObject" module="NiParticle">
@@ -2673,7 +2673,7 @@
     <niobject name="bhkWorldObject" abstract="true" inherit="bhkSerializable" module="BSHavok" versions="#BETHESDA#">
         Bethesda extension of hkpWorldObject, the base class for hkpEntity and hkpPhantom.
         <field name="Shape" type="Ref" template="bhkShape">The shape for this collision object.</field>
-        <field name="Unknown Int" type="uint" ver2="10.0.1.2" />
+        <field name="Unknown Int" type="uint" until="10.0.1.2" />
         <field name="Havok Filter" type="HavokFilter" />
         <field name="World Object Info" type="bhkWorldObjectCInfo" />
     </niobject>
@@ -2714,12 +2714,12 @@
     </niobject>
 
     <compound name="bhkRigidBodyCInfo550_660">
-        <field name="Unused 01" type="byte" arr1="4" binary="true" ver1="10.1.0.0" />
-        <field name="Havok Filter" type="HavokFilter" ver1="10.1.0.0" />
-        <field name="Unused 02" type="byte" arr1="4" binary="true" ver1="10.1.0.0" />
-        <field name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT" ver1="10.1.0.0" />
-        <field name="Unused 03" type="byte" ver1="10.1.0.0" />
-        <field name="Process Contact Callback Delay" type="ushort" default="0xffff" ver1="10.1.0.0" />
+        <field name="Unused 01" type="byte" arr1="4" binary="true" since="10.1.0.0" />
+        <field name="Havok Filter" type="HavokFilter" since="10.1.0.0" />
+        <field name="Unused 02" type="byte" arr1="4" binary="true" since="10.1.0.0" />
+        <field name="Collision Response" type="hkResponseType" default="RESPONSE_SIMPLE_CONTACT" since="10.1.0.0" />
+        <field name="Unused 03" type="byte" since="10.1.0.0" />
+        <field name="Process Contact Callback Delay" type="ushort" default="0xffff" since="10.1.0.0" />
         <field name="Unused 04" type="byte" arr1="4" binary="true" />
         <field name="Translation" type="Vector4"> A vector that moves the body by the specified amount. Only enabled in bhkRigidBodyT objects.</field>
         <field name="Rotation" type="hkQuaternion">The rotation Yaw/Pitch/Roll to apply to the body. Only enabled in bhkRigidBodyT objects.</field>
@@ -2735,9 +2735,9 @@
             How "bouncy" the body is, i.e. how much energy it has after colliding. Less than 1.0 loses energy, greater than 1.0 gains energy.
             If the restitution is not 0.0 the object will need extra CPU for all new collisions.
         </field>
-        <field name="Max Linear Velocity" type="float" default="104.4" ver1="10.1.0.0">Maximal linear velocity.</field>
-        <field name="Max Angular Velocity" type="float" default="31.57" ver1="10.1.0.0">Maximal angular velocity.</field>
-        <field name="Penetration Depth" type="float" default="0.15" ver1="10.1.0.0">
+        <field name="Max Linear Velocity" type="float" default="104.4" since="10.1.0.0">Maximal linear velocity.</field>
+        <field name="Max Angular Velocity" type="float" default="31.57" since="10.1.0.0">Maximal angular velocity.</field>
+        <field name="Penetration Depth" type="float" default="0.15" since="10.1.0.0">
             The maximum allowed penetration for this object.
             This is a hint to the engine to see how much CPU the engine should invest to keep this object from penetrating.
             A good choice is 5% - 20% of the smallest diameter of the object.
@@ -3047,7 +3047,7 @@
 
     <compound name="hkpMoppCode" versions="#BETHESDA#">
         <field name="Data Size" type="uint">Number of bytes for MOPP data.</field>
-        <field name="Offset" type="Vector4" ver1="10.1.0.0">
+        <field name="Offset" type="Vector4" since="10.1.0.0">
             XYZ: Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus 0.1.
             W: The scaling factor to quantize the MOPP: the quantization factor is equal to 256*256 divided by this number.
                In Oblivion files, scale is taken equal to 256*256*254 / (size + 0.2) where size is the largest dimension of the bounding box of the packed shape.
@@ -3092,14 +3092,14 @@
         <field name="Num Shape Properties" type="uint" />
         <field name="Shape Properties" type="bhkWorldObjCInfoProperty" arr1="Num Shape Properties" />
         <field name="Unknown 03" type="uint" arr1="3" />
-        <field name="Num Strips Data" type="uint" ver2="10.0.1.0" />
-        <field name="Strips Data" type="Ref" template="NiTriStripsData" arr1="Num Strips Data" ver2="10.0.1.0" />
+        <field name="Num Strips Data" type="uint" until="10.0.1.0" />
+        <field name="Strips Data" type="Ref" template="NiTriStripsData" arr1="Num Strips Data" until="10.0.1.0" />
     </niobject>
 
     <niobject name="bhkPackedNiTriStripsShape" inherit="bhkShapeCollection" module="BSHavok" versions="#BETHESDA#">
         Bethesda custom hkpShapeCollection using custom packed tri strips data.
-        <field name="Num Sub Shapes" type="ushort" ver2="20.0.0.5" />
-        <field name="Sub Shapes" type="hkSubPartData" arr1="Num Sub Shapes" ver2="20.0.0.5" />
+        <field name="Num Sub Shapes" type="ushort" until="20.0.0.5" />
+        <field name="Sub Shapes" type="hkSubPartData" arr1="Num Sub Shapes" until="20.0.0.5" />
         <field name="User Data" type="uint" default="0" />
         <field name="Unused 01" type="byte" arr1="4" binary="true" />
         <field name="Radius" type="float" default="0.1" />
@@ -3116,7 +3116,7 @@
         <field name="Radius" type="float" default="0.1" />
         <field name="Unused 01" type="byte" arr1="20" binary="true" />
         <field name="Grow By" type="uint" default="1" />
-        <field name="Scale" type="Vector4" default="#VEC4_1110#" ver1="10.1.0.0" />
+        <field name="Scale" type="Vector4" default="#VEC4_1110#" since="10.1.0.0" />
         <field name="Num Strips Data" type="uint" default="1" />
         <field name="Strips Data" type="Ref" template="NiTriStripsData" arr1="Num Strips Data" />
         <field name="Num Filters" type="uint" default="1" calc="#LEN[Strips Data]#" />
@@ -3125,10 +3125,10 @@
 
     <niobject name="NiExtraData" inherit="NiObject" module="NiMain">
         A generic extra data object.
-        <field name="Name" type="string" ver1="10.0.1.0" excludeT="BSExtraData">Name of this object.</field>
-        <field name="Next Extra Data" type="Ref" template="NiExtraData" ver2="4.2.2.0">Block number of the next extra data object.</field>
-        <field name="Extra Data" type="ByteArray" ver2="3.3.0.13">The extra data was sometimes stored as binary directly on NiExtraData.</field>
-        <field name="Num Bytes" type="uint" ver1="4.0.0.0" ver2="4.2.2.0">Ignore binary data after 4.x as the child block will cover it.</field>
+        <field name="Name" type="string" since="10.0.1.0" excludeT="BSExtraData">Name of this object.</field>
+        <field name="Next Extra Data" type="Ref" template="NiExtraData" until="4.2.2.0">Block number of the next extra data object.</field>
+        <field name="Extra Data" type="ByteArray" until="3.3.0.13">The extra data was sometimes stored as binary directly on NiExtraData.</field>
+        <field name="Num Bytes" type="uint" since="4.0.0.0" until="4.2.2.0">Ignore binary data after 4.x as the child block will cover it.</field>
     </niobject>
 
     <niobject name="NiInterpolator" abstract="true" inherit="NiObject" module="NiAnimation">
@@ -3204,43 +3204,43 @@
         <field name="Interpolator" type="Ref" template="NiInterpolator">Reference to an interpolator.</field>
         <field name="Weight" type="float" />
         <field name="Normalized Weight" type="float" />
-        <field name="Priority" type="int" ver2="10.1.0.109" />
-        <field name="Priority" type="byte" ver1="10.1.0.110" />
+        <field name="Priority" type="int" until="10.1.0.109" />
+        <field name="Priority" type="byte" since="10.1.0.110" />
         <field name="Ease Spinner" type="float" />
     </compound>
 
     <niobject name="NiBlendInterpolator" abstract="true" inherit="NiInterpolator" module="NiAnimation">
         Abstract base class for all NiInterpolators that blend the results of sub-interpolators together to compute a final weighted value.
-        <field name="Flags" type="InterpBlendFlags" ver1="10.1.0.112" />
-        <field name="Array Size" type="ushort" ver2="10.1.0.109" />
-        <field name="Array Grow By" type="ushort" ver2="10.1.0.109" />
-        <field name="Array Size" type="byte" ver1="10.1.0.110" />
-        <field name="Weight Threshold" type="float" ver1="10.1.0.112" />
+        <field name="Flags" type="InterpBlendFlags" since="10.1.0.112" />
+        <field name="Array Size" type="ushort" until="10.1.0.109" />
+        <field name="Array Grow By" type="ushort" until="10.1.0.109" />
+        <field name="Array Size" type="byte" since="10.1.0.110" />
+        <field name="Weight Threshold" type="float" since="10.1.0.112" />
         <!-- Flags conds -->
-        <field name="Interp Count" type="byte" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="Single Index" type="byte" default="#BYTE_MAX#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="High Priority" type="char" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="Next High Priority" type="char" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="Single Time" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="Next High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="High Ease Spinner" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
-        <field name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" cond="!(Flags #BITAND# 1)" ver1="10.1.0.112" />
+        <field name="Interp Count" type="byte" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Single Index" type="byte" default="#BYTE_MAX#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="High Priority" type="char" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Next High Priority" type="char" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Single Time" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Next High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="High Ease Spinner" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <!-- /Flags conds -->
-        <field name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" ver2="10.1.0.111" />
-        <field name="Manager Controlled" type="bool" ver2="10.1.0.111" />
-        <field name="Weight Threshold" type="float" ver2="10.1.0.111" />
-        <field name="Only Use Highest Weight" type="bool" ver2="10.1.0.111" />
-        <field name="Interp Count" type="ushort" ver2="10.1.0.109" />
-        <field name="Single Index" type="ushort" default="#USHRT_MAX#" ver2="10.1.0.109" />
-        <field name="Interp Count" type="byte" ver1="10.1.0.110" ver2="10.1.0.111" />
-        <field name="Single Index" type="byte" default="#BYTE_MAX#" ver1="10.1.0.110" ver2="10.1.0.111" />
-        <field name="Single Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.108" ver2="10.1.0.111" />
-        <field name="Single Time" type="float" default="#FLT_MIN#" ver1="10.1.0.108" ver2="10.1.0.111" />
-        <field name="High Priority" type="int" default="#INT_MIN#" ver2="10.1.0.109" />
-        <field name="Next High Priority" type="int" default="#INT_MIN#" ver2="10.1.0.109" />
-        <field name="High Priority" type="char" default="#CHAR_MIN#" ver1="10.1.0.110" ver2="10.1.0.111" />
-        <field name="Next High Priority" type="char" default="#CHAR_MIN#" ver1="10.1.0.110" ver2="10.1.0.111" />
+        <field name="Interp Array Items" type="InterpBlendItem" arr1="Array Size" until="10.1.0.111" />
+        <field name="Manager Controlled" type="bool" until="10.1.0.111" />
+        <field name="Weight Threshold" type="float" until="10.1.0.111" />
+        <field name="Only Use Highest Weight" type="bool" until="10.1.0.111" />
+        <field name="Interp Count" type="ushort" until="10.1.0.109" />
+        <field name="Single Index" type="ushort" default="#USHRT_MAX#" until="10.1.0.109" />
+        <field name="Interp Count" type="byte" since="10.1.0.110" until="10.1.0.111" />
+        <field name="Single Index" type="byte" default="#BYTE_MAX#" since="10.1.0.110" until="10.1.0.111" />
+        <field name="Single Interpolator" type="Ref" template="NiInterpolator" since="10.1.0.108" until="10.1.0.111" />
+        <field name="Single Time" type="float" default="#FLT_MIN#" since="10.1.0.108" until="10.1.0.111" />
+        <field name="High Priority" type="int" default="#INT_MIN#" until="10.1.0.109" />
+        <field name="Next High Priority" type="int" default="#INT_MIN#" until="10.1.0.109" />
+        <field name="High Priority" type="char" default="#CHAR_MIN#" since="10.1.0.110" until="10.1.0.111" />
+        <field name="Next High Priority" type="char" default="#CHAR_MIN#" since="10.1.0.110" until="10.1.0.111" />
     </niobject>
 
     <niobject name="NiBSplineInterpolator" abstract="true" inherit="NiInterpolator" module="NiAnimation">
@@ -3262,13 +3262,13 @@
 
     <niobject name="NiObjectNET" abstract="true" inherit="NiObject" module="NiMain">
         Abstract base class for NiObjects that support names, extra data, and time controllers.
-        <field name="Shader Type" type="BSLightingShaderType" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_SKY# #AND# #NI_BS_LTE_FO4#" onlyT="BSLightingShaderProperty">Configures the main shader path</field>
+        <field name="Shader Type" type="BSLightingShaderType" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SKY# #AND# #NI_BS_LTE_FO4#" onlyT="BSLightingShaderProperty">Configures the main shader path</field>
         <field name="Name" type="string">Name of this controllable object, used to refer to the object in .kf files.</field>
-        <field name="Legacy Extra Data" type="LegacyExtraData" ver2="2.3" />
-        <field name="Extra Data" type="Ref" template="NiExtraData" ver1="3.0" ver2="4.2.2.0">Extra data object index. (The first in a chain)</field>
-        <field name="Num Extra Data List" type="uint" ver1="10.0.1.0">The number of Extra Data objects referenced through the list.</field>
-        <field name="Extra Data List" type="Ref" template="NiExtraData" arr1="Num Extra Data List" ver1="10.0.1.0">List of extra data indices.</field>
-        <field name="Controller" type="Ref" template="NiTimeController" ver1="3.0">Controller object index. (The first in a chain)</field>
+        <field name="Legacy Extra Data" type="LegacyExtraData" until="2.3" />
+        <field name="Extra Data" type="Ref" template="NiExtraData" since="3.0" until="4.2.2.0">Extra data object index. (The first in a chain)</field>
+        <field name="Num Extra Data List" type="uint" since="10.0.1.0">The number of Extra Data objects referenced through the list.</field>
+        <field name="Extra Data List" type="Ref" template="NiExtraData" arr1="Num Extra Data List" since="10.0.1.0">List of extra data indices.</field>
+        <field name="Controller" type="Ref" template="NiTimeController" since="3.0">Controller object index. (The first in a chain)</field>
     </niobject>
 
     <niobject name="NiCollisionObject" inherit="NiObject" module="NiMain">
@@ -3282,7 +3282,7 @@
     <niobject name="NiCollisionData" inherit="NiCollisionObject" module="NiMain">
         Collision box.
         <field name="Propagation Mode" type="PropagationMode" default="PROPAGATE_ALWAYS" />
-        <field name="Collision Mode" type="CollisionMode" default="NOTEST" ver1="10.1.0.0" />
+        <field name="Collision Mode" type="CollisionMode" default="NOTEST" since="10.1.0.0" />
         <field name="Use ABV" type="byte">Use Alternate Bounding Volume.</field>
         <field name="Bounding Volume" type="BoundingVolume" cond="Use ABV == 1" />
     </niobject>
@@ -3384,28 +3384,28 @@
             <default type="BSLODTriShape" value="0x800000E" versions="V20_2_0_7_SSE" />
             <default type="BSLODTriShape" value="0x808000E" versions="V20_2_0_7_SKY" />
         </field>
-        <field name="Flags" type="ushort" ver1="3.0" vercond="#BSVER# #LTE# 26">Basic flags for AV objects.</field>
+        <field name="Flags" type="ushort" since="3.0" vercond="#BSVER# #LTE# 26">Basic flags for AV objects.</field>
         <field name="Translation" type="Vector3">The translation vector.</field>
         <field name="Rotation" type="Matrix33">The rotation part of the transformation matrix.</field>
         <field name="Scale" type="float" default="1.0">Scaling part (only uniform scaling is supported).</field>
-        <field name="Velocity" type="Vector3" ver2="4.2.2.0">Unknown function. Always seems to be (0, 0, 0)</field>
+        <field name="Velocity" type="Vector3" until="4.2.2.0">Unknown function. Always seems to be (0, 0, 0)</field>
         <field name="Num Properties" type="uint" vercond="#NI_BS_LTE_FO3#" />
         <field name="Properties" type="Ref" template="NiProperty" arr1="Num Properties" vercond="#NI_BS_LTE_FO3#">All rendering properties attached to this object.</field>
-        <field name="Unknown 1" type="uint" arr1="4" ver2="2.3" />
-        <field name="Unknown 2" type="byte" ver2="2.3" />
-        <field name="Has Bounding Volume" type="bool" ver1="3.0" ver2="4.2.2.0" />
-        <field name="Bounding Volume" type="BoundingVolume" cond="Has Bounding Volume" ver1="3.0" ver2="4.2.2.0" />
-        <field name="Collision Object" type="Ref" template="NiCollisionObject" ver1="10.0.1.0" />
+        <field name="Unknown 1" type="uint" arr1="4" until="2.3" />
+        <field name="Unknown 2" type="byte" until="2.3" />
+        <field name="Has Bounding Volume" type="bool" since="3.0" until="4.2.2.0" />
+        <field name="Bounding Volume" type="BoundingVolume" cond="Has Bounding Volume" since="3.0" until="4.2.2.0" />
+        <field name="Collision Object" type="Ref" template="NiCollisionObject" since="10.0.1.0" />
     </niobject>
 
     <niobject name="NiDynamicEffect" abstract="true" inherit="NiAVObject" module="NiMain">
         Abstract base class for dynamic effects such as NiLights or projected texture effects.
-        <field name="Switch State" type="bool" default="1" ver1="10.1.0.106" vercond="#NI_BS_LT_FO4#">If true, then the dynamic effect is applied to affected nodes during rendering.</field>
-        <field name="Num Affected Nodes" type="uint" ver2="4.0.0.2" />
-        <field name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" ver2="3.3.0.13">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
-        <field name="Affected Node Pointers" type="uint" arr1="Num Affected Nodes" ver1="4.0.0.0" ver2="4.0.0.2">As of 4.0 the pointer hash is no longer stored alongside each NiObject on disk, yet this node list still refers to the pointer hashes. Cannot leave the type as Ptr because the link will be invalid.</field>
-        <field name="Num Affected Nodes" type="uint" ver1="10.1.0.0" vercond="#NI_BS_LT_FO4#" />
-        <field name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" ver1="10.1.0.0" vercond="#NI_BS_LT_FO4#">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
+        <field name="Switch State" type="bool" default="1" since="10.1.0.106" vercond="#NI_BS_LT_FO4#">If true, then the dynamic effect is applied to affected nodes during rendering.</field>
+        <field name="Num Affected Nodes" type="uint" until="4.0.0.2" />
+        <field name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" until="3.3.0.13">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
+        <field name="Affected Node Pointers" type="uint" arr1="Num Affected Nodes" since="4.0.0.0" until="4.0.0.2">As of 4.0 the pointer hash is no longer stored alongside each NiObject on disk, yet this node list still refers to the pointer hashes. Cannot leave the type as Ptr because the link will be invalid.</field>
+        <field name="Num Affected Nodes" type="uint" since="10.1.0.0" vercond="#NI_BS_LT_FO4#" />
+        <field name="Affected Nodes" type="Ptr" template="NiNode" arr1="Num Affected Nodes" since="10.1.0.0" vercond="#NI_BS_LT_FO4#">If a node appears in this list, then its entire subtree will be affected by the effect.</field>
     </niobject>
 
     <niobject name="NiLight" abstract="true" inherit="NiDynamicEffect" module="NiMain">
@@ -3490,14 +3490,14 @@
         <field name="Planar Angle Variation" type="float">Planar Angle randomness / Second axis .</field>
         <field name="Initial Color" type="Color4" default="#VEC4_ONE#">Defines color of a birthed particle.</field>
         <field name="Initial Radius" type="float" default="1.0">Size of a birthed particle.</field>
-        <field name="Radius Variation" type="float" ver1="10.4.0.1">Particle Radius randomness.</field>
+        <field name="Radius Variation" type="float" since="10.4.0.1">Particle Radius randomness.</field>
         <field name="Life Span" type="float">Duration until a particle dies.</field>
         <field name="Life Span Variation" type="float">Adds randomness to Life Span.</field>
     </niobject>
 
     <niobject name="NiPSysVolumeEmitter" abstract="true" inherit="NiPSysEmitter" module="NiParticle">
         Abstract base class for particle emitters that emit particles from a volume.
-        <field name="Emitter Object" type="Ptr" template="NiNode" ver1="10.1.0.0">Node parent of this modifier?</field>
+        <field name="Emitter Object" type="Ptr" template="NiNode" since="10.1.0.0">Node parent of this modifier?</field>
     </niobject>
 
     <niobject name="NiTimeController" abstract="true" inherit="NiObject" module="NiMain">
@@ -3508,14 +3508,14 @@
         <field name="Phase" type="float">Phase (usually 0.0).</field>
         <field name="Start Time" type="float" default="#FLT_MAX#">Controller start time.</field>
         <field name="Stop Time" type="float" default="#FLT_MIN#">Controller stop time.</field>
-        <field name="Target" type="Ptr" template="NiObjectNET" ver1="3.3.0.13">Controller target (object index of the first controllable ancestor of this object).</field>
-        <field name="Unknown Integer" type="uint" ver2="3.1" />
+        <field name="Target" type="Ptr" template="NiObjectNET" since="3.3.0.13">Controller target (object index of the first controllable ancestor of this object).</field>
+        <field name="Unknown Integer" type="uint" until="3.1" />
     </niobject>
 
 
     <niobject name="NiInterpController" abstract="true" inherit="NiTimeController" module="NiAnimation">
         Abstract base class for all NiTimeController objects using NiInterpolator objects to animate their target objects.
-        <field name="Manager Controlled" type="bool" ver1="10.1.0.104" ver2="10.1.0.108" />
+        <field name="Manager Controlled" type="bool" since="10.1.0.104" until="10.1.0.108" />
     </niobject>
 
     <niobject name="NiMultiTargetTransformController" inherit="NiInterpController" module="NiAnimation">
@@ -3527,14 +3527,14 @@
     <niobject name="NiGeomMorpherController" inherit="NiInterpController" module="NiAnimation">
         DEPRECATED (20.5), replaced by NiMorphMeshModifier.
         Time controller for geometry morphing.
-        <field name="Morpher Flags" type="GeomMorpherFlags" ver1="10.0.1.2" />
+        <field name="Morpher Flags" type="GeomMorpherFlags" since="10.0.1.2" />
         <field name="Data" type="Ref" template="NiMorphData">Geometry morphing data index.</field>
-        <field name="Always Update" type="byte" ver1="4.0.0.2" />
-        <field name="Num Interpolators" type="uint" ver1="10.1.0.106" />
-        <field name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" ver1="10.1.0.106" ver2="20.0.0.5" />
-        <field name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" ver1="20.1.0.3" />
-        <field name="Num Unknown Ints" type="uint" ver1="10.2.0.0" ver2="20.0.0.5" vercond="#BSVER# #GT# 9" />
-        <field name="Unknown Ints" type="uint" arr1="Num Unknown Ints" ver1="10.2.0.0" ver2="20.0.0.5" vercond="#BSVER# #GT# 9" />
+        <field name="Always Update" type="byte" since="4.0.0.2" />
+        <field name="Num Interpolators" type="uint" since="10.1.0.106" />
+        <field name="Interpolators" type="Ref" template="NiInterpolator" arr1="Num Interpolators" since="10.1.0.106" until="20.0.0.5" />
+        <field name="Interpolator Weights" type="MorphWeight" arr1="Num Interpolators" since="20.1.0.3" />
+        <field name="Num Unknown Ints" type="uint" since="10.2.0.0" until="20.0.0.5" vercond="#BSVER# #GT# 9" />
+        <field name="Unknown Ints" type="uint" arr1="Num Unknown Ints" since="10.2.0.0" until="20.0.0.5" vercond="#BSVER# #GT# 9" />
     </niobject>
 
     <niobject name="NiMorphController" inherit="NiInterpController" module="NiLegacy" until="V10_0_1_0">
@@ -3548,13 +3548,13 @@
 
     <niobject name="NiSingleInterpController" abstract="true" inherit="NiInterpController" module="NiAnimation">
         Uses a single NiInterpolator to animate its target value.
-        <field name="Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.104" />
+        <field name="Interpolator" type="Ref" template="NiInterpolator" since="10.1.0.104" />
     </niobject>
 
     <niobject name="NiKeyframeController" inherit="NiSingleInterpController" module="NiAnimation">
         DEPRECATED (10.2), RENAMED (10.2) to NiTransformController
         A time controller object for animation key frames.
-        <field name="Data" type="Ref" template="NiKeyframeData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiKeyframeData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiTransformController" inherit="NiKeyframeController" module="NiAnimation">
@@ -3573,8 +3573,8 @@
         Particle system emitter controller.
         NiInterpController::GetInterpolatorID() string format:
             ['BirthRate', 'EmitterActive'] (for "Interpolator" and "Visibility Interpolator" respectively)
-        <field name="Data" type="Ref" template="NiPSysEmitterCtlrData" ver2="10.1.0.103" />
-        <field name="Visibility Interpolator" type="Ref" template="NiInterpolator" ver1="10.1.0.104" />
+        <field name="Data" type="Ref" template="NiPSysEmitterCtlrData" until="10.1.0.103" />
+        <field name="Visibility Interpolator" type="Ref" template="NiInterpolator" since="10.1.0.104" />
     </niobject>
 
     <niobject name="NiPSysModifierBoolCtlr" abstract="true" inherit="NiPSysModifierCtlr" module="NiParticle">
@@ -3583,12 +3583,12 @@
 
     <niobject name="NiPSysModifierActiveCtlr" inherit="NiPSysModifierBoolCtlr" module="NiParticle">
         A particle system modifier controller that animates active/inactive state for particles.
-        <field name="Data" type="Ref" template="NiVisData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiVisData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPSysModifierFloatCtlr" abstract="true" inherit="NiPSysModifierCtlr" module="NiParticle">
         A particle system modifier controller that animates a floating point value for particles.
-        <field name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiFloatData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPSysEmitterDeclinationCtlr" inherit="NiPSysModifierFloatCtlr" module="NiParticle">
@@ -3624,19 +3624,19 @@
         Changes the image a Map (TexDesc) will use. Uses a float interpolator to animate the texture index.
         Often used for performing flipbook animation.
         <field name="Texture Slot" type="TexType">Target texture slot (0=base, 4=glow).</field>
-        <field name="Accum Time" type="float" ver1="3.3.0.13" ver2="10.1.0.103" />
-        <field name="Delta" type="float" ver2="10.1.0.103">
+        <field name="Accum Time" type="float" since="3.3.0.13" until="10.1.0.103" />
+        <field name="Delta" type="float" until="10.1.0.103">
             Time between two flips.
             delta = (start_time - stop_time) / sources.num_indices
         </field>
         <field name="Num Sources" type="uint" />
-        <field name="Sources" type="Ref" template="NiSourceTexture" arr1="Num Sources" ver1="3.3.0.13">The texture sources.</field>
-        <field name="Images" type="Ref" template="NiImage" arr1="Num Sources" ver2="3.1">The image sources</field>
+        <field name="Sources" type="Ref" template="NiSourceTexture" arr1="Num Sources" since="3.3.0.13">The texture sources.</field>
+        <field name="Images" type="Ref" template="NiImage" arr1="Num Sources" until="3.1">The image sources</field>
     </niobject>
 
     <niobject name="NiAlphaController" inherit="NiFloatInterpController" module="NiAnimation">
         Animates the alpha value of a property using an interpolator.
-        <field name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiFloatData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiTextureTransformController" inherit="NiFloatInterpController" module="NiAnimation">
@@ -3647,7 +3647,7 @@
         <field name="Shader Map" type="bool">Is the target map a shader map?</field>
         <field name="Texture Slot" type="TexType">The target texture slot.</field>
         <field name="Operation" type="TransformMember">Controls which aspect of the texture transform to modify.</field>
-        <field name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiFloatData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiLightDimmerController" inherit="NiFloatInterpController" module="NiAnimation">
@@ -3660,7 +3660,7 @@
 
     <niobject name="NiVisController" inherit="NiBoolInterpController" module="NiAnimation">
         Animates the visibility of an NiAVObject.
-        <field name="Data" type="Ref" template="NiVisData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiVisData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiPoint3InterpController" abstract="true" inherit="NiSingleInterpController" module="NiAnimation">
@@ -3672,16 +3672,16 @@
         Bits 4-5: Target Color (00 = Ambient, 01 = Diffuse, 10 = Specular, 11 = Emissive)
         NiInterpController::GetCtlrID() string formats:
             ['AMB', 'DIFF', 'SPEC', 'SELF_ILLUM'] (Depending on "Target Color")
-        <field name="Target Color" type="MaterialColor" ver1="10.1.0.0">Selects which color to control.</field>
-        <field name="Data" type="Ref" template="NiPosData" ver2="10.1.0.103" />
+        <field name="Target Color" type="MaterialColor" since="10.1.0.0">Selects which color to control.</field>
+        <field name="Data" type="Ref" template="NiPosData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiLightColorController" inherit="NiPoint3InterpController" module="NiAnimation">
         Animates the ambient, diffuse and specular colors of an NiLight.
         NiInterpController::GetCtlrID() string formats:
             ['Diffuse', 'Ambient'] (Depending on "Target Color")
-        <field name="Target Color" type="LightColor" ver1="10.1.0.0" />
-        <field name="Data" type="Ref" template="NiPosData" ver2="10.1.0.103" />
+        <field name="Target Color" type="LightColor" since="10.1.0.0" />
+        <field name="Data" type="Ref" template="NiPosData" until="10.1.0.103" />
     </niobject>
 
 
@@ -3690,7 +3690,7 @@
         NiInterpController::GetCtlrID() string format:
             '%s'
         Where %s = Value of "Extra Data Name"
-        <field name="Extra Data Name" type="string" ver1="10.2.0.0" />
+        <field name="Extra Data Name" type="string" since="10.2.0.0" />
     </niobject>
 
     <niobject name="NiColorExtraDataController" inherit="NiExtraDataController" module="NiAnimation">
@@ -3700,10 +3700,10 @@
     <niobject name="NiFloatExtraDataController" inherit="NiExtraDataController" module="NiAnimation">
         Animates an NiFloatExtraData object attached to an NiAVObject.
         NiInterpController::GetCtlrID() string format is same as parent.
-        <field name="Num Extra Bytes" type="byte" ver2="10.1.0.0">Number of extra bytes.</field>
-        <field name="Unknown Bytes" type="byte" arr1="7" ver2="10.1.0.0" />
-        <field name="Unknown Extra Bytes" type="byte" arr1="Num Extra Bytes" ver2="10.1.0.0" />
-        <field name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+        <field name="Num Extra Bytes" type="byte" until="10.1.0.0">Number of extra bytes.</field>
+        <field name="Unknown Bytes" type="byte" arr1="7" until="10.1.0.0" />
+        <field name="Unknown Extra Bytes" type="byte" arr1="Num Extra Bytes" until="10.1.0.0" />
+        <field name="Data" type="Ref" template="NiFloatData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiFloatsExtraDataController" inherit="NiExtraDataController" module="NiAnimation">
@@ -3712,7 +3712,7 @@
             '%s[%d]'
         Where %s = Value of "Extra Data Name", %d = Value of "Floats Extra Data Index"
         <field name="Floats Extra Data Index" type="int" />
-        <field name="Data" type="Ref" template="NiFloatData" ver2="10.1.0.103" />
+        <field name="Data" type="Ref" template="NiFloatData" until="10.1.0.103" />
     </niobject>
 
     <niobject name="NiFloatsExtraDataPoint3Controller" inherit="NiExtraDataController" module="NiAnimation">
@@ -3730,10 +3730,10 @@
         <field name="Num LODs" type="uint">Number of LODs.</field>
         <field name="Num Node Groups" type="uint">Number of node arrays.</field>
         <field name="Node Groups" type="NodeSet" arr1="Num LODs">A list of node sets (each set a sequence of bones).</field>
-        <field name="Num Shape Groups" type="uint" ver1="4.2.2.0" vercond="#NISTREAM#">Number of shape groups.</field>
-        <field name="Shape Groups 1" type="SkinInfoSet" arr1="Num Shape Groups" ver1="4.2.2.0" vercond="#NISTREAM#">List of shape groups.</field>
-        <field name="Num Shape Groups 2" type="uint" ver1="4.2.2.0" vercond="#NISTREAM#">The size of the second list of shape groups.</field>
-        <field name="Shape Groups 2" type="Ref" template="NiTriBasedGeom" arr1="Num Shape Groups 2" ver1="4.2.2.0" vercond="#NISTREAM#">Group of NiTriShape indices.</field>
+        <field name="Num Shape Groups" type="uint" since="4.2.2.0" vercond="#NISTREAM#">Number of shape groups.</field>
+        <field name="Shape Groups 1" type="SkinInfoSet" arr1="Num Shape Groups" since="4.2.2.0" vercond="#NISTREAM#">List of shape groups.</field>
+        <field name="Num Shape Groups 2" type="uint" since="4.2.2.0" vercond="#NISTREAM#">The size of the second list of shape groups.</field>
+        <field name="Shape Groups 2" type="Ref" template="NiTriBasedGeom" arr1="Num Shape Groups 2" since="4.2.2.0" vercond="#NISTREAM#">Group of NiTriShape indices.</field>
     </niobject>
 
     <niobject name="NiBSBoneLODController" inherit="NiBoneLODController" module="BSAnimation">
@@ -3741,16 +3741,16 @@
     </niobject>
     
     <compound name="MaterialData">
-        <field name="Has Shader" type="bool" ver1="10.0.1.0" ver2="20.1.0.3">Shader.</field>
-        <field name="Shader Name" type="string" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">The shader name.</field>
-        <field name="Shader Extra Data" type="int" cond="Has Shader" ver1="10.0.1.0" ver2="20.1.0.3">Extra data associated with the shader. A value of -1 means the shader is the default implementation.</field>
-        <field name="Num Materials" type="uint" ver1="20.2.0.5" />
-        <field name="Material Name" type="NiFixedString" arr1="Num Materials" ver1="20.2.0.5">The name of the material.</field>
-        <field name="Material Extra Data" type="int" arr1="Num Materials" ver1="20.2.0.5">Extra data associated with the material. A value of -1 means the material is the default implementation.</field>
-        <field name="Active Material" type="int" default="-1" ver1="20.2.0.5">The index of the currently active material.</field>
-        <field name="Cyanide Unknown" type="byte" default="255" ver1="10.2.0.0" ver2="10.2.0.0" vercond="#USER# == 1">Cyanide extension (Blood Bowl).</field>
-        <field name="WorldShift Unknown" type="int" ver1="10.3.0.1" ver2="10.4.0.1" />
-        <field name="Material Needs Update" type="bool" ver1="20.2.0.7">Whether the materials for this object always needs to be updated before rendering with them.</field>
+        <field name="Has Shader" type="bool" since="10.0.1.0" until="20.1.0.3">Shader.</field>
+        <field name="Shader Name" type="string" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">The shader name.</field>
+        <field name="Shader Extra Data" type="int" cond="Has Shader" since="10.0.1.0" until="20.1.0.3">Extra data associated with the shader. A value of -1 means the shader is the default implementation.</field>
+        <field name="Num Materials" type="uint" since="20.2.0.5" />
+        <field name="Material Name" type="NiFixedString" arr1="Num Materials" since="20.2.0.5">The name of the material.</field>
+        <field name="Material Extra Data" type="int" arr1="Num Materials" since="20.2.0.5">Extra data associated with the material. A value of -1 means the material is the default implementation.</field>
+        <field name="Active Material" type="int" default="-1" since="20.2.0.5">The index of the currently active material.</field>
+        <field name="Cyanide Unknown" type="byte" default="255" since="10.2.0.0" until="10.2.0.0" vercond="#USER# == 1">Cyanide extension (Blood Bowl).</field>
+        <field name="WorldShift Unknown" type="int" since="10.3.0.1" until="10.4.0.1" />
+        <field name="Material Needs Update" type="bool" since="20.2.0.7">Whether the materials for this object always needs to be updated before rendering with them.</field>
     </compound>
 
     <niobject name="NiGeometry" abstract="true" inherit="NiAVObject" module="NiMain">
@@ -3759,17 +3759,17 @@
             Most new blocks (e.g. BSTriShape) do not refer to NiGeometry except NiParticleSystem was changed to use BSGeometry.
             This causes massive inheritance problems so the rows below are doubled up to exclude NiParticleSystem for Bethesda Stream 100+
             and to add data exclusive to BSGeometry.
-        <field name="Bounding Sphere" type="NiBound" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_SSE#" onlyT="NiParticleSystem" />
-        <field name="Bound Min Max" type="float" arr1="6" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_F76#" onlyT="NiParticleSystem" />
-        <field name="Skin" type="Ref" template="NiObject" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_SSE#" onlyT="NiParticleSystem" />
+        <field name="Bounding Sphere" type="NiBound" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" onlyT="NiParticleSystem" />
+        <field name="Bound Min Max" type="float" arr1="6" since="20.2.0.7" until="20.2.0.7" vercond="#BS_F76#" onlyT="NiParticleSystem" />
+        <field name="Skin" type="Ref" template="NiObject" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" onlyT="NiParticleSystem" />
         <field name="Data" type="Ref" template="NiGeometryData" vercond="#NI_BS_LT_SSE#">Data index (NiTriShapeData/NiTriStripData).</field>
-        <field name="Data" type="Ref" template="NiGeometryData" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</field>
-        <field name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="3.3.0.13" vercond="#NI_BS_LT_SSE#" />
-        <field name="Skin Instance" type="Ref" template="NiSkinInstance" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem" />
-        <field name="Material Data" type="MaterialData" ver1="10.0.1.0" vercond="#NI_BS_LT_SSE#" />
-        <field name="Material Data" type="MaterialData" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem" />
-        <field name="Shader Property" type="Ref" template="BSShaderProperty" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
-        <field name="Alpha Property" type="Ref" template="NiAlphaProperty" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Data" type="Ref" template="NiGeometryData" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem">Data index (NiTriShapeData/NiTriStripData).</field>
+        <field name="Skin Instance" type="Ref" template="NiSkinInstance" since="3.3.0.13" vercond="#NI_BS_LT_SSE#" />
+        <field name="Skin Instance" type="Ref" template="NiSkinInstance" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem" />
+        <field name="Material Data" type="MaterialData" since="10.0.1.0" vercond="#NI_BS_LT_SSE#" />
+        <field name="Material Data" type="MaterialData" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_SSE#" excludeT="NiParticleSystem" />
+        <field name="Shader Property" type="Ref" template="BSShaderProperty" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Alpha Property" type="Ref" template="NiAlphaProperty" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
     </niobject>
 
     <niobject name="NiTriBasedGeom" abstract="true" inherit="NiGeometry" module="NiMain">
@@ -3782,23 +3782,23 @@
             "Num Vertices" is renamed to "BS Max Vertices" for Bethesda 20.2 because Vertices, Normals, Tangents, Colors, and UV arrays
             do not have length for NiPSysData regardless of "Num" or booleans.
 
-        <field name="Group ID" type="int" ver1="10.1.0.114">Always zero.</field>
+        <field name="Group ID" type="int" since="10.1.0.114">Always zero.</field>
         <field name="Num Vertices" type="ushort" excludeT="NiPSysData">Number of vertices.</field>
         <field name="Num Vertices" type="ushort" onlyT="NiPSysData" vercond="#NI_BS_LT_FO3#">Number of vertices.</field>
-        <field name="BS Max Vertices" type="ushort" onlyT="NiPSysData" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_FO3#">Bethesda uses this for max number of particles in NiPSysData.</field>
-        <field name="Keep Flags" type="byte" ver1="10.1.0.0">Used with NiCollision objects when OBB or TRI is set.</field>
-        <field name="Compress Flags" type="byte" ver1="10.1.0.0" />
+        <field name="BS Max Vertices" type="ushort" onlyT="NiPSysData" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_FO3#">Bethesda uses this for max number of particles in NiPSysData.</field>
+        <field name="Keep Flags" type="byte" since="10.1.0.0">Used with NiCollision objects when OBB or TRI is set.</field>
+        <field name="Compress Flags" type="byte" since="10.1.0.0" />
         <field name="Has Vertices" type="bool" default="1">Is the vertex array present? (Always non-zero.)</field>
         <field name="Vertices" type="Vector3" arr1="Num Vertices" cond="Has Vertices">The mesh vertices.</field>
-        <field name="Data Flags" type="NiGeometryDataFlags" ver1="10.0.1.0" vercond="!#BS202#" />
+        <field name="Data Flags" type="NiGeometryDataFlags" since="10.0.1.0" vercond="!#BS202#" />
         <field name="BS Data Flags" type="BSGeometryDataFlags" vercond="#BS202#" />
-        <field name="Material CRC" type="uint" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Material CRC" type="uint" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
         <field name="Has Normals" type="bool">Do we have lighting normals? These are essential for proper lighting: if not present, the model will only be influenced by ambient light.</field>
         <field name="Normals" type="Vector3" arr1="Num Vertices" cond="Has Normals">The lighting normals.</field>
-        <field name="Tangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" ver1="10.1.0.0">Tangent vectors.</field>
-        <field name="Bitangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" ver1="10.1.0.0">Bitangent vectors.</field>
-        <field name="Has DIV2 Floats" type="bool" ver1="20.3.0.9" ver2="20.3.0.9" vercond="#DIVINITY2#" />
-        <field name="DIV2 Floats" type="float" arr1="Num Vertices" ver1="20.3.0.9" ver2="20.3.0.9" vercond="#DIVINITY2#" cond="Has DIV2 Floats" />
+        <field name="Tangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Tangent vectors.</field>
+        <field name="Bitangents" type="Vector3" arr1="Num Vertices" cond="(Has Normals) #AND# ((Data Flags | BS Data Flags) #BITAND# 4096)" since="10.1.0.0">Bitangent vectors.</field>
+        <field name="Has DIV2 Floats" type="bool" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
+        <field name="DIV2 Floats" type="float" arr1="Num Vertices" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" cond="Has DIV2 Floats" />
         <field name="Bounding Sphere" type="NiBound" />
         <field name="Has Vertex Colors" type="bool">
             Do we have vertex colors? These are usually used to fine-tune the lighting of the model.
@@ -3808,15 +3808,15 @@
             Note 2: set to either 0 or 0xFFFFFFFF for NifTexture compatibility.
         </field>
         <field name="Vertex Colors" type="Color4" default="#VEC4_ONE#" arr1="Num Vertices" cond="Has Vertex Colors">The vertex colors.</field>
-        <field name="Data Flags" type="NiGeometryDataFlags" ver2="4.2.2.0">The lower 6 bits of this field represent the number of UV texture sets. The rest is unused.</field>
-        <field name="Has UV" type="bool" ver2="4.0.0.2">
+        <field name="Data Flags" type="NiGeometryDataFlags" until="4.2.2.0">The lower 6 bits of this field represent the number of UV texture sets. The rest is unused.</field>
+        <field name="Has UV" type="bool" until="4.0.0.2">
             Do we have UV coordinates?
 
             Note: for compatibility with NifTexture, set this value to either 0x00000000 or 0xFFFFFFFF.
         </field>
         <field name="UV Sets" type="TexCoord" arr1="((Data Flags #BITAND# 63) | (BS Data Flags #BITAND# 1))" arr2="Num Vertices">The UV texture coordinates. They follow the OpenGL standard: some programs may require you to flip the second coordinate.</field>
-        <field name="Consistency Flags" type="ConsistencyType" ver1="10.0.1.0" default="CT_MUTABLE">Consistency Flags</field>
-        <field name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" ver1="20.0.0.4" />
+        <field name="Consistency Flags" type="ConsistencyType" since="10.0.1.0" default="CT_MUTABLE">Consistency Flags</field>
+        <field name="Additional Data" type="Ref" template="AbstractAdditionalGeometryData" since="20.0.0.4" />
     </niobject>
 
     <niobject name="AbstractAdditionalGeometryData" abstract="true" inherit="NiObject" module="NiMain">
@@ -3863,21 +3863,21 @@
         <field name="Num Triangles" type="uint" />
         <field name="Triangles" type="TriangleData" arr1="Num Triangles" />
         <field name="Num Vertices" type="uint" />
-        <field name="Compressed" type="bool" ver1="20.2.0.7" />
+        <field name="Compressed" type="bool" since="20.2.0.7" />
         <field name="Vertices" type="Vector3" arr1="Num Vertices" cond="Compressed == 0" />
         <field name="Compressed Vertices" type="HalfVector3" arr1="Num Vertices" cond="Compressed != 0">
             Compression on read may not be supported. Vertices may be packed in ushort that are not IEEE standard half-precision.
         </field>
-        <field name="Num Sub Shapes" type="ushort" ver1="20.2.0.7" />
-        <field name="Sub Shapes" type="hkSubPartData" arr1="Num Sub Shapes" ver1="20.2.0.7" />
+        <field name="Num Sub Shapes" type="ushort" since="20.2.0.7" />
+        <field name="Sub Shapes" type="hkSubPartData" arr1="Num Sub Shapes" since="20.2.0.7" />
     </niobject>
 
     <niobject name="NiAlphaProperty" inherit="NiProperty" module="NiMain">
         Transparency. Flags 0x00ED.
         <field name="Flags" type="AlphaFlags" default="4844" />
         <field name="Threshold" type="byte" default="128">Threshold for alpha testing</field>
-        <field name="Unknown Short 1" type="ushort" ver2="2.3" />
-        <field name="Unknown Int 2" type="uint" ver2="2.3" />
+        <field name="Unknown Short 1" type="ushort" until="2.3" />
+        <field name="Unknown Int 2" type="uint" until="2.3" />
     </niobject>
 
     <niobject name="NiAmbientLight" inherit="NiLight" module="NiMain">
@@ -3893,35 +3893,35 @@
     <niobject name="NiParticlesData" inherit="NiGeometryData" module="NiMain">
         Generic rotating particles data object.
         Bethesda 20.2.0.7 NIFs: NiParticlesData no longer inherits from NiGeometryData and inherits NiObject directly.
-        <field name="Num Particles" type="ushort" ver2="4.0.0.2">The maximum number of particles (matches the number of vertices).</field>
-        <field name="Particle Radius" type="float" ver2="10.0.1.0">The particles' size.</field>
-        <field name="Has Radii" type="bool" ver1="10.1.0.0">Is the particle size array present?</field>
-        <field name="Radii" type="float" arr1="Num Vertices" cond="Has Radii" ver1="10.1.0.0" vercond="!#BS202#">The individual particle sizes.</field>
+        <field name="Num Particles" type="ushort" until="4.0.0.2">The maximum number of particles (matches the number of vertices).</field>
+        <field name="Particle Radius" type="float" until="10.0.1.0">The particles' size.</field>
+        <field name="Has Radii" type="bool" since="10.1.0.0">Is the particle size array present?</field>
+        <field name="Radii" type="float" arr1="Num Vertices" cond="Has Radii" since="10.1.0.0" vercond="!#BS202#">The individual particle sizes.</field>
         <field name="Num Active" type="ushort">The number of active particles at the time the system was saved. This is also the number of valid entries in the following arrays.</field>
         <field name="Has Sizes" type="bool">Is the particle size array present?</field>
         <field name="Sizes" type="float" arr1="Num Vertices" cond="Has Sizes" vercond="!#BS202#">The individual particle sizes.</field>
-        <field name="Has Rotations" type="bool" ver1="10.0.1.0">Is the particle rotation array present?</field>
-        <field name="Rotations" type="Quaternion" arr1="Num Vertices" cond="Has Rotations" ver1="10.0.1.0" vercond="!#BS202#">The individual particle rotations.</field>
-        <field name="Has Rotation Angles" type="bool" ver1="20.0.0.4">Are the angles of rotation present?</field>
+        <field name="Has Rotations" type="bool" since="10.0.1.0">Is the particle rotation array present?</field>
+        <field name="Rotations" type="Quaternion" arr1="Num Vertices" cond="Has Rotations" since="10.0.1.0" vercond="!#BS202#">The individual particle rotations.</field>
+        <field name="Has Rotation Angles" type="bool" since="20.0.0.4">Are the angles of rotation present?</field>
         <field name="Rotation Angles" type="float" arr1="Num Vertices" cond="Has Rotation Angles" vercond="!#BS202#">Angles of rotation</field>
-        <field name="Has Rotation Axes" type="bool" ver1="20.0.0.4">Are axes of rotation present?</field>
-        <field name="Rotation Axes" type="Vector3" arr1="Num Vertices" cond="Has Rotation Axes" ver1="20.0.0.4" vercond="!#BS202#">Axes of rotation.</field>
+        <field name="Has Rotation Axes" type="bool" since="20.0.0.4">Are axes of rotation present?</field>
+        <field name="Rotation Axes" type="Vector3" arr1="Num Vertices" cond="Has Rotation Axes" since="20.0.0.4" vercond="!#BS202#">Axes of rotation.</field>
 
         <field name="Has Texture Indices" type="bool" vercond="#BS202#" />
-        <field name="Num Subtexture Offsets" type="uint" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#">How many quads to use in BSPSysSubTexModifier for texture atlasing</field>
-        <field name="Num Subtexture Offsets" type="byte" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BSSTREAM# #AND# #NI_BS_LTE_FO3#">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</field>
+        <field name="Num Subtexture Offsets" type="uint" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#">How many quads to use in BSPSysSubTexModifier for texture atlasing</field>
+        <field name="Num Subtexture Offsets" type="byte" since="20.2.0.7" until="20.2.0.7" vercond="#BSSTREAM# #AND# #NI_BS_LTE_FO3#">2,4,8,16,32,64 are potential values. If "Has" was no then this should be 256, which represents a 16x16 framed image, which is invalid</field>
         <field name="Subtexture Offsets" type="Vector4" arr1="Num Subtexture Offsets" vercond="#BS202#">Defines UV offsets</field>
-        <field name="Aspect Ratio" type="float" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#">Sets aspect ratio for Subtexture Offset UV quads</field>
-        <field name="Aspect Flags" type="AspectFlags" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
-        <field name="Speed to Aspect Aspect 2" type="float" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
-        <field name="Speed to Aspect Speed 1" type="float" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
-        <field name="Speed to Aspect Speed 2" type="float" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Aspect Ratio" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#">Sets aspect ratio for Subtexture Offset UV quads</field>
+        <field name="Aspect Flags" type="AspectFlags" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Speed to Aspect Aspect 2" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Speed to Aspect Speed 1" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
+        <field name="Speed to Aspect Speed 2" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GT_FO3#" />
     </niobject>
 
     <niobject name="NiRotatingParticlesData" inherit="NiParticlesData" module="NiLegacy" until="V10_0_1_0">
         Rotating particles data object.
-        <field name="Has Rotations 2" type="bool" ver2="4.2.2.0">Is the particle rotation array present?</field>
-        <field name="Rotations 2" type="Quaternion" arr1="Num Vertices" cond="Has Rotations 2" ver2="4.2.2.0">The individual particle rotations.</field>
+        <field name="Has Rotations 2" type="bool" until="4.2.2.0">Is the particle rotation array present?</field>
+        <field name="Rotations 2" type="Quaternion" arr1="Num Vertices" cond="Has Rotations 2" until="4.2.2.0">The individual particle rotations.</field>
     </niobject>
 
     <niobject name="NiAutoNormalParticlesData" inherit="NiParticlesData" module="NiLegacy" until="V10_0_1_0">
@@ -3932,18 +3932,18 @@
         Particle system data.
         <field name="Particle Info" type="NiParticleInfo" arr1="Num Vertices" vercond="!#BS202#" />
         <field name="Unknown Vector" type="Vector3" vercond="#BS_F76#" />
-        <field name="Has Rotation Speeds" type="bool" ver1="20.0.0.2" />
-        <field name="Rotation Speeds" type="float" arr1="Num Vertices" cond="Has Rotation Speeds" ver1="20.0.0.2" vercond="!#BS202#" />
+        <field name="Has Rotation Speeds" type="bool" since="20.0.0.2" />
+        <field name="Rotation Speeds" type="float" arr1="Num Vertices" cond="Has Rotation Speeds" since="20.0.0.2" vercond="!#BS202#" />
         <field name="Num Added Particles" type="ushort" vercond="!#BS202#" />
         <field name="Added Particles Base" type="ushort" vercond="!#BS202#" />
     </niobject>
     
     <niobject name="NiMeshPSysData" inherit="NiPSysData" module="NiParticle">
         Particle meshes data.
-        <field name="Default Pool Size" type="uint" ver1="10.2.0.0" />
-        <field name="Fill Pools On Load" type="bool" ver1="10.2.0.0" />
-        <field name="Num Generations" type="uint" ver1="10.2.0.0" />
-        <field name="Generations" type="uint" ver1="10.2.0.0" arr1="Num Generations" />
+        <field name="Default Pool Size" type="uint" since="10.2.0.0" />
+        <field name="Fill Pools On Load" type="bool" since="10.2.0.0" />
+        <field name="Num Generations" type="uint" since="10.2.0.0" />
+        <field name="Generations" type="uint" since="10.2.0.0" arr1="Num Generations" />
         <field name="Particle Meshes" type="Ref" template="NiNode" />
     </niobject>
 
@@ -3988,7 +3988,7 @@
 
     <niobject name="NiBlendTransformInterpolator" inherit="NiBlendInterpolator" module="NiAnimation">
         Blends NiQuatTransform values together.
-        <field name="Value" type="NiQuatTransform" ver2="10.1.0.109" />
+        <field name="Value" type="NiQuatTransform" until="10.1.0.109" />
     </niobject>
 
     <niobject name="NiBoolData" inherit="NiObject" module="NiAnimation">
@@ -4062,14 +4062,14 @@
 
     <niobject name="NiCamera" inherit="NiAVObject" module="NiMain">
         Camera object.
-        <field name="Camera Flags" type="ushort" ver1="10.1.0.0">Obsolete flags.</field>
+        <field name="Camera Flags" type="ushort" since="10.1.0.0">Obsolete flags.</field>
         <field name="Frustum Left" type="float" default="-0.63707">Frustrum left.</field>
         <field name="Frustum Right" type="float" default="0.63707">Frustrum right.</field>
         <field name="Frustum Top" type="float" default="0.385714">Frustrum top.</field>
         <field name="Frustum Bottom" type="float" default="-0.385714">Frustrum bottom.</field>
         <field name="Frustum Near" type="float" default="1.0">Frustrum near.</field>
         <field name="Frustum Far" type="float" default="5000.0">Frustrum far.</field>
-        <field name="Use Orthographic Projection" type="bool" ver1="10.1.0.0">Determines whether perspective is used.  Orthographic means no perspective.</field>
+        <field name="Use Orthographic Projection" type="bool" since="10.1.0.0">Determines whether perspective is used.  Orthographic means no perspective.</field>
         <field name="Viewport Left" type="float">Viewport left.</field>
         <field name="Viewport Right" type="float" default="1.0">Viewport right.</field>
         <field name="Viewport Top" type="float" default="1.0">Viewport top.</field>
@@ -4077,8 +4077,8 @@
         <field name="LOD Adjust" type="float" default="1.0">Level of detail adjust.</field>
         <field name="Scene" type="Ref" template="NiAVObject" />
         <field name="Num Screen Polygons" type="uint" calc="0">Deprecated. Array is always zero length on disk write.</field>
-        <field name="Num Screen Textures" type="uint" calc="0" ver1="4.2.1.0">Deprecated. Array is always zero length on disk write.</field>
-        <field name="Unknown Int 3" type="uint" ver2="3.1" />
+        <field name="Num Screen Textures" type="uint" calc="0" since="4.2.1.0">Deprecated. Array is always zero length on disk write.</field>
+        <field name="Unknown Int 3" type="uint" until="3.1" />
     </niobject>
 
     <niobject name="NiColorData" inherit="NiObject" module="NiAnimation">
@@ -4102,34 +4102,34 @@
     <niobject name="NiSequence" inherit="NiObject" module="NiAnimation">
         Root node in NetImmerse .kf files (until version 10.0).
         <field name="Name" type="string">The sequence name by which the animation system finds and manages this sequence.</field>
-        <field name="Accum Root Name" type="string" ver2="10.1.0.103">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
-        <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver2="10.1.0.103" />
-        <field name="Num DIV2 Ints" type="uint" ver1="20.3.0.9" ver2="20.3.0.9" vercond="#DIVINITY2#" />
-        <field name="DIV2 Ints" type="int" arr1="Num DIV2 Ints" ver1="20.3.0.9" ver2="20.3.0.9" vercond="#DIVINITY2#" />
-        <field name="DIV2 Ref" type="Ref" template="NiObject" ver1="20.3.0.9" ver2="20.3.0.9" vercond="#DIVINITY2#" />
+        <field name="Accum Root Name" type="string" until="10.1.0.103">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
+        <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" until="10.1.0.103" />
+        <field name="Num DIV2 Ints" type="uint" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
+        <field name="DIV2 Ints" type="int" arr1="Num DIV2 Ints" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
+        <field name="DIV2 Ref" type="Ref" template="NiObject" since="20.3.0.9" until="20.3.0.9" vercond="#DIVINITY2#" />
         <field name="Num Controlled Blocks" type="uint" />
-        <field name="Array Grow By" type="uint" default="1" ver1="10.1.0.106" />
+        <field name="Array Grow By" type="uint" default="1" since="10.1.0.106" />
         <field name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" />
     </niobject>
 
     <niobject name="NiControllerSequence" inherit="NiSequence" module="NiAnimation">
         Root node in Gamebryo .kf files (version 10.0.1.0 and up).
-        <field name="Weight" type="float" default="1.0" ver1="10.1.0.106">The weight of a sequence describes how it blends with other sequences at the same priority.</field>
-        <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" ver1="10.1.0.106" />
-        <field name="Cycle Type" type="CycleType" default="CYCLE_CLAMP" ver1="10.1.0.106" />
-        <field name="Frequency" type="float" default="1.0" ver1="10.1.0.106" />
+        <field name="Weight" type="float" default="1.0" since="10.1.0.106">The weight of a sequence describes how it blends with other sequences at the same priority.</field>
+        <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" since="10.1.0.106" />
+        <field name="Cycle Type" type="CycleType" default="CYCLE_CLAMP" since="10.1.0.106" />
+        <field name="Frequency" type="float" default="1.0" since="10.1.0.106" />
         <!-- Actually 10.3.0.1 but WorldShift 10.4.0.1 custom version acts like 10.3.0.1 -->
-        <field name="Phase" type="float" ver1="10.1.0.106" ver2="10.4.0.1" />
-        <field name="Start Time" type="float" default="#FLT_MAX#" ver1="10.1.0.106" />
-        <field name="Stop Time" type="float" default="#FLT_MIN#" ver1="10.1.0.106" />
-        <field name="Play Backwards" type="bool" ver1="10.1.0.106" ver2="10.1.0.106" />
-        <field name="Manager" type="Ptr" template="NiControllerManager" ver1="10.1.0.106">The owner of this sequence.</field>
-        <field name="Accum Root Name" type="string" ver1="10.1.0.106">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
-        <field name="Accum Flags" type="AccumFlags" default="ACCUM_X_FRONT" ver1="20.3.0.8" />
-        <field name="String Palette" type="Ref" template="NiStringPalette" ver1="10.1.0.113" ver2="20.1.0.0" />
-        <field name="Anim Notes" type="Ref" template="BSAnimNotes" ver1="20.2.0.7" vercond="(#BSVER# #GTE# 24) #AND# (#BSVER# #LTE# 28)" />
-        <field name="Num Anim Note Arrays" type="ushort" ver1="20.2.0.7" vercond="#BSVER# #GT# 28" />
-        <field name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" ver1="20.2.0.7" vercond="#BSVER# #GT# 28" />
+        <field name="Phase" type="float" since="10.1.0.106" until="10.4.0.1" />
+        <field name="Start Time" type="float" default="#FLT_MAX#" since="10.1.0.106" />
+        <field name="Stop Time" type="float" default="#FLT_MIN#" since="10.1.0.106" />
+        <field name="Play Backwards" type="bool" since="10.1.0.106" until="10.1.0.106" />
+        <field name="Manager" type="Ptr" template="NiControllerManager" since="10.1.0.106">The owner of this sequence.</field>
+        <field name="Accum Root Name" type="string" since="10.1.0.106">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
+        <field name="Accum Flags" type="AccumFlags" default="ACCUM_X_FRONT" since="20.3.0.8" />
+        <field name="String Palette" type="Ref" template="NiStringPalette" since="10.1.0.113" until="20.1.0.0" />
+        <field name="Anim Notes" type="Ref" template="BSAnimNotes" since="20.2.0.7" vercond="(#BSVER# #GTE# 24) #AND# (#BSVER# #LTE# 28)" />
+        <field name="Num Anim Note Arrays" type="ushort" since="20.2.0.7" vercond="#BSVER# #GT# 28" />
+        <field name="Anim Note Arrays" type="Ref" template="BSAnimNotes" arr1="Num Anim Note Arrays" since="20.2.0.7" vercond="#BSVER# #GT# 28" />
     </niobject>
 
     <niobject name="NiAVObjectPalette" abstract="true" inherit="NiObject" module="NiMain">
@@ -4182,13 +4182,13 @@
 
     <niobject name="NiGravity" inherit="NiParticleModifier" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1) particle modifier. Applies a gravitational field on the particles.
-        <field name="Decay" type="float" ver1="3.3.0.13" />
+        <field name="Decay" type="float" since="3.3.0.13" />
         <field name="Force" type="float">The strength/force of this gravity.</field>
         <field name="Type" type="FieldType">The force field type.</field>
         <field name="Position" type="Vector3">The position of the mass point relative to the particle system.</field>
         <field name="Direction" type="Vector3">The direction of the applied acceleration.</field>
-        <field name="Unknown 01" type="float" ver2="2.3" />
-        <field name="Unknown 02" type="float" ver2="2.3" />
+        <field name="Unknown 01" type="float" until="2.3" />
+        <field name="Unknown 02" type="float" until="2.3" />
     </niobject>
 
     <niobject name="NiIntegerExtraData" inherit="NiExtraData" module="NiMain">
@@ -4231,7 +4231,7 @@
         <field name="Num Rotation Keys" type="uint">The number of quaternion rotation keys. If the rotation type is XYZ (type 4) then this *must* be set to 1, and in this case the actual number of keys is stored in the XYZ Rotations field.</field>
         <field name="Rotation Type" type="KeyType" cond="Num Rotation Keys != 0">The type of interpolation to use for rotation.  Can also be 4 to indicate that separate X, Y, and Z values are used for the rotation instead of Quaternions.</field>
         <field name="Quaternion Keys" type="QuatKey" arg="Rotation Type" template="Quaternion" arr1="Num Rotation Keys" cond="Rotation Type != 4">The rotation keys if Quaternion rotation is used.</field>
-        <field name="Order" type="float" cond="Rotation Type == 4" ver2="10.1.0.0" />
+        <field name="Order" type="float" cond="Rotation Type == 4" until="10.1.0.0" />
         <field name="XYZ Rotations" type="KeyGroup" template="float" arr1="3" cond="Rotation Type == 4">Individual arrays of keys for rotating X, Y, and Z individually.</field>
         <field name="Translations" type="KeyGroup" template="Vector3">Translation keys.</field>
         <field name="Scales" type="KeyGroup" template="float">Scale keys.</field>
@@ -4246,7 +4246,7 @@
     <niobject name="NiLookAtController" inherit="NiTimeController" module="NiAnimation" until="V20_5_0_0">
         DEPRECATED (10.2), REMOVED (20.5)
         Replaced by NiTransformController and NiLookAtInterpolator.
-        <field name="Look At Flags" type="LookAtFlags" ver1="10.1.0.0" />
+        <field name="Look At Flags" type="LookAtFlags" since="10.1.0.0" />
         <field name="Look At" type="Ptr" template="NiNode" />
     </niobject>
 
@@ -4255,7 +4255,7 @@
         <field name="Flags" type="LookAtFlags" />
         <field name="Look At" type="Ptr" template="NiNode" />
         <field name="Look At Name" type="string" />
-        <field name="Transform" type="NiQuatTransform" ver2="20.4.0.12" />
+        <field name="Transform" type="NiQuatTransform" until="20.4.0.12" />
         <field name="Interpolator: Translation" type="Ref" template="NiPoint3Interpolator" />
         <field name="Interpolator: Roll" type="Ref" template="NiFloatInterpolator" />
         <field name="Interpolator: Scale" type="Ref" template="NiFloatInterpolator" />
@@ -4263,7 +4263,7 @@
 
     <niobject name="NiMaterialProperty" inherit="NiProperty" module="NiMain">
         Describes the surface properties of an object e.g. translucency, ambient color, diffuse color, emissive color, and specular color.
-        <field name="Flags" type="ushort" ver1="3.0" ver2="10.0.1.2">Property flags.</field>
+        <field name="Flags" type="ushort" since="3.0" until="10.0.1.2">Property flags.</field>
         <field name="Ambient Color" type="Color3" default="#VEC3_ONE#" vercond="#BSVER# #LT# 26">How much the material reflects ambient light.</field>
         <field name="Diffuse Color" type="Color3" default="#VEC3_ONE#" vercond="#BSVER# #LT# 26">How much the material reflects diffuse light.</field>
         <field name="Specular Color" type="Color3" default="#VEC3_ONE#">How much light the material reflects in a specular manner.</field>
@@ -4341,7 +4341,7 @@
         01 ROTATE_ABOUT_UP
         10 RIGID_FACE_CAMERA
         11 ALWAYS_FACE_CENTER
-        <field name="Billboard Mode" type="BillboardMode" ver1="10.1.0.0">The way the billboard will react to the camera.</field>
+        <field name="Billboard Mode" type="BillboardMode" since="10.1.0.0">The way the billboard will react to the camera.</field>
     </niobject>
 
     <niobject name="NiBSAnimationNode" inherit="NiNode" module="BSLegacy" until="V10_0_1_0">
@@ -4360,16 +4360,16 @@
 
     <niobject name="NiSwitchNode" inherit="NiNode" module="NiMain">
         Represents groups of multiple scenegraph subtrees, only one of which (the "active child") is drawn at any given time.
-        <field name="Switch Node Flags" type="NiSwitchFlags" default="3" ver1="10.1.0.0" />
+        <field name="Switch Node Flags" type="NiSwitchFlags" default="3" since="10.1.0.0" />
         <field name="Index" type="uint" />
     </niobject>
 
     <niobject name="NiLODNode" inherit="NiSwitchNode" module="NiMain">
         Level of detail selector. Links to different levels of detail of the same model, used to switch a geometry at a specified distance.
-        <field name="LOD Center" type="Vector3" ver1="4.0.0.2" ver2="10.0.1.0" />
-        <field name="Num LOD Levels" type="uint" ver2="10.0.1.0" />
-        <field name="LOD Levels" type="LODRange" arr1="Num LOD Levels" ver2="10.0.1.0" />
-        <field name="LOD Level Data" type="Ref" template="NiLODData" ver1="10.1.0.0" />
+        <field name="LOD Center" type="Vector3" since="4.0.0.2" until="10.0.1.0" />
+        <field name="Num LOD Levels" type="uint" until="10.0.1.0" />
+        <field name="LOD Levels" type="LODRange" arr1="Num LOD Levels" until="10.0.1.0" />
+        <field name="LOD Level Data" type="Ref" template="NiLODData" since="10.1.0.0" />
     </niobject>
 
     <niobject name="NiPalette" inherit="NiObject" module="NiMain">
@@ -4387,7 +4387,7 @@
         <field name="DeltaV" type="float" />
         <field name="Start" type="float" />
         <field name="Decay Type" type="DecayType" />
-        <field name="Symmetry Type" type="SymmetryType" ver1="4.1.0.12" />
+        <field name="Symmetry Type" type="SymmetryType" since="4.1.0.12" />
         <field name="Position" type="Vector3">The position of the mass point relative to the particle system?</field>
         <field name="Direction" type="Vector3">The direction of the applied acceleration?</field>
     </niobject>
@@ -4444,9 +4444,9 @@
         <field name="Near End" type="ushort" vercond="#BS_GTE_SKY#" />
         <field name="Data" type="Ref" template="NiPSysData" vercond="#BS_GTE_SSE#" />
 
-        <field name="World Space" type="bool" default="1" ver1="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</field>
-        <field name="Num Modifiers" type="uint" ver1="10.1.0.0">The number of modifier references.</field>
-        <field name="Modifiers" type="Ref" template="NiPSysModifier" arr1="Num Modifiers" ver1="10.1.0.0">The list of particle modifiers.</field>
+        <field name="World Space" type="bool" default="1" since="10.1.0.0">If true, Particles are birthed into world space.  If false, Particles are birthed into object space.</field>
+        <field name="Num Modifiers" type="uint" since="10.1.0.0">The number of modifier references.</field>
+        <field name="Modifiers" type="Ref" template="NiPSysModifier" arr1="Num Modifiers" since="10.1.0.0">The list of particle modifiers.</field>
     </niobject>
 
     <niobject name="NiMeshParticleSystem" inherit="NiParticleSystem" module="NiParticle">
@@ -4460,8 +4460,8 @@
 
     <niobject name="NiParticleSystemController" inherit="NiTimeController" module="NiLegacy" until="V10_0_1_0">
         A generic particle system time controller object.
-        <field name="Old Speed" type="uint" ver2="3.1">Particle speed in old files</field>
-        <field name="Speed" type="float" ver1="3.3.0.13">Particle speed</field>
+        <field name="Old Speed" type="uint" until="3.1">Particle speed in old files</field>
+        <field name="Speed" type="float" since="3.3.0.13">Particle speed</field>
         <field name="Speed Variation" type="float">Particle random speed modifier</field>
         <field name="Declination" type="float">
             vertical emit direction [radians]
@@ -4477,38 +4477,38 @@
         <field name="Initial Size" type="float" default="1.0">Particle size</field>
         <field name="Emit Start Time" type="float">Particle emit start time</field>
         <field name="Emit Stop Time" type="float">Particle emit stop time</field>
-        <field name="Reset Particle System" type="byte" ver1="3.3.0.13" />
-        <field name="Old Emit Rate" type="uint" ver2="3.1">Particle emission rate in old files</field>
-        <field name="Birth Rate" type="float" ver1="3.3.0.13">Particle emission rate (particles per second)</field>
+        <field name="Reset Particle System" type="byte" since="3.3.0.13" />
+        <field name="Old Emit Rate" type="uint" until="3.1">Particle emission rate in old files</field>
+        <field name="Birth Rate" type="float" since="3.3.0.13">Particle emission rate (particles per second)</field>
         <field name="Lifetime" type="float">Particle lifetime</field>
         <field name="Lifetime Variation" type="float">Particle lifetime random modifier</field>
-        <field name="Use Birth Rate" type="byte" ver1="3.3.0.13" />
-        <field name="Spawn On Death" type="byte" ver1="3.3.0.13" />
+        <field name="Use Birth Rate" type="byte" since="3.3.0.13" />
+        <field name="Spawn On Death" type="byte" since="3.3.0.13" />
         <field name="Emitter Dimensions" type="Vector3" />
         <field name="Emitter" type="Ptr" template="NiAVObject">The object which acts as the basis for the particle emitter.</field>
-        <field name="Num Spawn Generations" type="ushort" default="1" ver1="3.3.0.13" />
-        <field name="Percentage Spawned" type="float" default="1.0" ver1="3.3.0.13" />
-        <field name="Spawn Multiplier" type="ushort" ver1="3.3.0.13" />
-        <field name="Spawn Speed Chaos" type="float" ver1="3.3.0.13" />
-        <field name="Spawn Dir Chaos" type="float" ver1="3.3.0.13" />
-        <field name="Particle Velocity" type="Vector3" ver2="3.1">Particle velocity</field>
-        <field name="Particle Unknown Vector" type="Vector3" ver2="3.1" />
-        <field name="Particle Lifetime" type="float" ver2="3.1">The particle's age.</field>
-        <field name="Particle Link" type="Ref" template="NiObject" ver2="3.1" />
-        <field name="Particle Timestamp" type="uint" ver2="3.1">Timestamp of the last update.</field>
-        <field name="Particle Unknown Short" type="ushort" ver2="3.1">Unknown short</field>
-        <field name="Particle Vertex Id" type="ushort" ver2="3.1">Particle/vertex index matches array index</field>
+        <field name="Num Spawn Generations" type="ushort" default="1" since="3.3.0.13" />
+        <field name="Percentage Spawned" type="float" default="1.0" since="3.3.0.13" />
+        <field name="Spawn Multiplier" type="ushort" since="3.3.0.13" />
+        <field name="Spawn Speed Chaos" type="float" since="3.3.0.13" />
+        <field name="Spawn Dir Chaos" type="float" since="3.3.0.13" />
+        <field name="Particle Velocity" type="Vector3" until="3.1">Particle velocity</field>
+        <field name="Particle Unknown Vector" type="Vector3" until="3.1" />
+        <field name="Particle Lifetime" type="float" until="3.1">The particle's age.</field>
+        <field name="Particle Link" type="Ref" template="NiObject" until="3.1" />
+        <field name="Particle Timestamp" type="uint" until="3.1">Timestamp of the last update.</field>
+        <field name="Particle Unknown Short" type="ushort" until="3.1">Unknown short</field>
+        <field name="Particle Vertex Id" type="ushort" until="3.1">Particle/vertex index matches array index</field>
 
-        <field name="Num Particles" type="ushort" ver1="3.3.0.13">Size of the following array. (Maximum number of simultaneous active particles)</field>
-        <field name="Num Valid" type="ushort" ver1="3.3.0.13">Number of valid entries in the following array. (Number of active particles at the time the system was saved)</field>
-        <field name="Particles" type="NiParticleInfo" arr1="Num Particles" ver1="3.3.0.13" />
-        <field name="Emitter Modifier" type="Ref" template="NiEmitterModifier" ver1="3.3.0.13" />
+        <field name="Num Particles" type="ushort" since="3.3.0.13">Size of the following array. (Maximum number of simultaneous active particles)</field>
+        <field name="Num Valid" type="ushort" since="3.3.0.13">Number of valid entries in the following array. (Number of active particles at the time the system was saved)</field>
+        <field name="Particles" type="NiParticleInfo" arr1="Num Particles" since="3.3.0.13" />
+        <field name="Emitter Modifier" type="Ref" template="NiEmitterModifier" since="3.3.0.13" />
         <field name="Particle Modifier" type="Ref" template="NiParticleModifier">Link to some optional particle modifiers (NiGravity, NiParticleGrowFade, NiParticleBomb, ...)</field>
         <field name="Particle Collider" type="Ref" template="NiParticleCollider" />
-        <field name="Static Target Bound" type="byte" ver1="3.3.0.15" />
-        <field name="Color Data" type="Ref" template="NiColorData" ver2="3.1" />
-        <field name="Unknown Float 1" type="float" ver2="3.1" />
-        <field name="Unknown Floats 2" arr1="Particle Unknown Short" type="float" ver2="3.1" />
+        <field name="Static Target Bound" type="byte" since="3.3.0.15" />
+        <field name="Color Data" type="Ref" template="NiColorData" until="3.1" />
+        <field name="Unknown Float 1" type="float" until="3.1" />
+        <field name="Unknown Floats 2" arr1="Particle Unknown Short" type="float" until="3.1" />
     </niobject>
 
     <niobject name="NiBSPArrayController" inherit="NiParticleSystemController" module="BSLegacy" until="V10_0_1_0">
@@ -4518,7 +4518,7 @@
     <niobject name="NiPathController" inherit="NiTimeController" module="NiAnimation" until="V20_5_0_0">
         DEPRECATED (10.2), REMOVED (20.5). Replaced by NiTransformController and NiPathInterpolator.
         Time controller for a path.
-        <field name="Path Flags" type="PathFlags" ver1="10.1.0.0" />
+        <field name="Path Flags" type="PathFlags" since="10.1.0.0" />
         <field name="Bank Dir" type="int" default="1">-1 = Negative, 1 = Positive</field>
         <field name="Max Bank Angle" type="float">Max angle in radians.</field>
         <field name="Smoothing" type="float" />
@@ -4540,25 +4540,25 @@
         However, faking this inheritance is useful for several things.
         <field name="Pixel Format" type="PixelFormat">The format of the pixels in this internally stored image.</field>
         <!-- Technically since 10.3.0.3, fudging for WorldShift custom version as no games have official 10.3 NIFs anyway. -->
-        <field name="Red Mask" type="uint" ver2="10.4.0.1">0x000000ff (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
-        <field name="Green Mask" type="uint" ver2="10.4.0.1">0x0000ff00 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
-        <field name="Blue Mask" type="uint" ver2="10.4.0.1">0x00ff0000 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
-        <field name="Alpha Mask" type="uint" ver2="10.4.0.1">0xff000000 (for 32bpp) or 0x00000000 (for 24bpp and 8bpp)</field>
-        <field name="Bits Per Pixel" type="uint" ver2="10.4.0.1">Bits per pixel, 0 (Compressed), 8, 24 or 32.</field>
-        <field name="Old Fast Compare" type="byte" arr1="8" ver2="10.4.0.1">
+        <field name="Red Mask" type="uint" until="10.4.0.1">0x000000ff (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
+        <field name="Green Mask" type="uint" until="10.4.0.1">0x0000ff00 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
+        <field name="Blue Mask" type="uint" until="10.4.0.1">0x00ff0000 (for 24bpp and 32bpp) or 0x00000000 (for 8bpp)</field>
+        <field name="Alpha Mask" type="uint" until="10.4.0.1">0xff000000 (for 32bpp) or 0x00000000 (for 24bpp and 8bpp)</field>
+        <field name="Bits Per Pixel" type="uint" until="10.4.0.1">Bits per pixel, 0 (Compressed), 8, 24 or 32.</field>
+        <field name="Old Fast Compare" type="byte" arr1="8" until="10.4.0.1">
             [96,8,130,0,0,65,0,0] if 24 bits per pixel
             [129,8,130,32,0,65,12,0] if 32 bits per pixel
             [34,0,0,0,0,0,0,0] if 8 bits per pixel
             [X,0,0,0,0,0,0,0] if 0 (Compressed) bits per pixel where X = PixelFormat
         </field>
-        <field name="Tiling" type="PixelTiling" ver1="10.1.0.0" ver2="10.4.0.1">Seems to always be zero.</field>
-        <field name="Bits Per Pixel" type="byte" ver1="10.4.0.2">Bits per pixel, 0 (Compressed), 8, 24 or 32.</field>
-        <field name="Renderer Hint" type="uint" ver1="10.4.0.2" />
-        <field name="Extra Data" type="uint" ver1="10.4.0.2" />
-        <field name="Flags" type="byte" ver1="10.4.0.2" />
-        <field name="Tiling" type="PixelTiling" ver1="10.4.0.2" />
-        <field name="sRGB Space" type="bool" ver1="20.3.0.4" />
-        <field name="Channels" type="PixelFormatComponent" arr1="4" ver1="10.4.0.2">Channel Data</field>
+        <field name="Tiling" type="PixelTiling" since="10.1.0.0" until="10.4.0.1">Seems to always be zero.</field>
+        <field name="Bits Per Pixel" type="byte" since="10.4.0.2">Bits per pixel, 0 (Compressed), 8, 24 or 32.</field>
+        <field name="Renderer Hint" type="uint" since="10.4.0.2" />
+        <field name="Extra Data" type="uint" since="10.4.0.2" />
+        <field name="Flags" type="byte" since="10.4.0.2" />
+        <field name="Tiling" type="PixelTiling" since="10.4.0.2" />
+        <field name="sRGB Space" type="bool" since="20.3.0.4" />
+        <field name="Channels" type="PixelFormatComponent" arr1="4" since="10.4.0.2">Channel Data</field>
     </niobject>
 
     <niobject name="NiPersistentSrcTextureRendererData" inherit="NiPixelFormat" module="NiMain">
@@ -4567,10 +4567,10 @@
         <field name="Bytes Per Pixel" type="uint" />
         <field name="Mipmaps" type="MipMap" arr1="Num Mipmaps" />
         <field name="Num Pixels" type="uint" />
-        <field name="Pad Num Pixels" type="uint" ver1="20.2.0.6" />
+        <field name="Pad Num Pixels" type="uint" since="20.2.0.6" />
         <field name="Num Faces" type="uint" />
-        <field name="Platform" type="PlatformID" ver2="30.1.0.0" />
-        <field name="Renderer" type="RendererID" ver1="30.1.0.1" />
+        <field name="Platform" type="PlatformID" until="30.1.0.0" />
+        <field name="Renderer" type="RendererID" since="30.1.0.1" />
         <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels * Num Faces" />
     </niobject>
 
@@ -4582,15 +4582,15 @@
         <field name="Mipmaps" type="MipMap" arr1="Num Mipmaps" />
         <field name="Num Pixels" type="uint" />
         <!-- Technically since 10.3.0.6, fudging for WorldShift custom version as no games have official 10.3 NIFs anyway. -->
-        <field name="Num Faces" type="uint" ver1="10.4.0.2" default="1" />
-        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels" ver2="10.4.0.1" />
-        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels * Num Faces" ver1="10.4.0.2" />
+        <field name="Num Faces" type="uint" since="10.4.0.2" default="1" />
+        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels" until="10.4.0.1" />
+        <field name="Pixel Data" type="byte" binary="true" arr1="Num Pixels * Num Faces" since="10.4.0.2" />
     </niobject>
 
     <niobject name="NiParticleCollider" inherit="NiParticleModifier" module="NiLegacy" until="V10_0_1_0">
         <field name="Bounce" type="float" />
-        <field name="Spawn On Collide" type="bool" ver1="4.2.0.2" />
-        <field name="Die On Collide" type="bool" ver1="4.2.0.2" />
+        <field name="Spawn On Collide" type="bool" since="4.2.0.2" />
+        <field name="Die On Collide" type="bool" since="4.2.0.2" />
     </niobject>
 
     <niobject name="NiPlanarCollider" inherit="NiParticleCollider" module="NiLegacy" until="V10_0_1_0">
@@ -4701,7 +4701,7 @@
         <field name="Grow Generation" type="ushort">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</field>
         <field name="Fade Time" type="float">The time taken to shrink from their specified size to 0.</field>
         <field name="Fade Generation" type="ushort">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system.</field>
-        <field name="Base Scale" type="float" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_GTE_FO3#">A multiplier on the base particle scale.</field>
+        <field name="Base Scale" type="float" since="20.2.0.7" until="20.2.0.7" vercond="#BS_GTE_FO3#">A multiplier on the base particle scale.</field>
     </niobject>
 
     <niobject name="NiPSysMeshEmitter" inherit="NiPSysEmitter" module="NiParticle">
@@ -4771,12 +4771,12 @@
     <niobject name="NiPSysRotationModifier" inherit="NiPSysModifier" module="NiParticle">
         Particle modifier that adds rotations to particles.
         <field name="Rotation Speed" type="float">Initial Rotation Speed in radians per second.</field>
-        <field name="Rotation Speed Variation" type="float" ver1="20.0.0.2">Distributes rotation speed over the range [Speed - Variation, Speed + Variation].</field>
+        <field name="Rotation Speed Variation" type="float" since="20.0.0.2">Distributes rotation speed over the range [Speed - Variation, Speed + Variation].</field>
         <field name="Unknown Vector" type="Vector4" vercond="#BS_F76#" />
         <field name="Unknown Byte" type="byte" vercond="#BS_F76#" />
-        <field name="Rotation Angle" type="float" ver1="20.0.0.2">Initial Rotation Angle in radians.</field>
-        <field name="Rotation Angle Variation" type="float" ver1="20.0.0.2">Distributes rotation angle over the range [Angle - Variation, Angle + Variation].</field>
-        <field name="Random Rot Speed Sign" type="bool" ver1="20.0.0.2">Randomly negate the initial rotation speed?</field>
+        <field name="Rotation Angle" type="float" since="20.0.0.2">Initial Rotation Angle in radians.</field>
+        <field name="Rotation Angle Variation" type="float" since="20.0.0.2">Distributes rotation angle over the range [Angle - Variation, Angle + Variation].</field>
+        <field name="Random Rot Speed Sign" type="bool" since="20.0.0.2">Randomly negate the initial rotation speed?</field>
         <field name="Random Axis" type="bool" default="1">Assign a random axis to new particles?</field>
         <field name="Axis" type="Vector3" default="#X_AXIS#">Initial rotation axis.</field>
     </niobject>
@@ -4791,7 +4791,7 @@
         <field name="Spawn Dir Variation" type="float">How much the spawned particle direction can vary.</field>
         <field name="Life Span" type="float">Lifespan assigned to spawned particles.</field>
         <field name="Life Span Variation" type="float">The amount the lifespan can vary.</field>
-        <field name="WorldShift Spawn Speed Addition" type="float" ver1="10.2.0.1" ver2="10.4.0.1" />
+        <field name="WorldShift Spawn Speed Addition" type="float" since="10.2.0.1" until="10.4.0.1" />
     </niobject>
 
     <niobject name="NiPSysPartSpawnModifier" inherit="NiPSysModifier" module="NiCustom" versions="V10_2_0_1 V10_3_0_1 V10_4_0_1">
@@ -4969,15 +4969,15 @@
         Skinning data.
         <field name="Skin Transform" type="NiTransform">Offset of the skin from this bone in bind position.</field>
         <field name="Num Bones" type="uint">Number of bones.</field>
-        <field name="Skin Partition" type="Ref" template="NiSkinPartition" ver1="4.0.0.2" ver2="10.1.0.0">This optionally links a NiSkinPartition for hardware-acceleration information.</field>
-        <field name="Has Vertex Weights" type="byte" ver1="4.2.1.0" default="1">Enables Vertex Weights for this NiSkinData.</field>
+        <field name="Skin Partition" type="Ref" template="NiSkinPartition" since="4.0.0.2" until="10.1.0.0">This optionally links a NiSkinPartition for hardware-acceleration information.</field>
+        <field name="Has Vertex Weights" type="byte" since="4.2.1.0" default="1">Enables Vertex Weights for this NiSkinData.</field>
         <field name="Bone List" type="BoneData" arr1="Num Bones" arg="Has Vertex Weights">Contains offset data for each node that this skin is influenced by.</field>
     </niobject>
 
     <niobject name="NiSkinInstance" inherit="NiObject" module="NiMain">
         Skinning instance.
         <field name="Data" type="Ref" template="NiSkinData">Skinning data reference.</field>
-        <field name="Skin Partition" type="Ref" template="NiSkinPartition" ver1="10.1.0.101">Refers to a NiSkinPartition objects, which partitions the mesh such that every vertex is only influenced by a limited number of bones.</field>
+        <field name="Skin Partition" type="Ref" template="NiSkinPartition" since="10.1.0.101">Refers to a NiSkinPartition objects, which partitions the mesh such that every vertex is only influenced by a limited number of bones.</field>
         <field name="Skeleton Root" type="Ptr" template="NiNode">Armature root node.</field>
         <field name="Num Bones" type="uint">The number of node bones referenced as influences.</field>
         <field name="Bones" type="Ptr" template="NiNode" arr1="Num Bones">List of all armature bones.</field>
@@ -4994,10 +4994,10 @@
     <niobject name="NiSkinPartition" inherit="NiObject" module="NiMain">
         Skinning data, optimized for hardware skinning. The mesh is partitioned in submeshes such that each vertex of a submesh is influenced only by a limited and fixed number of bones.
         <field name="Num Partitions" type="uint" />
-		<field name="Data Size" type="uint" calc="#LEN[Vertex Data]# #MUL# Vertex Size" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Vertex Size" type="uint" calc="(Vertex Desc #BITAND# 0xF) #MUL# 4" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Vertex Desc" type="BSVertexDesc" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_SSE#" />
-		<field name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc #RSH# 44" arr1="Data Size / Vertex Size" cond="Data Size #GT# 0" ver1="20.2.0.7" ver2="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Data Size" type="uint" calc="#LEN[Vertex Data]# #MUL# Vertex Size" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Vertex Size" type="uint" calc="(Vertex Desc #BITAND# 0xF) #MUL# 4" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Vertex Desc" type="BSVertexDesc" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
+		<field name="Vertex Data" type="BSVertexDataSSE" arg="Vertex Desc #RSH# 44" arr1="Data Size / Vertex Size" cond="Data Size #GT# 0" since="20.2.0.7" until="20.2.0.7" vercond="#BS_SSE#" />
 		<field name="Partitions" type="SkinPartition" arr1="Num Partitions" />
     </niobject>
 
@@ -5015,16 +5015,16 @@
     <niobject name="NiSourceTexture" inherit="NiTexture" module="NiMain">
         Describes texture source and properties.
         <field name="Use External" type="byte" default="1">Is the texture external?</field>
-        <field name="Use Internal" type="byte" default="1" cond="Use External == 0" ver2="10.0.1.3" />
+        <field name="Use Internal" type="byte" default="1" cond="Use External == 0" until="10.0.1.3" />
         <field name="File Name" type="FilePath" cond="Use External == 1">The external texture file name.</field>
-        <field name="File Name" type="FilePath" cond="Use External == 0" ver1="10.1.0.0">The original source filename of the image embedded by the referred NiPixelData object.</field>
-        <field name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 1" ver1="10.1.0.0" />
-        <field name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0 #AND# Use Internal == 1" ver2="10.0.1.3">NiPixelData or NiPersistentSrcTextureRendererData</field>
-        <field name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0" ver1="10.0.1.4">NiPixelData or NiPersistentSrcTextureRendererData</field>
+        <field name="File Name" type="FilePath" cond="Use External == 0" since="10.1.0.0">The original source filename of the image embedded by the referred NiPixelData object.</field>
+        <field name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 1" since="10.1.0.0" />
+        <field name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0 #AND# Use Internal == 1" until="10.0.1.3">NiPixelData or NiPersistentSrcTextureRendererData</field>
+        <field name="Pixel Data" type="Ref" template="NiPixelFormat" cond="Use External == 0" since="10.0.1.4">NiPixelData or NiPersistentSrcTextureRendererData</field>
         <field name="Format Prefs" type="FormatPrefs">A set of preferences for the texture format. They are a request only and the renderer may ignore them.</field>
         <field name="Is Static" type="byte" default="1">If set, then the application cannot assume that any dynamic changes to the pixel data will show in the rendered image.</field>
-        <field name="Direct Render" type="bool" default="1" ver1="10.1.0.103">A hint to the renderer that the texture can be loaded directly from a texture file into a renderer-specific resource, bypassing the NiPixelData object.</field>
-        <field name="Persist Render Data" type="bool" default="0" ver1="20.2.0.4">Pixel Data is NiPersistentSrcTextureRendererData instead of NiPixelData.</field>
+        <field name="Direct Render" type="bool" default="1" since="10.1.0.103">A hint to the renderer that the texture can be loaded directly from a texture file into a renderer-specific resource, bypassing the NiPixelData object.</field>
+        <field name="Persist Render Data" type="bool" default="0" since="20.2.0.4">Pixel Data is NiPersistentSrcTextureRendererData instead of NiPixelData.</field>
     </niobject>
 
     <niobject name="NiSpecularProperty" inherit="NiProperty" module="NiMain">
@@ -5041,30 +5041,30 @@
     <niobject name="NiSpotLight" inherit="NiPointLight" module="NiMain">
         A spot.
         <field name="Outer Spot Angle" type="float" range="#F_DEG#" />
-        <field name="Inner Spot Angle" type="float" range="#F_DEG#" ver1="20.2.0.5" />
+        <field name="Inner Spot Angle" type="float" range="#F_DEG#" since="20.2.0.5" />
         <field name="Exponent" type="float" default="1.0">Describes the distribution of light.</field>
     </niobject>
 
     <niobject name="NiStencilProperty" inherit="NiProperty" module="NiMain">
         Allows control of stencil testing.
-        <field name="Flags" type="ushort" ver2="10.0.1.2">Property flags.</field>
-        <field name="Stencil Enabled" type="byte" ver2="20.0.0.5">Enables or disables the stencil test.</field>
-        <field name="Stencil Function" type="StencilTestFunc" ver2="20.0.0.5">Selects the compare mode function.</field>
-        <field name="Stencil Ref" type="uint" ver2="20.0.0.5" />
-        <field name="Stencil Mask" type="uint" default="#UINT_MAX#" ver2="20.0.0.5">A bit mask. The default is 0xffffffff.</field>
-        <field name="Fail Action" type="StencilAction" ver2="20.0.0.5" />
-        <field name="Z Fail Action" type="StencilAction" ver2="20.0.0.5" />
-        <field name="Pass Action" type="StencilAction" ver2="20.0.0.5" />
-        <field name="Draw Mode" default="DRAW_BOTH" type="StencilDrawMode" ver2="20.0.0.5">Used to enabled double sided faces. Default is 3 (DRAW_BOTH).</field>
-        <field name="Flags" type="StencilFlags" default="19840" ver1="20.1.0.3" />
-        <field name="Stencil Ref" type="uint" ver1="20.1.0.3" />
-        <field name="Stencil Mask" type="uint" default="#UINT_MAX#" ver1="20.1.0.3">A bit mask. The default is 0xffffffff.</field>
+        <field name="Flags" type="ushort" until="10.0.1.2">Property flags.</field>
+        <field name="Stencil Enabled" type="byte" until="20.0.0.5">Enables or disables the stencil test.</field>
+        <field name="Stencil Function" type="StencilTestFunc" until="20.0.0.5">Selects the compare mode function.</field>
+        <field name="Stencil Ref" type="uint" until="20.0.0.5" />
+        <field name="Stencil Mask" type="uint" default="#UINT_MAX#" until="20.0.0.5">A bit mask. The default is 0xffffffff.</field>
+        <field name="Fail Action" type="StencilAction" until="20.0.0.5" />
+        <field name="Z Fail Action" type="StencilAction" until="20.0.0.5" />
+        <field name="Pass Action" type="StencilAction" until="20.0.0.5" />
+        <field name="Draw Mode" default="DRAW_BOTH" type="StencilDrawMode" until="20.0.0.5">Used to enabled double sided faces. Default is 3 (DRAW_BOTH).</field>
+        <field name="Flags" type="StencilFlags" default="19840" since="20.1.0.3" />
+        <field name="Stencil Ref" type="uint" since="20.1.0.3" />
+        <field name="Stencil Mask" type="uint" default="#UINT_MAX#" since="20.1.0.3">A bit mask. The default is 0xffffffff.</field>
     </niobject>
 
     <niobject name="NiStringExtraData" inherit="NiExtraData" module="NiMain">
         Extra data in the form of text.
         Used in various official or user-defined ways, e.g. preventing optimization on objects ("NiOptimizeKeep", "sgoKeep").
-        <field name="String Data" type="string" ver1="4.0.0.0">The string.</field>
+        <field name="String Data" type="string" since="4.0.0.0">The string.</field>
     </niobject>
 
     <niobject name="NiStringPalette" inherit="NiObject" module="NiMain">
@@ -5089,25 +5089,25 @@
         <field name="Model Projection Matrix" type="Matrix33">Model projection matrix.  Always identity?</field>
         <field name="Model Projection Translation" type="Vector3">Model projection translation.  Always (0,0,0)?</field>
         <field name="Texture Filtering" type="TexFilterMode" default="FILTER_TRILERP">Texture Filtering mode.</field>
-        <field name="Max Anisotropy" type="ushort" ver1="20.5.0.4" />
+        <field name="Max Anisotropy" type="ushort" since="20.5.0.4" />
         <field name="Texture Clamping" type="TexClampMode" default="WRAP_S_WRAP_T">Texture Clamp mode.</field>
         <field name="Texture Type" default="TEX_ENVIRONMENT_MAP" type="TextureType">The type of effect that the texture is used for.</field>
         <field name="Coordinate Generation Type" default="CG_SPHERE_MAP" type="CoordGenType">The method that will be used to generate UV coordinates for the texture effect.</field>
-        <field name="Image" type="Ref" template="NiImage" ver2="3.1">Image index.</field>
-        <field name="Source Texture" type="Ref" template="NiSourceTexture" ver1="3.1">Source texture index.</field>
+        <field name="Image" type="Ref" template="NiImage" until="3.1">Image index.</field>
+        <field name="Source Texture" type="Ref" template="NiSourceTexture" since="3.1">Source texture index.</field>
         <field name="Enable Plane" default="0" type="byte">Determines whether a clipping plane is used. Always 8-bit.</field>
         <field name="Plane" type="NiPlane" />
-        <field name="PS2 L" type="short" default="0" ver2="10.2.0.0" />
-        <field name="PS2 K" type="short" default="-75" ver2="10.2.0.0" />
-        <field name="Unknown Short" type="ushort" ver2="4.1.0.12" default="0" />
+        <field name="PS2 L" type="short" default="0" until="10.2.0.0" />
+        <field name="PS2 K" type="short" default="-75" until="10.2.0.0" />
+        <field name="Unknown Short" type="ushort" until="4.1.0.12" default="0" />
     </niobject>
 
     <niobject name="NiTextureModeProperty" inherit="NiProperty" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
-        <field name="Unknown Ints" type="uint" arr1="3" ver2="2.3" />
-        <field name="Flags" type="ushort" ver1="3.0">Either 210 or 194.</field>
-        <field name="PS2 L" type="short" default="0" ver1="3.1" ver2="10.2.0.0" />
-        <field name="PS2 K" type="short" default="-75" ver1="3.1" ver2="10.2.0.0" />
+        <field name="Unknown Ints" type="uint" arr1="3" until="2.3" />
+        <field name="Flags" type="ushort" since="3.0">Either 210 or 194.</field>
+        <field name="PS2 L" type="short" default="0" since="3.1" until="10.2.0.0" />
+        <field name="PS2 K" type="short" default="-75" since="3.1" until="10.2.0.0" />
     </niobject>
 
     <niobject name="NiImage" inherit="NiObject" module="NiLegacy" until="V10_0_1_0">
@@ -5116,22 +5116,22 @@
         <field name="File Name" type="FilePath" cond="Use External != 0">The filepath to the texture.</field>
         <field name="Image Data" type="Ref" template="NiRawImageData" cond="Use External == 0">Link to the internally stored image data.</field>
         <field name="Unknown Int" type="uint" default="7" />
-        <field name="Unknown Float" type="float" ver1="3.1" default="128.5" />
+        <field name="Unknown Float" type="float" since="3.1" default="128.5" />
     </niobject>
 
     <niobject name="NiTextureProperty" inherit="NiProperty" module="NiLegacy" until="V10_0_1_0">
         LEGACY (pre-10.1)
-        <field name="Unknown Ints 1" type="uint" arr1="2" ver2="2.3" />
-        <field name="Flags" type="ushort" ver1="3.0">Property flags.</field>
+        <field name="Unknown Ints 1" type="uint" arr1="2" until="2.3" />
+        <field name="Flags" type="ushort" since="3.0">Property flags.</field>
         <field name="Image" type="Ref" template="NiImage">Link to the texture image.</field>
-        <field name="Unknown Ints 2" type="uint" arr1="2" ver1="3.0" ver2="3.03" />
+        <field name="Unknown Ints 2" type="uint" arr1="2" since="3.0" until="3.03" />
     </niobject>
 
     <niobject name="NiTexturingProperty" inherit="NiProperty" module="NiMain">
         Describes how a fragment shader should be configured for a given piece of geometry.
-        <field name="Flags" type="ushort" ver2="10.0.1.2">Property flags.</field>
-        <field name="Flags" type="TexturingFlags" ver1="20.1.0.2">Property flags.</field>
-        <field name="Apply Mode" type="ApplyMode" default="APPLY_MODULATE" ver1="3.3.0.13" ver2="20.1.0.1">Determines how the texture will be applied.  Seems to have special functions in Oblivion.</field>
+        <field name="Flags" type="ushort" until="10.0.1.2">Property flags.</field>
+        <field name="Flags" type="TexturingFlags" since="20.1.0.2">Property flags.</field>
+        <field name="Apply Mode" type="ApplyMode" default="APPLY_MODULATE" since="3.3.0.13" until="20.1.0.1">Determines how the texture will be applied.  Seems to have special functions in Oblivion.</field>
         <field name="Texture Count" type="uint" default="7">Number of textures.</field>
         <field name="Has Base Texture" type="bool" />
         <field name="Base Texture" type="TexDesc" cond="Has Base Texture" />
@@ -5143,31 +5143,31 @@
         <field name="Gloss Texture" type="TexDesc" cond="Has Gloss Texture" />
         <field name="Has Glow Texture" type="bool" />
         <field name="Glow Texture" type="TexDesc" cond="Has Glow Texture" />
-        <field name="Has Bump Map Texture" type="bool" ver1="3.3.0.13" cond="Texture Count #GT# 5" />
-        <field name="Bump Map Texture" type="TexDesc" ver1="3.3.0.13" cond="Has Bump Map Texture" />
-        <field name="Bump Map Luma Scale" type="float" ver1="3.3.0.13" cond="Has Bump Map Texture" />
-        <field name="Bump Map Luma Offset" type="float" ver1="3.3.0.13" cond="Has Bump Map Texture" />
-        <field name="Bump Map Matrix" type="Matrix22" ver1="3.3.0.13" cond="Has Bump Map Texture" />
-        <field name="Has Normal Texture" type="bool" cond="Texture Count #GT# 6" ver1="20.2.0.5" />
-        <field name="Normal Texture" type="TexDesc" cond="Has Normal Texture" ver1="20.2.0.5" />
-        <field name="Has Parallax Texture" type="bool" cond="Texture Count #GT# 7" ver1="20.2.0.5" />
-        <field name="Parallax Texture" type="TexDesc" cond="Has Parallax Texture" ver1="20.2.0.5" />
-        <field name="Parallax Offset" type="float" cond="Has Parallax Texture" ver1="20.2.0.5" />
-        <field name="Has Decal 0 Texture" type="bool" cond="Texture Count #GT# 6" ver2="20.2.0.4" />
-        <field name="Has Decal 0 Texture" type="bool" cond="Texture Count #GT# 8" ver1="20.2.0.5" />
+        <field name="Has Bump Map Texture" type="bool" since="3.3.0.13" cond="Texture Count #GT# 5" />
+        <field name="Bump Map Texture" type="TexDesc" since="3.3.0.13" cond="Has Bump Map Texture" />
+        <field name="Bump Map Luma Scale" type="float" since="3.3.0.13" cond="Has Bump Map Texture" />
+        <field name="Bump Map Luma Offset" type="float" since="3.3.0.13" cond="Has Bump Map Texture" />
+        <field name="Bump Map Matrix" type="Matrix22" since="3.3.0.13" cond="Has Bump Map Texture" />
+        <field name="Has Normal Texture" type="bool" cond="Texture Count #GT# 6" since="20.2.0.5" />
+        <field name="Normal Texture" type="TexDesc" cond="Has Normal Texture" since="20.2.0.5" />
+        <field name="Has Parallax Texture" type="bool" cond="Texture Count #GT# 7" since="20.2.0.5" />
+        <field name="Parallax Texture" type="TexDesc" cond="Has Parallax Texture" since="20.2.0.5" />
+        <field name="Parallax Offset" type="float" cond="Has Parallax Texture" since="20.2.0.5" />
+        <field name="Has Decal 0 Texture" type="bool" cond="Texture Count #GT# 6" until="20.2.0.4" />
+        <field name="Has Decal 0 Texture" type="bool" cond="Texture Count #GT# 8" since="20.2.0.5" />
         <field name="Decal 0 Texture" type="TexDesc" cond="Has Decal 0 Texture" />
-        <field name="Has Decal 1 Texture" type="bool" cond="Texture Count #GT# 7" ver2="20.2.0.4" />
-        <field name="Has Decal 1 Texture" type="bool" cond="Texture Count #GT# 9" ver1="20.2.0.5" />
+        <field name="Has Decal 1 Texture" type="bool" cond="Texture Count #GT# 7" until="20.2.0.4" />
+        <field name="Has Decal 1 Texture" type="bool" cond="Texture Count #GT# 9" since="20.2.0.5" />
         <field name="Decal 1 Texture" type="TexDesc" cond="Has Decal 1 Texture" />
-        <field name="Has Decal 2 Texture" type="bool" cond="Texture Count #GT# 8" ver2="20.2.0.4" />
-        <field name="Has Decal 2 Texture" type="bool" cond="Texture Count #GT# 10" ver1="20.2.0.5" />
+        <field name="Has Decal 2 Texture" type="bool" cond="Texture Count #GT# 8" until="20.2.0.4" />
+        <field name="Has Decal 2 Texture" type="bool" cond="Texture Count #GT# 10" since="20.2.0.5" />
         <field name="Decal 2 Texture" type="TexDesc" cond="Has Decal 2 Texture" />
-        <field name="Has Decal 3 Texture" type="bool" cond="Texture Count #GT# 9" ver2="20.2.0.4" />
-        <field name="Has Decal 3 Texture" type="bool" cond="Texture Count #GT# 11" ver1="20.2.0.5" />
+        <field name="Has Decal 3 Texture" type="bool" cond="Texture Count #GT# 9" until="20.2.0.4" />
+        <field name="Has Decal 3 Texture" type="bool" cond="Texture Count #GT# 11" since="20.2.0.5" />
         <field name="Decal 3 Texture" type="TexDesc" cond="Has Decal 3 Texture" />
         
-        <field name="Num Shader Textures" type="uint" ver1="10.0.1.0" />
-        <field name="Shader Textures" type="ShaderTexDesc" arr1="Num Shader Textures" ver1="10.0.1.0" />
+        <field name="Num Shader Textures" type="uint" since="10.0.1.0" />
+        <field name="Shader Textures" type="ShaderTexDesc" arr1="Num Shader Textures" since="10.0.1.0" />
     </niobject>
 
     <niobject name="NiMultiTextureProperty" inherit="NiTexturingProperty" module="NiLegacy" />
@@ -5183,11 +5183,11 @@
     <niobject name="NiTriShapeData" inherit="NiTriBasedGeomData" module="NiMain">
         Holds mesh data using a list of singular triangles.
         <field name="Num Triangle Points" type="uint" range="0:196605">Num Triangles times 3.</field>
-        <field name="Has Triangles" type="bool" ver1="10.1.0.0">Do we have triangle data?</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" ver2="10.0.1.2">Triangle data.</field>
-        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Has Triangles" ver1="10.0.1.3">Triangle face data.</field>
-        <field name="Num Match Groups" type="ushort" ver1="3.1">Number of shared normals groups.</field>
-        <field name="Match Groups" type="MatchGroup" arr1="Num Match Groups" ver1="3.1">The shared normals.</field>
+        <field name="Has Triangles" type="bool" since="10.1.0.0">Do we have triangle data?</field>
+        <field name="Triangles" type="Triangle" arr1="Num Triangles" until="10.0.1.2">Triangle data.</field>
+        <field name="Triangles" type="Triangle" arr1="Num Triangles" cond="Has Triangles" since="10.0.1.3">Triangle face data.</field>
+        <field name="Num Match Groups" type="ushort" since="3.1">Number of shared normals groups.</field>
+        <field name="Match Groups" type="MatchGroup" arr1="Num Match Groups" since="3.1">The shared normals.</field>
     </niobject>
 
     <niobject name="NiTriStrips" inherit="NiTriBasedGeom" module="NiMain">
@@ -5198,9 +5198,9 @@
         Holds mesh data using strips of triangles.
         <field name="Num Strips" type="ushort" default="1" />
         <field name="Strip Lengths" type="ushort" arr1="Num Strips">The number of points in each triangle strip.</field>
-        <field name="Has Points" type="bool" default="1" ver1="10.0.1.3">Do we have strip point data?</field>
-        <field name="Points" type="ushort" arr1="Num Strips" arr2="Strip Lengths" ver2="10.0.1.2">The points in the Triangle strips.  Size is the sum of all entries in Strip Lengths.</field>
-        <field name="Points" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="Has Points" ver1="10.0.1.3">The points in the Triangle strips. Size is the sum of all entries in Strip Lengths.</field>
+        <field name="Has Points" type="bool" default="1" since="10.0.1.3">Do we have strip point data?</field>
+        <field name="Points" type="ushort" arr1="Num Strips" arr2="Strip Lengths" until="10.0.1.2">The points in the Triangle strips.  Size is the sum of all entries in Strip Lengths.</field>
+        <field name="Points" type="ushort" arr1="Num Strips" arr2="Strip Lengths" cond="Has Points" since="10.0.1.3">The points in the Triangle strips. Size is the sum of all entries in Strip Lengths.</field>
     </niobject>
 
     <niobject name="NiEnvMappedTriShape" inherit="NiObjectNET" module="NiLegacy" until="V10_0_1_0">
@@ -5297,8 +5297,8 @@
     <niobject name="NiVertexColorProperty" inherit="NiProperty" module="NiMain">
         Property of vertex colors. This object is referred to by the root object of the NIF file whenever some NiTriShapeData object has vertex colors with non-default settings; if not present, vertex colors have vertex_mode=2 and lighting_mode=1.
         <field name="Flags" type="VertexColorFlags" />
-        <field name="Vertex Mode" type="SourceVertexMode" ver2="20.0.0.5">In Flags from 20.1.0.3 on.</field>
-        <field name="Lighting Mode" type="LightingMode" ver2="20.0.0.5">In Flags from 20.1.0.3 on.</field>
+        <field name="Vertex Mode" type="SourceVertexMode" until="20.0.0.5">In Flags from 20.1.0.3 on.</field>
+        <field name="Lighting Mode" type="LightingMode" until="20.0.0.5">In Flags from 20.1.0.3 on.</field>
     </niobject>
 
     <niobject name="NiVertWeightsExtraData" inherit="NiExtraData" module="NiMain">
@@ -5324,7 +5324,7 @@
     <niobject name="NiZBufferProperty" inherit="NiProperty" module="NiMain">
         Allows applications to set the test and write modes of the renderer's Z-buffer and to set the comparison function used for the Z-buffer test.
         <field name="Flags" type="ZBufferFlags" default="3" />
-        <field name="Function" type="TestFunction" default="TEST_LESS_EQUAL" ver1="4.1.0.12" ver2="20.0.0.5">
+        <field name="Function" type="TestFunction" default="TEST_LESS_EQUAL" since="4.1.0.12" until="20.0.0.5">
             Z-Test function. In Flags from 20.1.0.3 on.
         </field>
     </niobject>
@@ -5348,7 +5348,7 @@
     <niobject name="NiSortAdjustNode" inherit="NiNode" module="NiMain">
         Used to turn sorting off for individual subtrees in a scene. Useful if objects must be drawn in a fixed order.
         <field name="Sorting Mode" type="SortingMode" default="SORTING_INHERIT">Sorting</field>
-        <field name="Accumulator" type="Ref" template="NiAccumulator" ver2="20.0.0.3" />
+        <field name="Accumulator" type="Ref" template="NiAccumulator" until="20.0.0.3" />
     </niobject>
 
     <niobject name="NiSourceCubeMap" inherit="NiSourceTexture" module="NiLegacy">
@@ -5361,18 +5361,18 @@
         Object which manages a NxScene object and the Gamebryo objects that interact with it.
         <field name="Scene Transform" type="NiTransform" />
         <field name="PhysX to World Scale" type="float" default="1.0" />
-        <field name="Num Props" type="uint" ver1="20.3.0.2" />
-        <field name="Props" type="Ref" template="NiPhysXProp" arr1="Num Props" ver1="20.3.0.2" />
+        <field name="Num Props" type="uint" since="20.3.0.2" />
+        <field name="Props" type="Ref" template="NiPhysXProp" arr1="Num Props" since="20.3.0.2" />
         <field name="Num Sources" type="uint" />
         <field name="Sources" type="Ref" template="NiPhysXSrc" arr1="Num Sources" />
         <field name="Num Dests" type="uint" />
         <field name="Dests" type="Ref" template="NiPhysXDest" arr1="Num Dests" />
-        <field name="Num Modified Meshes" type="uint" ver1="20.4.0.0" />
-        <field name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" ver1="20.4.0.0" />
-        <field name="Time Step" type="float" default="0.016666" ver1="20.2.0.8" />
-        <field name="Keep Meshes" type="bool" ver1="20.2.0.8" ver2="20.3.0.1" />
-        <field name="Num Sub Steps" type="uint" default="1" ver1="20.3.0.9" />
-        <field name="Max Sub Steps" type="uint" default="8" ver1="20.3.0.9" />
+        <field name="Num Modified Meshes" type="uint" since="20.4.0.0" />
+        <field name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" since="20.4.0.0" />
+        <field name="Time Step" type="float" default="0.016666" since="20.2.0.8" />
+        <field name="Keep Meshes" type="bool" since="20.2.0.8" until="20.3.0.1" />
+        <field name="Num Sub Steps" type="uint" default="1" since="20.3.0.9" />
+        <field name="Max Sub Steps" type="uint" default="8" since="20.3.0.9" />
         <field name="Snapshot" type="Ref" template="NiPhysXSceneDesc" />
         <field name="Flags" type="ushort" />
     </niobject>
@@ -5488,7 +5488,7 @@
 
     <niobject name="NiPhysXSceneDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         Object which caches the properties of NxScene, stored as a snapshot in a NiPhysXScene.
-        <field name="Broad Phase Type" type="NiSceneDescNxBroadPhaseType" ver2="20.2.0.7" />
+        <field name="Broad Phase Type" type="NiSceneDescNxBroadPhaseType" until="20.2.0.7" />
         <field name="Gravity" type="Vector3" />
         <field name="Max Timestep" type="float" default="0.016666" />
         <field name="Max Iterations" type="uint" default="8" />
@@ -5502,43 +5502,43 @@
         <field name="Max Static Shapes" type="uint" cond="Has Limits" />
         <field name="Max Dynamic Shapes" type="uint" cond="Has Limits" />
         <field name="Simulation Type" type="NxSimulationType" default="SIMULATION_SW" />
-        <field name="HW Scene Type" type="NiSceneDescNxHwSceneType" ver2="20.2.0.8" />
-        <field name="HW Pipeline Spec" type="NiSceneDescNxHwPipelineSpec" ver2="20.2.0.8" />
+        <field name="HW Scene Type" type="NiSceneDescNxHwSceneType" until="20.2.0.8" />
+        <field name="HW Pipeline Spec" type="NiSceneDescNxHwPipelineSpec" until="20.2.0.8" />
         <field name="Ground Plane" type="bool" />
         <field name="Bounds Plane" type="bool" />
-        <field name="Collision Detection" type="bool" ver2="20.2.0.7" />
-        <field name="Flags" type="uint" ver1="20.2.0.8" />
-        <field name="Internal Thread Count" type="uint" ver1="20.2.0.8" />
-        <field name="Background Thread Count" type="uint" ver1="20.2.0.8" />
-        <field name="Thread Mask" type="uint" ver1="20.2.0.8" />
-        <field name="Background Thread Priority" type="uint" ver1="20.5.0.3" />
-        <field name="Background Thread Mask" type="uint" ver1="20.2.0.8" />
-        <field name="Num HW Scenes" type="uint" ver1="20.3.0.1" ver2="20.3.0.5" />
-        <field name="Sim Thread Stack Size" type="uint" ver1="20.3.0.1" />
-        <field name="Sim Thread Priority" type="NxThreadPriority" default="TP_NORMAL" ver1="20.3.0.1" />
-        <field name="Worker Thread Stack Size" type="uint" ver1="20.3.0.1" />
-        <field name="Worker Thread Priority" type="NxThreadPriority" default="TP_NORMAL" ver1="20.3.0.1" />
-        <field name="Up Axis" type="uint" ver1="20.3.0.1" />
-        <field name="Subdivision Level" type="uint" default="5" ver1="20.3.0.1" />
-        <field name="Static Structure" type="NxPruningStructure" default="PRUNING_NONE" ver1="20.3.0.1" />
-        <field name="Dynamic Structure" type="NxPruningStructure" default="PRUNING_STATIC_AABB_TREE" ver1="20.3.0.1" />
-        <field name="Dynamic Tree Rebuild Rate Hint" type="uint" ver1="20.5.0.3" />
-        <field name="Broad Phase Type" type="NxBroadPhaseType" ver1="20.4.0.0" />
-        <field name="Grid Cells X" type="uint" ver1="20.4.0.0" />
-        <field name="Grid Cells Y" type="uint" ver1="20.4.0.0" />
-        <field name="Num Actors" type="uint" ver2="20.3.0.1" />
-        <field name="Actors" type="Ref" template="NiPhysXActorDesc" arr1="Num Actors" ver2="20.3.0.1" />
-        <field name="Num Joints" type="uint" ver2="20.3.0.1" />
-        <field name="Joints" type="Ref" template="NiPhysXJointDesc" arr1="Num Joints" ver2="20.3.0.1" />
-        <field name="Num Materials" type="uint" ver2="20.3.0.1" />
-        <field name="Materials" type="NiPhysXMaterialDescMap" arr1="Num Materials" ver2="20.3.0.1" />
+        <field name="Collision Detection" type="bool" until="20.2.0.7" />
+        <field name="Flags" type="uint" since="20.2.0.8" />
+        <field name="Internal Thread Count" type="uint" since="20.2.0.8" />
+        <field name="Background Thread Count" type="uint" since="20.2.0.8" />
+        <field name="Thread Mask" type="uint" since="20.2.0.8" />
+        <field name="Background Thread Priority" type="uint" since="20.5.0.3" />
+        <field name="Background Thread Mask" type="uint" since="20.2.0.8" />
+        <field name="Num HW Scenes" type="uint" since="20.3.0.1" until="20.3.0.5" />
+        <field name="Sim Thread Stack Size" type="uint" since="20.3.0.1" />
+        <field name="Sim Thread Priority" type="NxThreadPriority" default="TP_NORMAL" since="20.3.0.1" />
+        <field name="Worker Thread Stack Size" type="uint" since="20.3.0.1" />
+        <field name="Worker Thread Priority" type="NxThreadPriority" default="TP_NORMAL" since="20.3.0.1" />
+        <field name="Up Axis" type="uint" since="20.3.0.1" />
+        <field name="Subdivision Level" type="uint" default="5" since="20.3.0.1" />
+        <field name="Static Structure" type="NxPruningStructure" default="PRUNING_NONE" since="20.3.0.1" />
+        <field name="Dynamic Structure" type="NxPruningStructure" default="PRUNING_STATIC_AABB_TREE" since="20.3.0.1" />
+        <field name="Dynamic Tree Rebuild Rate Hint" type="uint" since="20.5.0.3" />
+        <field name="Broad Phase Type" type="NxBroadPhaseType" since="20.4.0.0" />
+        <field name="Grid Cells X" type="uint" since="20.4.0.0" />
+        <field name="Grid Cells Y" type="uint" since="20.4.0.0" />
+        <field name="Num Actors" type="uint" until="20.3.0.1" />
+        <field name="Actors" type="Ref" template="NiPhysXActorDesc" arr1="Num Actors" until="20.3.0.1" />
+        <field name="Num Joints" type="uint" until="20.3.0.1" />
+        <field name="Joints" type="Ref" template="NiPhysXJointDesc" arr1="Num Joints" until="20.3.0.1" />
+        <field name="Num Materials" type="uint" until="20.3.0.1" />
+        <field name="Materials" type="NiPhysXMaterialDescMap" arr1="Num Materials" until="20.3.0.1" />
         <field name="Group Collision Flags" type="bool" arr1="1024" />
         <field name="Filter Ops" type="NxFilterOp" arr1="3" />
         <field name="Filter Constants" type="uint" arr1="8" />
         <field name="Filter" type="bool" default="1" />
-        <field name="Num States" type="uint" ver2="20.3.0.1" />
-        <field name="Num Compartments" type="uint" ver1="20.3.0.6" />
-        <field name="Compartments" type="NxCompartmentDescMap" arr1="Num Compartments" ver1="20.3.0.6" />
+        <field name="Num States" type="uint" until="20.3.0.1" />
+        <field name="Num Compartments" type="uint" since="20.3.0.6" />
+        <field name="Compartments" type="NxCompartmentDescMap" arr1="Num Compartments" since="20.3.0.6" />
     </niobject>
 
     <niobject name="NiPhysXProp" inherit="NiObjectNET" module="NiPhysX" since="V20_2_0_8">
@@ -5548,9 +5548,9 @@
         <field name="Sources" type="Ref" template="NiPhysXSrc" arr1="Num Sources" />
         <field name="Num Dests" type="uint" />
         <field name="Dests" type="Ref" template="NiPhysXDest" arr1="Num Dests" />
-        <field name="Num Modified Meshes" type="uint" ver1="20.4.0.0" />
-        <field name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" ver1="20.4.0.0" />
-        <field name="Temp Name" type="NiFixedString" ver1="30.1.0.2" ver2="30.2.0.2" />
+        <field name="Num Modified Meshes" type="uint" since="20.4.0.0" />
+        <field name="Modified Meshes" type="Ref" template="NiMesh" arr1="Num Modified Meshes" since="20.4.0.0" />
+        <field name="Temp Name" type="NiFixedString" since="30.1.0.2" until="30.2.0.2" />
         <field name="Keep Meshes" type="bool" />
         <field name="Snapshot" type="Ref" template="NiPhysXPropDesc" />
     </niobject>
@@ -5561,13 +5561,13 @@
         <field name="Actors" type="Ref" template="NiPhysXActorDesc" arr1="Num Actors" />
         <field name="Num Joints" type="uint" />
         <field name="Joints" type="Ref" template="NiPhysXJointDesc" arr1="Num Joints" />
-        <field name="Num Clothes" type="uint" ver1="20.3.0.5" />
-        <field name="Clothes" type="Ref" template="NiPhysXClothDesc" arr1="Num Clothes" ver1="20.3.0.5" />
+        <field name="Num Clothes" type="uint" since="20.3.0.5" />
+        <field name="Clothes" type="Ref" template="NiPhysXClothDesc" arr1="Num Clothes" since="20.3.0.5" />
         <field name="Num Materials" type="uint" />
         <field name="Materials" type="NiPhysXMaterialDescMap" arr1="Num Materials" />
         <field name="Num States" type="uint" />
-        <field name="State Names" type="NiTFixedStringMap" template="uint" ver1="20.4.0.0" />
-        <field name="Flags" type="byte" ver1="20.4.0.0" />
+        <field name="State Names" type="NiTFixedStringMap" template="uint" since="20.4.0.0" />
+        <field name="Flags" type="byte" since="20.4.0.0" />
     </niobject>
 
     <niobject name="NiPhysXActorDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5579,10 +5579,10 @@
         <field name="Density" type="float" />
         <field name="Actor Flags" type="uint" />
         <field name="Actor Group" type="ushort" />
-        <field name="Dominance Group" type="ushort" ver1="20.4.0.0" />
-        <field name="Contact Report Flags" type="uint" ver1="20.4.0.0" />
-        <field name="Force Field Material" type="ushort" ver1="20.4.0.0" />
-        <field name="Dummy" type="uint" ver1="20.3.0.1" ver2="20.3.0.5" />
+        <field name="Dominance Group" type="ushort" since="20.4.0.0" />
+        <field name="Contact Report Flags" type="uint" since="20.4.0.0" />
+        <field name="Force Field Material" type="ushort" since="20.4.0.0" />
+        <field name="Dummy" type="uint" since="20.3.0.1" until="20.3.0.5" />
         <field name="Num Shape Descs" type="uint" />
         <field name="Shape Descriptions" type="Ref" template="NiPhysXShapeDesc" arr1="Num Shape Descs" />
         <field name="Actor Parent" type="Ref" template="NiPhysXActorDesc" />
@@ -5593,7 +5593,7 @@
     <compound name="PhysXBodyStoredVels" since="V20_2_0_8">
         <field name="Linear Velocity" type="Vector3" />
         <field name="Angular Velocity" type="Vector3" />
-        <field name="Sleep" type="bool" ver1="30.2.0.3" />
+        <field name="Sleep" type="bool" since="30.2.0.3" />
     </compound>
 
     <niobject name="NiPhysXBodyDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5612,9 +5612,9 @@
         <field name="Sleep Linear Velocity" type="float" default="-1.0" />
         <field name="Sleep Angular Velocity" type="float" default="-1.0" />
         <field name="Solver Iteration Count" type="uint" default="4" />
-        <field name="Sleep Energy Threshold" type="float" default="-1.0" ver1="20.3.0.0" />
-        <field name="Sleep Damping" type="float" ver1="20.3.0.0" />
-        <field name="Contact Report Threshold" type="float" default="#FLT_MAX#" ver1="20.4.0.0" />
+        <field name="Sleep Energy Threshold" type="float" default="-1.0" since="20.3.0.0" />
+        <field name="Sleep Damping" type="float" since="20.3.0.0" />
+        <field name="Contact Report Threshold" type="float" default="#FLT_MAX#" since="20.4.0.0" />
     </niobject>
 
     <enum name="NxJointType" storage="uint" prefix="NX_JOINT" since="V20_2_0_8">
@@ -5671,7 +5671,7 @@
     <compound name="NiPhysXJointLimit" since="V20_2_0_8">
         <field name="Limit Plane Normal" type="Vector3" />
         <field name="Limit Plane D" type="float" />
-        <field name="Limit Plane R" type="float" ver1="20.4.0.0" />
+        <field name="Limit Plane R" type="float" since="20.4.0.0" />
     </compound>
 
     <niobject name="NiPhysXJointDesc" abstract="true" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5681,8 +5681,8 @@
         <field name="Actors" type="NiPhysXJointActor" arr1="2" />
         <field name="Max Force" type="float" />
         <field name="Max Torque" type="float" />
-        <field name="Solver Extrapolation Factor" type="float" ver1="20.5.0.3" />
-        <field name="Use Acceleration Spring" type="uint" ver1="20.5.0.3" />
+        <field name="Solver Extrapolation Factor" type="float" since="20.5.0.3" />
+        <field name="Use Acceleration Spring" type="uint" since="20.5.0.3" />
         <field name="Joint Flags" type="uint" />
         <field name="Limit Point" type="Vector3" />
         <field name="Num Limits" type="uint" />
@@ -5777,7 +5777,7 @@
         <field name="Mass" type="float" default="-1.0" />
         <field name="Skin Width" type="float" default="-1.0" />
         <field name="Shape Name" type="NiFixedString" />
-        <field name="Non Interacting Compartment Types" type="uint" ver1="20.4.0.0" />
+        <field name="Non Interacting Compartment Types" type="uint" since="20.4.0.0" />
         <field name="Collision Bits" type="uint" arr1="4" />
         <field name="Plane" type="NxPlane" cond="Shape Type == 0" />
         <field name="Sphere Radius" type="float" cond="Shape Type == 1" />
@@ -5788,15 +5788,15 @@
 
     <niobject name="NiPhysXMeshDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
         Holds mesh data for streaming.
-        <field name="Is Convex" type="bool" ver2="20.3.0.4" />
+        <field name="Is Convex" type="bool" until="20.3.0.4" />
         <field name="Mesh Name" type="NiFixedString" />
         <field name="Mesh Data" type="ByteArray" />
-        <field name="Back Compat Vertex Map Size" type="ushort" ver1="20.3.0.5" ver2="30.2.0.2" />
-        <field name="Back Compat Vertex Map" type="ushort" arr1="Back Compat Vertex Map Size" ver1="20.3.0.5" ver2="30.2.0.2" />
+        <field name="Back Compat Vertex Map Size" type="ushort" since="20.3.0.5" until="30.2.0.2" />
+        <field name="Back Compat Vertex Map" type="ushort" arr1="Back Compat Vertex Map Size" since="20.3.0.5" until="30.2.0.2" />
         <field name="Mesh Flags" type="uint" />
-        <field name="Mesh Paging Mode" type="uint" ver1="20.3.0.1" />
-        <field name="Is Hardware" type="bool" ver1="20.3.0.2" ver2="20.3.0.4" />
-        <field name="Flags" type="byte" ver1="20.3.0.5" />
+        <field name="Mesh Paging Mode" type="uint" since="20.3.0.1" />
+        <field name="Is Hardware" type="bool" since="20.3.0.2" until="20.3.0.4" />
+        <field name="Flags" type="byte" since="20.3.0.5" />
     </niobject>
 
     <bitflags name="NxMaterialFlag" storage="uint" prefix="NX_MF" since="V20_2_0_8">
@@ -5828,8 +5828,8 @@
         <field name="Flags" type="NxMaterialFlag" />
         <field name="Friction Combine Mode" type="NxCombineMode" />
         <field name="Restitution Combine Mode" type="NxCombineMode" />
-        <field name="Has Spring" type="bool" ver2="20.2.3.0" />
-        <field name="Spring" type="NxSpringDesc" ver2="20.2.3.0" cond="Has Spring" />
+        <field name="Has Spring" type="bool" until="20.2.3.0" />
+        <field name="Spring" type="NxSpringDesc" until="20.2.3.0" cond="Has Spring" />
     </compound>
 
     <niobject name="NiPhysXMaterialDesc" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -5886,43 +5886,43 @@
         For serializing NxClothDesc objects.
         <field name="Name" type="NiFixedString" />
         <field name="Mesh" type="Ref" template="NiPhysXMeshDesc" />
-        <field name="Pose" type="Matrix34" ver2="20.3.0.9" />
+        <field name="Pose" type="Matrix34" until="20.3.0.9" />
         <field name="Thickness" type="float" default="0.01" />
-        <field name="Self Collision Thickness" type="float" ver1="30.1.0.3" />
+        <field name="Self Collision Thickness" type="float" since="30.1.0.3" />
         <field name="Density" type="float" default="1.0" />
         <field name="Bending Stiffness" type="float" default="1.0" />
         <field name="Stretching Stiffness" type="float" default="1.0" />
         <field name="Damping Coefficient" type="float" default="0.5" />
-        <field name="Hard Stretch Limitation Factor" type="float" ver1="30.1.0.3" />
+        <field name="Hard Stretch Limitation Factor" type="float" since="30.1.0.3" />
         <field name="Friction" type="float" default="0.5" />
         <field name="Pressure" type="float" default="1.0" />
         <field name="Tear Factor" type="float" default="1.5" />
         <field name="Collision Response Coeff" type="float" default="0.2" />
         <field name="Attach Response Coeff" type="float" default="0.2" />
         <field name="Attach Tear Factor" type="float" default="1.5" />
-        <field name="To Fluid Response Coeff" type="float" default="1.0" ver1="20.4.0.0" />
-        <field name="From Fluid Response Coeff" type="float" default="1.0" ver1="20.4.0.0" />
-        <field name="Min Adhere Velocity" type="float" default="1.0" ver1="20.4.0.0" />
-        <field name="Relative Grid Spacing" type="float" default="0.25" ver1="20.4.0.0" />
+        <field name="To Fluid Response Coeff" type="float" default="1.0" since="20.4.0.0" />
+        <field name="From Fluid Response Coeff" type="float" default="1.0" since="20.4.0.0" />
+        <field name="Min Adhere Velocity" type="float" default="1.0" since="20.4.0.0" />
+        <field name="Relative Grid Spacing" type="float" default="0.25" since="20.4.0.0" />
         <field name="Solver Iterations" type="uint" default="5" />
-        <field name="Hier Solver Iterations" type="uint" ver1="30.1.0.3" />
+        <field name="Hier Solver Iterations" type="uint" since="30.1.0.3" />
         <field name="External Acceleration" type="Vector3" />
-        <field name="Wind Acceleration" type="Vector3" ver1="20.4.0.0" />
+        <field name="Wind Acceleration" type="Vector3" since="20.4.0.0" />
         <field name="Wake Up Counter" type="float" default="0.4" />
         <field name="Sleep Linear Velocity" type="float" default="-1.0" />
         <field name="Collision Group" type="ushort" />
         <field name="Collision Bits" type="uint" arr1="4" />
-        <field name="Force Field Material" type="ushort" ver1="20.4.0.0" />
+        <field name="Force Field Material" type="ushort" since="20.4.0.0" />
         <field name="Flags" type="NxClothFlag" default="0x20" />
-        <field name="Vertex Map Size" type="ushort" ver1="30.2.0.3" />
-        <field name="Vertex Map" type="ushort" arr1="Vertex Map Size" ver1="30.2.0.3" />
-        <field name="Num States" type="uint" ver1="20.4.0.0" />
-        <field name="States" type="PhysXClothState" arr1="Num States" ver1="20.4.0.0" />
+        <field name="Vertex Map Size" type="ushort" since="30.2.0.3" />
+        <field name="Vertex Map" type="ushort" arr1="Vertex Map Size" since="30.2.0.3" />
+        <field name="Num States" type="uint" since="20.4.0.0" />
+        <field name="States" type="PhysXClothState" arr1="Num States" since="20.4.0.0" />
         <field name="Num Attachments" type="uint" />
         <field name="Attachments" type="PhysXClothAttachment" arr1="Num Attachments" />
         <field name="Parent Actor" type="Ref" template="NiPhysXActorDesc" />
-        <field name="Dest" type="Ref" template="NiPhysXDest" ver2="20.4.0.9" />
-        <field name="Target Mesh" type="Ref" template="NiMesh" ver2="20.5.0.0" />
+        <field name="Dest" type="Ref" template="NiPhysXDest" until="20.4.0.9" />
+        <field name="Target Mesh" type="Ref" template="NiMesh" until="20.5.0.0" />
     </niobject>
 
     <niobject name="NiPhysXDest" abstract="true" inherit="NiObject" module="NiPhysX" since="V20_2_0_8">
@@ -6009,8 +6009,8 @@
     <niobject name="NiRoom" inherit="NiNode" module="NiMain">
         NiRoom objects represent cells in a cell-portal culling system.
         <field name="Num Walls" type="uint" />
-        <field name="Walls" type="Ref" template="NiWall" arr1="Num Walls" ver2="3.3.0.13" />
-        <field name="Wall Planes" type="NiPlane" arr1="Num Walls" ver1="4.0.0.0" />
+        <field name="Walls" type="Ref" template="NiWall" arr1="Num Walls" until="3.3.0.13" />
+        <field name="Wall Planes" type="NiPlane" arr1="Num Walls" since="4.0.0.0" />
         <field name="Num In Portals" type="uint" />
         <field name="In Portals" type="Ptr" template="NiPortal" arr1="Num In Portals">The portals which see into the room.</field>
         <field name="Num Out Portals" type="uint" />
@@ -7181,7 +7181,7 @@
 
     <niobject name="NiMesh" inherit="NiRenderObject" module="NiMesh" since="V20_5_0_0">
         <field name="Primitive Type" type="MeshPrimitiveType">The primitive type of the mesh, such as triangles or lines.</field>
-        <field name="EM Data" type="MeshDataEpicMickey" ver1="20.6.5.0" ver2="20.6.5.0" />
+        <field name="EM Data" type="MeshDataEpicMickey" since="20.6.5.0" until="20.6.5.0" />
         <field name="Num Submeshes" type="ushort">The number of submeshes contained in this mesh.</field>
         <field name="Instancing Enabled" type="bool">Sets whether hardware instancing is being used.</field>
         <field name="Bounding Sphere" type="NiBound">The combined bounding volume of all submeshes.</field>
@@ -7189,8 +7189,8 @@
         <field name="Datastreams" type="DataStreamRef" arr1="Num Datastreams" />
         <field name="Num Modifiers" type="uint" />
         <field name="Modifiers" type="Ref" template="NiMeshModifier" arr1="Num Modifiers" />
-        <field name="Has Extra EM Data" type="bool" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 9" />
-        <field name="Extra EM Data" type="ExtraMeshDataEpicMickey" cond="Has Extra EM Data" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 9" />
+        <field name="Has Extra EM Data" type="bool" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 9" />
+        <field name="Extra EM Data" type="ExtraMeshDataEpicMickey" cond="Has Extra EM Data" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 9" />
     </niobject>
 
     <niobject name="NiMorphWeightsController" inherit="NiInterpController" module="NiAnimation" since="V20_5_0_0">
@@ -7301,18 +7301,18 @@
         <field name="Has Colors" type="bool" />
         <field name="Has Rotations" type="bool" />
         <field name="Has Rotation Axes" type="bool" />
-        <field name="Has Animated Textures" type="bool" ver1="20.6.1.0" />
+        <field name="Has Animated Textures" type="bool" since="20.6.1.0" />
         <field name="World Space" type="bool" default="1" />
-        <field name="Normal Method" type="AlignMethod" default="ALIGN_CAMERA" ver1="20.6.1.0" />
-        <field name="Normal Direction" type="Vector3" ver1="20.6.1.0" />
-        <field name="Up Method" type="AlignMethod" default="ALIGN_CAMERA" ver1="20.6.1.0" />
-        <field name="Up Direction" type="Vector3" ver1="20.6.1.0" />
-        <field name="Living Spawner" type="Ref" template="NiPSSpawner" ver1="20.6.1.0" />
-        <field name="Num Spawn Rate Keys" type="byte" ver1="20.6.1.0" />
-        <field name="Spawn Rate Keys" type="PSSpawnRateKey" arr1="Num Spawn Rate Keys" ver1="20.6.1.0" />
-        <field name="Pre RPI" type="bool" ver1="20.6.1.0" />
-        <field name="DEM Unknown Int" type="uint" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 14" />
-        <field name="DEM Unknown Byte" type="byte" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="Normal Method" type="AlignMethod" default="ALIGN_CAMERA" since="20.6.1.0" />
+        <field name="Normal Direction" type="Vector3" since="20.6.1.0" />
+        <field name="Up Method" type="AlignMethod" default="ALIGN_CAMERA" since="20.6.1.0" />
+        <field name="Up Direction" type="Vector3" since="20.6.1.0" />
+        <field name="Living Spawner" type="Ref" template="NiPSSpawner" since="20.6.1.0" />
+        <field name="Num Spawn Rate Keys" type="byte" since="20.6.1.0" />
+        <field name="Spawn Rate Keys" type="PSSpawnRateKey" arr1="Num Spawn Rate Keys" since="20.6.1.0" />
+        <field name="Pre RPI" type="bool" since="20.6.1.0" />
+        <field name="DEM Unknown Int" type="uint" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
     </niobject>
 
     <niobject name="NiPSMeshParticleSystem" inherit="NiPSParticleSystem" module="NiPSParticle" since="V20_5_0_0">
@@ -7363,7 +7363,7 @@
         Abstract base class for a single step in the particle system simulation process.  It has no seralized data.
     </niobject>
 
-    <enum name="PSLoopBehavior" ver1="20.5.0.0" storage="uint" since="V20_5_0_0">
+    <enum name="PSLoopBehavior" since="20.5.0.0" storage="uint" since="V20_5_0_0">
         <option name="PS_LOOP_CLAMP_BIRTH" value="0">Key times map such that the first key occurs at the birth of the particle, and times later than the last key get the last key value.</option>
         <option name="PS_LOOP_CLAMP_DEATH" value="1">Key times map such that the last key occurs at the death of the particle, and times before the initial key time get the value of the initial key.</option>
         <option name="PS_LOOP_AGESCALE" value="2">Scale the animation to fit the particle lifetime, so that the first key is age zero, and the last key comes at the particle death.</option>
@@ -7373,20 +7373,20 @@
 
     <niobject name="NiPSSimulatorGeneralStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
         Encapsulates a floodgate kernel that updates particle size, colors, and rotations.
-        <field name="Num Size Keys" type="byte" ver1="20.6.1.0" />
-        <field name="Size Keys" type="Key" template="float" arg="1" arr1="Num Size Keys" ver1="20.6.1.0">The particle size keys.</field>
-        <field name="Size Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" ver1="20.6.1.0">The loop behavior for the size keys.</field>
+        <field name="Num Size Keys" type="byte" since="20.6.1.0" />
+        <field name="Size Keys" type="Key" template="float" arg="1" arr1="Num Size Keys" since="20.6.1.0">The particle size keys.</field>
+        <field name="Size Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" since="20.6.1.0">The loop behavior for the size keys.</field>
         <field name="Num Color Keys" type="byte" />
         <field name="Color Keys" type="Key" template="ByteColor4" arg="1" arr1="Num Color Keys">The particle color keys.</field>
-        <field name="Color Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" ver1="20.6.1.0">The loop behavior for the color keys.</field>
-        <field name="Num Rotation Keys" type="byte" ver1="20.6.1.0" />
-        <field name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys" ver1="20.6.1.0">The particle rotation keys.</field>
-        <field name="Rotation Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" ver1="20.6.1.0">The loop behavior for the rotation keys.</field>
+        <field name="Color Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" since="20.6.1.0">The loop behavior for the color keys.</field>
+        <field name="Num Rotation Keys" type="byte" since="20.6.1.0" />
+        <field name="Rotation Keys" type="QuatKey" template="Quaternion" arg="1" arr1="Num Rotation Keys" since="20.6.1.0">The particle rotation keys.</field>
+        <field name="Rotation Loop Behavior" type="PSLoopBehavior" default="PS_LOOP_AGESCALE" since="20.6.1.0">The loop behavior for the rotation keys.</field>
         <field name="Grow Time" type="float"> The the amount of time over which a particle's size is ramped from 0.0 to 1.0 in seconds</field>
         <field name="Shrink Time" type="float">The the amount of time over which a particle's size is ramped from 1.0 to 0.0 in seconds</field>
         <field name="Grow Generation" type="ushort">Specifies the particle generation to which the grow effect should be applied. This is usually generation 0, so that newly created particles will grow.</field>
         <field name="Shrink Generation" type="ushort">Specifies the particle generation to which the shrink effect should be applied. This is usually the highest supported generation for the particle system, so that particles will shrink immediately before getting killed.</field>
-        <field name="DEM Unknown Byte" type="byte" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
     </niobject>
 
     <niobject name="NiPSSimulatorForcesStep" inherit="NiPSSimulatorStep" module="NiPSParticle" since="V20_5_0_0">
@@ -7501,9 +7501,9 @@
 
     <niobject name="NiPSGravityFieldForce" inherit="NiPSFieldForce" module="NiPSParticle" since="V20_5_0_0">
         Inside a field, updates particle velocity to simulate the effects of directional gravity.
-        <field name="DEM Unknown Short" type="ushort" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Short" type="ushort" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
         <field name="Direction" type="Vector3" default="#X_AXIS#" />
-        <field name="DEM Unknown Byte" type="byte" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
     </niobject>
 
     <niobject name="NiPSDragFieldForce" inherit="NiPSFieldForce" module="NiPSParticle" since="V20_5_0_0">
@@ -7534,12 +7534,12 @@
         <field name="Name" type="NiFixedString" />
         <field name="Speed" type="float" />
         <field name="Speed Var" type="float" />
-        <field name="Speed Flip Ratio" type="float" ver1="20.6.1.0" />
+        <field name="Speed Flip Ratio" type="float" since="20.6.1.0" />
         <field name="Declination" type="float" />
         <field name="Declination Var" type="float" />
         <field name="Planar Angle" type="float" />
         <field name="Planar Angle Var" type="float" />
-        <field name="Color" type="ByteColor4" ver2="20.6.0.0" />
+        <field name="Color" type="ByteColor4" until="20.6.0.0" />
         <field name="Size" type="float" />
         <field name="Size Var" type="float" />
         <field name="Lifespan" type="float" />
@@ -7551,12 +7551,12 @@
         <field name="Rotation Axis" type="Vector3" />
         <field name="Random Rot Speed Sign" type="bool" />
         <field name="Random Rot Axis" type="bool" />
-        <field name="Unknown" type="bool" ver1="30.0.0.0" ver2="30.0.0.1" />
+        <field name="Unknown" type="bool" since="30.0.0.0" until="30.0.0.1" />
     </niobject>
 
     <niobject name="NiPSVolumeEmitter" abstract="true" inherit="NiPSEmitter" module="NiPSParticle" since="V20_5_0_0">
         Abstract base class for particle emitters that emit particles from a volume.
-        <field name="DEM Unknown Byte" type="byte" ver1="20.6.5.0" ver2="20.6.5.0" vercond="#USER# #GT# 14" />
+        <field name="DEM Unknown Byte" type="byte" since="20.6.5.0" until="20.6.5.0" vercond="#USER# #GT# 14" />
         <field name="Emitter Object" type="Ptr" template="NiAVObject" />
     </niobject>
 
@@ -7588,8 +7588,8 @@
         Emits particles from one or more NiMesh objects. A random mesh emitter is selected for each particle emission.
         <field name="Num Mesh Emitters" type="uint" />
         <field name="Mesh Emitters" type="Ptr" template="NiMesh" arr1="Num Mesh Emitters" />
-        <field name="Emit Axis" type="Vector3" ver2="20.6.0.0" />
-        <field name="Emitter Object" type="Ptr" template="NiAVObject" ver1="20.6.1.0" />
+        <field name="Emit Axis" type="Vector3" until="20.6.0.0" />
+        <field name="Emitter Object" type="Ptr" template="NiAVObject" since="20.6.1.0" />
         <field name="Mesh Emission Type" type="EmitFrom" />
         <field name="Initial Velocity Type" type="VelocityType" />
     </niobject>
@@ -7734,9 +7734,9 @@
 
     <niobject name="NiPSSpawner" inherit="NiObject" module="NiPSParticle" since="V20_5_0_0">
         Creates a new particle whose initial parameters are based on an existing particle.
-        <field name="Master Particle System" type="Ptr" template="NiPSParticleSystem" ver1="20.6.1.0" />
+        <field name="Master Particle System" type="Ptr" template="NiPSParticleSystem" since="20.6.1.0" />
         <field name="Percentage Spawned" type="float" default="1.0" />
-        <field name="Spawn Speed Factor" type="float" default="1.0" ver1="20.6.1.0" />
+        <field name="Spawn Speed Factor" type="float" default="1.0" since="20.6.1.0" />
         <field name="Spawn Speed Factor Var" type="float" />
         <field name="Spawn Dir Chaos" type="float" />
         <field name="Life Span" type="float" />
@@ -7930,11 +7930,11 @@
         This was not found in any 20.5.0.0 KFs available and they instead use NiControllerSequence directly.
         After 20.5.0.1, Controlled Blocks are no longer used and instead the sequences uses NiEvaluator.
         <field name="Name" type="NiFixedString" />
-        <field name="Num Controlled Blocks" type="uint" ver2="20.5.0.1" />
-        <field name="Array Grow By" type="uint" ver2="20.5.0.1" />
-        <field name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" ver2="20.5.0.1" />
-        <field name="Num Evaluators" type="uint" ver1="20.5.0.2" />
-        <field name="Evaluators" type="Ref" template="NiEvaluator" arr1="Num Evaluators" ver1="20.5.0.2" />
+        <field name="Num Controlled Blocks" type="uint" until="20.5.0.1" />
+        <field name="Array Grow By" type="uint" until="20.5.0.1" />
+        <field name="Controlled Blocks" type="ControlledBlock" arr1="Num Controlled Blocks" until="20.5.0.1" />
+        <field name="Num Evaluators" type="uint" since="20.5.0.2" />
+        <field name="Evaluators" type="Ref" template="NiEvaluator" arr1="Num Evaluators" since="20.5.0.2" />
         <field name="Text Keys" type="Ref" template="NiTextKeyExtraData" />
         <field name="Duration" type="float" />
         <field name="Cycle Type" type="CycleType" />
@@ -7971,9 +7971,9 @@
         <field name="Target" type="Ptr" template="NiDynamicEffect" />
         <field name="Depth Bias" type="float" />
         <field name="Size Hint" type="ushort" default="1024" />
-        <field name="Near Clipping Distance" type="float" ver1="20.3.0.7" />
-        <field name="Far Clipping Distance" type="float" ver1="20.3.0.7" />
-        <field name="Directional Light Frustum Width" type="float" ver1="20.3.0.7" />
+        <field name="Near Clipping Distance" type="float" since="20.3.0.7" />
+        <field name="Far Clipping Distance" type="float" since="20.3.0.7" />
+        <field name="Directional Light Frustum Width" type="float" since="20.3.0.7" />
     </niobject>
 
     <niobject name="NiFurSpringController" inherit="NiTimeController" module="NiCustom" versions="V10_2_0_0__1">

--- a/nif.xml
+++ b/nif.xml
@@ -2048,17 +2048,17 @@
 
     <bitflags name="VertexAttribute" storage="ushort" prefix="VF" versions="#SSE# #FO4# #F76#">
         The bits of BSVertexDesc that describe the enabled vertex attributes.
-        <option bit="1" name="Vertex" />
-        <option bit="2" name="UVs" />
-        <option bit="3" name="UVs_2" />
-        <option bit="4" name="Normals" />
-        <option bit="5" name="Tangents" />
-        <option bit="6" name="Vertex_Colors" />
-        <option bit="7" name="Skinned" />
-        <option bit="8" name="Land_Data" />
-        <option bit="9" name="Eye_Data" />
-        <option bit="10" name="Instance" />
-        <option bit="11" name="Full_Precision" />
+        <option bit="0" name="Vertex" />
+        <option bit="1" name="UVs" />
+        <option bit="2" name="UVs_2" />
+        <option bit="3" name="Normals" />
+        <option bit="4" name="Tangents" />
+        <option bit="5" name="Vertex_Colors" />
+        <option bit="6" name="Skinned" />
+        <option bit="7" name="Land_Data" />
+        <option bit="8" name="Eye_Data" />
+        <option bit="9" name="Instance" />
+        <option bit="10" name="Full_Precision" />
     </bitflags>
 
     <bitfield name="BSVertexDesc" storage="uint64" versions="#SSE# #FO4# #F76#">

--- a/nif.xml
+++ b/nif.xml
@@ -2077,6 +2077,7 @@
     </bitfield>
 
 	<struct name="BSVertexData" versions="#SSE# #FO4# #F76#" module="BSMain">
+        Byte fields for normal, tangent and bitangent map [0, 255] to [-1, 1].
 		<field name="Vertex" type="Vector3" cond="(#ARG# #BITAND# 0x401) == 0x401" />
 		<field name="Bitangent X" type="float" cond="(#ARG# #BITAND# 0x411) == 0x411" />
 		<field name="Unused W" type="uint" cond="(#ARG# #BITAND# 0x411) == 0x401" />
@@ -2207,10 +2208,17 @@
         <field name="Entry Properties" type="FurnitureEntryPoints" vercond="#BS_GT_FO3#" />
     </struct>
 
+    <bitfield name="bhkWeldInfo" storage="ushort">
+        <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
+        <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
+        <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
+        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false" />
+    </bitfield>
+
     <struct name="TriangleData" module="BSHavok" versions="#BETHESDA#">
         Bethesda Havok. A triangle with extra data used for physics.
         <field name="Triangle" type="Triangle">The triangle.</field>
-        <field name="Welding Info" type="ushort">Additional havok information on how triangles are welded.</field>
+        <field name="Welding Info" type="bhkWeldInfo">Additional havok information on how triangles are welded.</field>
         <field name="Normal" type="Vector3" until="20.0.0.5">This is the triangle's normal.</field>
     </struct>
 
@@ -2574,7 +2582,7 @@
         Bethesda extension of hkpCompressedMeshShape::BigTriangle. Triangles that don't fit the maximum size.
         <field name="Triangle" type="Triangle" />
         <field name="Material" type="uint" />
-        <field name="Welding Info" type="ushort" />
+        <field name="Welding Info" type="bhkWeldInfo" />
     </struct>
     
     <struct name="bhkQsTransform" size="32" module="BSHavok" versions="#SKY_AND_LATER#">
@@ -2582,13 +2590,6 @@
         <field name="Translation" type="Vector4">A vector that moves the chunk by the specified amount. W is not used.</field>
         <field name="Rotation" type="hkQuaternion">Rotation. Reference point for rotation is bhkRigidBody translation.</field>
     </struct>
-
-    <bitfield name="bhkWeldInfo" storage="ushort">
-        <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
-        <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
-        <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
-        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false" />
-    </bitfield>
 
     <struct name="bhkCMSChunk" module="BSHavok" versions="#SKY_AND_LATER#">
         Bethesda extension of hkpCompressedMeshShape::Chunk. A compressed chunk of hkpCompressedMeshShape geometry.
@@ -3111,9 +3112,11 @@
     <struct name="hkpMoppCode" module="BSHavok" versions="#BETHESDA#">
         <field name="Data Size" type="uint">Number of bytes for MOPP data.</field>
         <field name="Offset" type="Vector4" since="10.1.0.0">
-            XYZ: Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus 0.1.
+            XYZ: Origin of the object in mopp coordinates. This is the minimum of all vertices in the packed shape along each axis, minus the radius of the child bhkPackedNiTriStripsShape/
+                 bhkCompressedMeshShape.
             W: The scaling factor to quantize the MOPP: the quantization factor is equal to 256*256 divided by this number.
-               In Oblivion files, scale is taken equal to 256*256*254 / (size + 0.2) where size is the largest dimension of the bounding box of the packed shape.
+               In Oblivion and Skyrim files, scale is taken equal to 256*256*254 / (size + 2 * radius) where size is the largest dimension of the bounding box of the packed shape,
+               and radius is the radius of the child bhkPackedNiTriStripsShape/bhkCompressedMeshShape.
         </field>
         <field name="Build Type" type="hkMoppCodeBuildType" vercond="#BS_GT_FO3#">Tells if MOPP Data was organized into smaller chunks (PS3) or not (PC)</field>
         <field name="Data" type="byte" binary="true" length="Data Size">The tree of bounding volume data.</field>

--- a/nif.xml
+++ b/nif.xml
@@ -8117,8 +8117,8 @@
         using the default values.
         Name should be 'INV' (without the quotes).
         For rotations, a short of "4712" appears as "4.712" but "959" appears as "0.959"  meshes\weapons\daedric\daedricbowskinned.nif
-        <field name="Rotation X" type="ushort" default="4712"></field>
-        <field name="Rotation Y" type="ushort" default="6283"></field>
+        <field name="Rotation X" type="ushort" default="0"></field>
+        <field name="Rotation Y" type="ushort" default="0"></field>
         <field name="Rotation Z" type="ushort" default="0"></field>
         <field name="Zoom" type="float" default="1.0">Zoom factor.</field>
     </niobject>

--- a/nif.xml
+++ b/nif.xml
@@ -2603,7 +2603,7 @@
         <field name="Num Strips" type="uint" />
         <field name="Strips" type="ushort" length="Num Strips">Length of strips longer than one triangle.</field>
         <field name="Num Welding Info" type="uint">Generally the same as Num Indices field.</field>
-        <field name="Welding Info" type="ushort" length="Num Welding Info" />
+        <field name="Welding Info" type="bhkWeldInfo" length="Num Welding Info" />
     </struct>
 
     <struct name="bhkMalleableConstraintCInfo" module="BSHavok" versions="#BETHESDA#">

--- a/nifdoc.py
+++ b/nifdoc.py
@@ -32,9 +32,9 @@ import logging
 import argparse
 from shutil import copy2
 
-from tools.nifxml import Compound, Block, Enum, parse_xml, version2number
-from tools.nifxml import TYPES_BLOCK, TYPES_BASIC, TYPES_COMPOUND, TYPES_ENUM, TYPES_FLAG, TYPES_VERSION
-from tools.nifxml import NAMES_BLOCK, NAMES_BASIC, NAMES_COMPOUND, NAMES_ENUM, NAMES_FLAG, NAMES_VERSION
+from tools.nifxml import Struct, Block, Enum, parse_xml, version2number
+from tools.nifxml import TYPES_BLOCK, TYPES_BASIC, TYPES_STRUCT, TYPES_ENUM, TYPES_FLAG, TYPES_VERSION
+from tools.nifxml import NAMES_BLOCK, NAMES_BASIC, NAMES_STRUCT, NAMES_ENUM, NAMES_FLAG, NAMES_VERSION
 
 from tools.nifdoc import nifdoc_tmpl as tmpl
 
@@ -62,7 +62,7 @@ def main():
         return
 
     NAMES_BASIC.sort()
-    NAMES_COMPOUND.sort()
+    NAMES_STRUCT.sort()
     NAMES_BLOCK.sort()
     NAMES_ENUM.sort()
     NAMES_FLAG.sort()
@@ -100,8 +100,8 @@ def main():
     doc = DocGenerator(root_dir + DOC_PATH, heading, metadata, version2number(minver))
     logger.info("Generating NiObject Pages...")
     doc.gen_pages(NAMES_BLOCK, TYPES_BLOCK, tmpl.NIOBJECT if metadata else tmpl.NIOBJECT_NO_META)
-    logger.info("Generating Compound Pages...")
-    doc.gen_pages(NAMES_COMPOUND, TYPES_COMPOUND, tmpl.COMPOUND if metadata else tmpl.COMPOUND_NO_META)
+    logger.info("Generating Struct Pages...")
+    doc.gen_pages(NAMES_STRUCT, TYPES_STRUCT, tmpl.STRUCT if metadata else tmpl.STRUCT_NO_META)
     logger.info("Generating Basic Pages...")
     doc.gen_pages(NAMES_BASIC, TYPES_BASIC, tmpl.BASIC)
     logger.info("Generating Enum Pages...")
@@ -111,7 +111,7 @@ def main():
     logger.info("Generating Index Pages...")
     doc.gen_list_page('Basic Data Types', NAMES_BASIC, TYPES_BASIC, 'basic_list')
     doc.gen_list_page('NIF Object List', NAMES_BLOCK, TYPES_BLOCK, 'niobject_list')
-    doc.gen_list_page('Compound Data Types', NAMES_COMPOUND, TYPES_COMPOUND, 'compound_list')
+    doc.gen_list_page('Struct Data Types', NAMES_STRUCT, TYPES_STRUCT, 'struct_list')
     doc.gen_list_page('Enum Data Types', sorted(enums), enums, 'enum_list')
     doc.gen_list_page('NIF File Format Versions', NAMES_VERSION, TYPES_VERSION, 'version_list', tmpl.VERSION_ROW, 'Versions')
     doc.gen_index()
@@ -128,7 +128,7 @@ class DocGenerator:
         self.attr_row = tmpl.ATTR if metadata else tmpl.ATTR_NO_META
         self.inherit = tmpl.INHERIT_ROW if metadata else tmpl.INHERIT_NO_META
         self.min_ver = min_ver
-        self.blocks = dict(TYPES_BLOCK, **TYPES_COMPOUND)
+        self.blocks = dict(TYPES_BLOCK, **TYPES_STRUCT)
         install_dir = os.path.abspath(path)
         if not os.path.exists(install_dir):
             os.makedirs(install_dir)
@@ -140,11 +140,11 @@ class DocGenerator:
     #
     # Template Helper functions
     #
-    def list_attributes(self, compound):
+    def list_attributes(self, struct):
         """Create Attribute List"""
         attrs = ''
         count = 0
-        for mem in compound.members:
+        for mem in struct.members:
             if self.min_ver and mem.until and mem.until < self.min_ver:
                 continue
             attr_type = tmpl.TYPE_LINK.format(clean(mem.type), mem.type)
@@ -204,7 +204,7 @@ class DocGenerator:
     def member_of(self, name):
         """Create Member Of list"""
         found = ''
-        for b_name in NAMES_BLOCK + NAMES_COMPOUND:
+        for b_name in NAMES_BLOCK + NAMES_STRUCT:
             for bmem in self.blocks[b_name].members:
                 if bmem.type == name:
                     found += tmpl.LI_LINK.format(clean(b_name), b_name)
@@ -250,7 +250,7 @@ class DocGenerator:
             if isinstance(tag, Block):
                 contents['attributes'] = self.list_ancestor_attributes(tag)
                 contents['parent_of'] = self.list_child_blocks(tag)
-            elif isinstance(tag, Compound):
+            elif isinstance(tag, Struct):
                 contents['attributes'] = self.list_attributes(tag)
             elif isinstance(tag, Enum):
                 contents['choices'] = self.list_choices(tag)

--- a/nifdoc.py
+++ b/nifdoc.py
@@ -145,7 +145,7 @@ class DocGenerator:
         attrs = ''
         count = 0
         for mem in compound.members:
-            if self.min_ver and mem.ver2 and mem.ver2 < self.min_ver:
+            if self.min_ver and mem.until and mem.until < self.min_ver:
                 continue
             attr_type = tmpl.TYPE_LINK.format(clean(mem.type), mem.type)
             if mem.template:
@@ -158,8 +158,8 @@ class DocGenerator:
                 'attr_arr2': mem.arr2.lhs,
                 'attr_cond': mem.cond,
                 'attr_desc': mem.description.replace('\n', '<br/>'),
-                'attr_from': mem.orig_ver1,
-                'attr_to': mem.orig_ver2,
+                'attr_from': mem.orig_since,
+                'attr_to': mem.orig_until,
                 'row': 'even' if count % 2 == 0 else 'odd'
             }
             count += 1  # Manually increment because of 'continue' on skipped versioned rows

--- a/nifdoc.py
+++ b/nifdoc.py
@@ -79,7 +79,7 @@ def main():
     parser.add_argument('-no-h1', '--no-heading', action='store_true',
                         help="Whether to not generate the main <h1> heading. Used by NifSkope for built-in help.")
     parser.add_argument('-no-meta', '--no-metadata-columns', action='store_true',
-                        help="Whether to not generate the metadata attribute columns (arg, arr1, arr2, etc.)")
+                        help="Whether to not generate the metadata attribute columns (arg, length, width, etc.)")
     parser.add_argument('-min-ver', '--minimum-version',
                         help="Hides attributes below this version. Format 'XX.X.X.XX'")
     args = parser.parse_args()
@@ -154,8 +154,8 @@ class DocGenerator:
                 'attr_name': mem.name,
                 'attr_type': attr_type,
                 'attr_arg': mem.arg,
-                'attr_arr1': mem.arr1.lhs,
-                'attr_arr2': mem.arr2.lhs,
+                'attr_length': mem.length.lhs,
+                'attr_width': mem.width.lhs,
                 'attr_cond': mem.cond,
                 'attr_desc': mem.description.replace('\n', '<br/>'),
                 'attr_from': mem.orig_since,

--- a/tools/nifdoc/nifdoc_tmpl.py
+++ b/tools/nifdoc/nifdoc_tmpl.py
@@ -48,8 +48,8 @@ ATTR = """
 \t<td class="aname">{attr_name}</td>
 \t<td class="atype">{attr_type}</td>
 \t<td class="aarg">{attr_arg}</td>
-\t<td class="aarr1">{attr_arr1}</td>
-\t<td class="aarr2">{attr_arr2}</td>
+\t<td class="alength">{attr_length}</td>
+\t<td class="awidth">{attr_width}</td>
 \t<td class="acond">{attr_cond}</td>
 \t<td class="adesc">{attr_desc}</td>
 \t<td class="afrom">{attr_from}</td>
@@ -100,8 +100,8 @@ BLOCK = """
 \t\t<th>Name</th>
 \t\t<th>Type</th>
 \t\t<th>Arg</th>
-\t\t<th>Arr1</th>
-\t\t<th>Arr2</th>
+\t\t<th>Length</th>
+\t\t<th>Width</th>
 \t\t<th>Cond</th>
 \t\t<th>Description</th>
 \t\t<th>From</th><th>To</th>

--- a/tools/nifdoc/nifdoc_tmpl.py
+++ b/tools/nifdoc/nifdoc_tmpl.py
@@ -32,7 +32,7 @@ MAIN_BEG = """<!doctype html>
 </head>
 <body>"""
 MAIN_END = """
-\t<p align="center"><a href="index.html">NIF Objects</a> | <a href="compound_list.html">Compound Types</a> 
+\t<p align="center"><a href="index.html">NIF Objects</a> | <a href="struct_list.html">Struct Types</a> 
 \t| <a href="enum_list.html">Enum Types</a> | <a href="basic_list.html">Basic Types</a> | <a href="version_list.html">File Versions</a></p>
 \t{contents}
 </body>
@@ -125,10 +125,10 @@ BLOCK_NM = """
 </table>
 """
 
-# Compound and NiObject with and without metadata columns
-COMPOUND = BLOCK + FOUND_IN
+# Struct and NiObject with and without metadata columns
+STRUCT = BLOCK + FOUND_IN
 NIOBJECT = BLOCK + PARENT_OF
-COMPOUND_NO_META = BLOCK_NM + FOUND_IN
+STRUCT_NO_META = BLOCK_NM + FOUND_IN
 NIOBJECT_NO_META = BLOCK_NM + PARENT_OF
 
 # Object tree for index.html

--- a/tools/nifxml/nifxml.py
+++ b/tools/nifxml/nifxml.py
@@ -611,8 +611,8 @@ class Member:
     @ivar func: The function of this member variable.  Comes from the "func" attribute of the <add> tag.
     @ivar default: The default value of this member variable.  Comes from the "default" attribute of the <add> tag.
         Formatted to be ready to use in a C++ constructor initializer list.
-    @ivar ver1: The first version this member exists.  Comes from the "ver1" attribute of the <add> tag.
-    @ivar ver2: The last version this member exists.  Comes from the "ver2" attribute of the <add> tag.
+    @ivar since: The first version this member exists.  Comes from the "since" attribute of the <add> tag.
+    @ivar until: The last version this member exists.  Comes from the "until" attribute of the <add> tag.
     @ivar userver: The user version where this member exists.  Comes from the "userver" attribute of the <add> tag.
     @ivar userver2: The user version 2 where this member exists.  Comes from the "userver2" attribute of the <add> tag.
     @ivar vercond: The version condition of this member variable.  Comes from the "vercond" attribute of the <add> tag.
@@ -662,10 +662,10 @@ class Member:
         self.cond = Expr(element.getAttribute('cond'))  # type: Expr
         self.func = element.getAttribute('function')  # type: str
         self.default = element.getAttribute('default')  # type: str
-        self.orig_ver1 = element.getAttribute('ver1')  # type: str
-        self.orig_ver2 = element.getAttribute('ver2')  # type: str
-        self.ver1 = version2number(element.getAttribute('ver1'))  # type: int
-        self.ver2 = version2number(element.getAttribute('ver2'))  # type: int
+        self.orig_since = element.getAttribute('since')  # type: str
+        self.orig_until = element.getAttribute('until')  # type: str
+        self.since = version2number(element.getAttribute('since'))  # type: int
+        self.until = version2number(element.getAttribute('until'))  # type: int
         xint = lambda s: int(s) if s else None
         self.userver = xint(element.getAttribute('userver'))  # type: Optional[int]
         self.userver2 = xint(element.getAttribute('userver2'))  # type: Optional[int]


### PR DESCRIPTION
### Changes to spec

#### Default `type` attribute to `onlyT`
For easier parsing, the `type` attribute of the `<default>` tag was changed to `onlyT`. The `type` attribute in default tags means that the associated value only applies when the struct or niobject it's in is that type. The `onlyT` attribute on field tags takes a similar place, meaning the field only exists when the struct or niobject it's in is that type. The change was made to unify this (the type attribute in fields is already used).

#### Addition of the `<verattr>` tag.
The `verattr` tag is introduced to make it easier for codegen to link the attributes of versions to global variables (like those used by the `vercond` attribute). Essentially, it functions like token replacement specifically for attribute names of the version tag. It can also be used to specify priority between the different attributes that define a version number, in order to more robustly define the ordering of version IDs. Example:

```xml
<verattr name="num" access="Version" index="0" />
<verattr name="user" access="User Version" index="1" />
<verattr name="bsver" access="BS Header\BS Version" index="2" />

<version id="V20_2_0_7__11_3" num="20.2.0.7" user="11" bsver="21">Fallout 3, Fallout NV</version>
```

The `name` attribute of the `verattr` tag corresponds to the attribute name in the `version` tag. This should not use any of the predefined attributes (`id`, `supported`, `custom` or `ext`). The `access` attribute defines the 
associated global variable (using the same definitions as the `vercond` attribute). The `index` attribute defines the priority of each `verattr` token. These should start at 0 and each index should only be used once. The lower the index, the more significant the version attribute. So in the example, a version with a higher `num` attribute than another version, is always later than that other version, regardless of any other version attributes.

In the cobra-tools repository some verattr tags also got the `type=` attribute, which was necessary because otherwise there was no way to know if it was a bitfield or not (and hence how to do assignment). The default is interpretation as versions/integers, so in nif.xml it was not necessary.

#### Changes originating from NifSkope dev8
- The `ver1` and `ver2` attributes were renamed to `until` and `since`, respectively. This was already done on most tags, but not yet on `<field>` tags.
- The `<compound>` tag was renamed to `<struct>`.
- The `arr1` and `arr2` attributes were renamed to `length` and `width`, respectively.

### Other NifSkope dev8 changes
- Compounds (now structs) were organized into modules.
- Additions of some new version tokens.
- Addition of stopcond attribute to BSLightingShaderProperty and BSEffectShaderProperty (not sure what this is for or what it is supposed to do).
- Addition of two FO76-specific structs.

### Changes to BSInvMarker
- Changed default values to reflect how they are when the BSInvMarker block is missing (0 for all rotations).\

### Identifications of unknown material values.
I have identified a number of previously unidentified Skyrim Havok Material values. This was done via the following process:
- Give all materials the WPNArrowBounceImpact in the WPNzArrowImpactSet.
- Test suspected unmapped materials in a test nif by shooting at it with a bow.
- If the arrow bounced or stuck, it means that there is an associated material in-game.
- Check which material it is by changing the 'arrows stick' flag on the material. Skip already mapped materials and ones that don't match the observed behaviour. Most were relatively easy by which mesh they appeared in.

Any option that was left unmatched did not have a response. I think these materials are not actually used in-game, or at least not in the traditional way. Some may have some other function (I suspect 1574477864 and 1591009235, since they appear with relative consistency in creature skeletons under the character controller) and some may just be mistakes (I suspect 2290050264, since there are vanilla objects with that like the sabre cat pelt. It simply has no sound when colliding at all).
The value for any given material is obtained via a hash of the lower case material name, using [this hash](https://github.com/Ryan-rsm-McKenzie/bsa/blob/master/src/bsa/fo4.cpp#L143) (also used in Fallout 4 for material and ba2, thank you zilav for pointing that out).
In python this can be easily replicated using the following code:
```python
binascii.crc32(bytes(material_name.lower(), 'utf-8'), 0xFFFFFFFF) ^ 0xFFFFFFFF
```

### Changes to bhkCMSChunk
- Use of UshortVector3 in the Vertices field instead of single values and explanation of how those values are calculated.
- Addition of small doc string to Indices field.
- Addition of small doc string to Strips field.
- Change of "Welding Info" field to better show what is stored there.

A detailed explanation follows below. An example mesh to study would be genkitrmwall01.nif, or farmhous01walkway.nif.
#### Use of UshortVector3 in the Vertices field.
Previously, the vertices field was regarded as one array of ushorts. However, these numbers are actually associated per vertex, like so:

- Vertex0 X
- Vertex0 Y
- Vertex0 Z
- Vertex1 X
- Vertex2 Y
- etc...

This stores the havok coordinates for each vertex. However, they are still ushorts, rather than floats (or hfloats). The values, however, are actually the havok coordinate*1000, giving some measure of precision. Negative coordinates are not needed: the lowest X, Y and Z are alway 0, and the translation entry in the chunk itself gives allows for the final position to be negative.
#### Doc string in indices and strips field
The strips field defines strips of vertices within the indices field. Let an example be the following:
indices field: [7, 4, 6, 5, 15, 11, 14, 10, 17, 16, 6]
strips field: [4, 4]
This defines strips [7, 4, 6, 5] and [15, 11, 14, 10], with the numbers referring to the vertex index in the vertices array. The single-triangle at the end ([17, 16, 6]) is not included in the strips field (there can be multiple of these, each taking three entries).
In the example above, the resulting triangles would be:

- [7, 4, 6], [4, 6, 5]
- [15, 11, 14], [11, 14, 10]
- [17, 16, 6]

Here, even-index triangles (starting from index 0 within every strip) are defined counterclockwise and odd-index triangles are defined clockwise.
#### Changes to welding info field
This is the most difficult to decode, and there are still some mysteries remaining. However, I believe the most important parts are here.

Welding info is always as long as the indices field. This way, one entry in welding info is associated with one entry in the indices field.
Each entry in welding info contains information about the edges of the triangle which is defined by the associated indices entry and the two following entries. This means there are some welding info fields which contain information for non-existing triangles. So in the example above, the welding info would look like this:

- Welding info for triangle [7, 4, 6]
- Welding info for triangle [4, 6, 5]
- Welding info for nonexistent triangle
- Welding info for nonexistent triangle
- Welding info for triangle [15, 11, 14]
- Welding info for triangle [11, 14, 10]
- Welding info for nonexistent triangle
- Welding info for nonexistent triangle
- Welding info for [17, 16, 6]
- Welding info for nonexistent triangle
- Welding info for nonexistent triangle

The welding info for nonexistent triangles is often the same as the indices entry it is associated with, but I think they are entirely inconsequential entries.
The welding info for existent triangles is formatted as follows (expressed in bits):
`0 xxxxx xxxxx xxxxx`
Here, each group of 5 bits contains the exterior angle that an edge of the triangle makes with another triangle, measured as shown below. Edges without an other adjacent triangle are considered to have an angle of 180.
![image](https://user-images.githubusercontent.com/45334438/126079537-f0d1e30c-19f6-41d9-ab6e-34ea1f246c51.png)
_Illustration of how to measure the exterior angle. Blue arrows show the normal facing direction of a triangle_
This mapping of course isn't perfectly smooth, because there are only 5 bits to store this information in. The association of various exterior angles with the decimal representation of the welding info for that edge is shown below, with an included trendline.
![image](https://user-images.githubusercontent.com/45334438/126079517-b52a2894-9d9f-40ce-8d99-f7d6b35461c6.png)
The best approximation that I have found so far for a function that matches exterior angle to the outputted value is as follows :
```python
edge_weld_info = 15 + int((degrees - 180) * 15 / 180)
```
While this function does not _exactly_ match all the data points I have, the uncertainty is, from some experimentation, close enough to be due to precision limits.

The way in which these angles are associated with the edge is as follows:
If the triangle is even-index in the strip (counterclockwise), reverse the vertex indices. Otherwise, leave them as they are.
The weld information is now in the same order as the vertex indices. The weld information for an edge is associated with the vertex that edge goes to.
For a more concrete example:
Let's consider the indices above, looking only at the first strip ([7, 4, 6, 5]). This has two triangles. Let's consider the situation where they make a 270° exterior (90° interior) angle with each other, as shown below, and all the other edges are unconnected or connected at 180° to another triangle, except that edge 5-6 also makes a similar angle with another triangle.
![image](https://user-images.githubusercontent.com/45334438/126080941-5e537cfd-eac8-491b-a42e-0b8d8ec78dac.png)
The following weld information would then be associated with that strip:
- 0 01111 10110 01111 (or 0 15 22 15, i.e. flat, 270°, flat)
- 0 01111 10110 10110 (or 0 15 22 22, i.e. flat, 270°, 270°)
- Weld information for nonexistent triangle (could be ushort(6))
- Weld information for nonexistent triangle (could be ushort(5))

[7, 4, 6] is reversed to become [6, 4, 7], so: [7-6 is flat, 6-4 is 270°, 4-7 is 270°]
And the other triangle remains [4, 6, 5], so [5-4 is flat, 4-6 is 270°, 6-5 is flat]