### PR TITLE
Add Digimon Masters Online

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -207,7 +207,7 @@
     <version id="V20_3_0_2" num="20.3.0.2">Emerge</version>
     <version id="V20_3_0_3" num="20.3.0.3">Emerge</version>
     <version id="V20_3_0_6" num="20.3.0.6">Emerge</version>
-    <version id="V20_3_0_9" num="20.3.0.9" user="0 0x10000" ext="nft item">{{Bully SE}}, {{LEGO Universe}}, Warhammer, Lazeska, Howling Sword, Ragnarok Online 2, Divinity 2 (0x10000)</version>
+    <version id="V20_3_0_9" num="20.3.0.9" user="0 0x10000" ext="nft item">{{Bully SE}}, {{LEGO Universe}}, Warhammer, Lazeska, Howling Sword, Ragnarok Online 2, Divinity 2 (0x10000), Digimon Masters Online</version>
     <version id="V20_3_0_9_DIV2" num="20.3.0.9" user="0x20000 0x30000" ext="item">{{Divinity 2}}</version>
     <version id ="V20_3_1_1" num="20.3.1.1">Fantasy Frontier, Aura Kingdom</version>
     <version id ="V20_3_1_2" num="20.3.1.2">{{Fantasy Frontier}}, {{Aura Kingdom}}</version>
@@ -8470,5 +8470,7 @@
         Fallout 76 Collision Query Proxy Data
         <field name="Binary Data" type="ByteArray" />
     </niobject>
+
+    <niobject name="CsNiNode" inherit="NiNode" />
 
 </niftoolsxml>


### PR DESCRIPTION
Version: Gamebryo 20.3.0.9 (I am not sure if that place is ok because theorically speaking the game should have an unmodified gamebryo)
The maps have a custom node called "CsNiNode" with some binary informations (NiBinaryExtraData) which are out of scope for the specifications.