### PR TITLE
Various updates, mostly for cobra-tools codegen and xml standardization

### DIFF
--- a/nif.xml
+++ b/nif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
-<niftoolsxml version="0.9.3.0">
+<niftoolsxml version="0.10.0.0">
 
     <token name="verexpr" attrs="vercond">
         Commonly used version expressions.

--- a/nif.xml
+++ b/nif.xml
@@ -185,7 +185,7 @@
     <version id="V20_0_0_4" num="20.0.0.4" user="0">{{Civilization IV}}, {{Sid Meier's Railroads}}, Florensia, Ragnarok Online 2, IRIS Online</version>
     <version id="V20_0_0_4__10" num="20.0.0.4" user="10" bsver="11">{{Oblivion KF}}</version>
     <version id="V20_0_0_4__11" num="20.0.0.4" user="11" bsver="11">Oblivion, Fallout 3</version>
-    <version id="V20_0_0_5_OBL" num="20.0.0.5" user="10" bsver="11">{{Oblivion}}</version>
+    <version id="V20_0_0_5_OBL" num="20.0.0.5" user="10 11" bsver="11">{{Oblivion}}</version>
     <version id="V20_1_0_3" num="20.1.0.3">{{Shin Megami Tensei: Imagine}}</version>
     <version id="V20_2_0_7" num="20.2.0.7" user="0">{{Florensia}}, Empire Earth III, Atlantica Online, IRIS Online, Wizard101</version>
     <version id="V20_2_0_7__11_1" num="20.2.0.7" user="11" bsver="14">Fallout 3, Fallout NV</version>

--- a/nif.xml
+++ b/nif.xml
@@ -1419,6 +1419,8 @@
         <option value="3" name="Face Tint" />
         <option value="4" name="Skin Tint" />
         <option value="5" name="Hair Tint" />
+        <option value="12" name="Eye Envmap">Enables EnvMap Mask, Eye EnvMap Scale</option>
+        <option value="17" name="Terrain" />
     </enum>
 
     <enum name="EffectShaderControlledVariable" storage="uint" prefix="ESCV" versions="#SKY_AND_LATER#">
@@ -1942,9 +1944,9 @@
         <field name="BS Version" type="ulittle32" />
         <field name="Author" type="ExportString" />
         <field name="Unknown Int" type="uint" cond="BS Version #GT# 130" />
-        <field name="Process Script" type="ExportString" />
+        <field name="Process Script" type="ExportString"  cond="BS Version #LT# 131" />
         <field name="Export Script" type="ExportString" />
-        <field name="Max Filepath" type="ExportString" cond="BS Version == 130" />
+        <field name="Max Filepath" type="ExportString" cond="BS Version >= 103" />
     </struct>
 
     <!-- Don't use vercond in Header, it breaks niflib -->

--- a/nif.xml
+++ b/nif.xml
@@ -183,7 +183,7 @@
     <version id="V10_3_0_1" num="10.3.0.1" custom="true">WorldShift</version>
     <version id="V10_4_0_1" num="10.4.0.1" custom="true">{{WorldShift}}</version>
     <version id="V20_0_0_4" num="20.0.0.4" user="0">{{Civilization IV}}, {{Sid Meier's Railroads}}, Florensia, Ragnarok Online 2, IRIS Online</version>
-    <version id="V20_0_0_4__10" num="20.0.0.4" user="10" bsver="11">{{Oblivion KF}}</version>
+    <version id="V20_0_0_4__10" num="20.0.0.4" user="10" bsver="11">{{Oblivion KF}}, Oblivion</version>
     <version id="V20_0_0_4__11" num="20.0.0.4" user="11" bsver="11">Oblivion, Fallout 3</version>
     <version id="V20_0_0_5_OBL" num="20.0.0.5" user="10 11" bsver="11">{{Oblivion}}</version>
     <version id="V20_1_0_3" num="20.1.0.3">{{Shin Megami Tensei: Imagine}}</version>
@@ -280,7 +280,7 @@
     </basic>
 
     <basic name="bool" boolean="true" integral="true" countable="false">
-        A boolean; 32-bit from 4.0.0.2, and 8-bit from 4.1.0.1 on.
+        A boolean; 32-bit up to and including 4.0.0.2, 8-bit from 4.1.0.1 on.
     </basic>
 
     <basic name="BlockTypeIndex" integral="true" countable="false" size="2">

--- a/nif.xml
+++ b/nif.xml
@@ -28,84 +28,6 @@
             Note: A unique game name should only have `{{}}` around it once.
     -->
 
-    <verattr name="num" access="#VER#" index="0" />
-    <verattr name="user" access="#USER#" index="1" />
-    <verattr name="bsver" access="#BSVER#" index="2" />
-
-    <version id="V2_3" num="2.3" supported="false">Dark Age of Camelot</version>
-    <version id="V3_0" num="3.0" supported="false">Star Trek: Bridge Commander</version>
-    <version id="V3_03" num="3.03" supported="false">Dark Age of Camelot</version>
-    <version id="V3_1" num="3.1" supported="false">Dark Age of Camelot, Star Trek: Bridge Commander</version>
-    <version id="V3_3_0_13" num="3.3.0.13">{{Munch's Oddysee}}, Oblivion</version>
-    <version id="V4_0_0_0" num="4.0.0.0">Freedom Force</version>
-    <version id="V4_0_0_2" num="4.0.0.2">{{Morrowind}}, {{Freedom Force}}</version>
-    <version id="V4_1_0_12" num="4.1.0.12">Dark Age of Camelot</version>
-    <version id="V4_2_0_2" num="4.2.0.2">Civilization IV</version>
-    <version id="V4_2_1_0" num="4.2.1.0">Dark Age of Camelot, Civilization IV</version>
-    <version id="V4_2_2_0" num="4.2.2.0">{{Culpa Innata}}, Civilization IV, Dark Age of Camelot, Empire Earth II</version>
-    <version id="V10_0_1_0" num="10.0.1.0">{{Zoo Tycoon 2}}, Civilization IV, Oblivion</version>
-    <version id="V10_0_1_2" num="10.0.1.2" bsver="1 3">Oblivion</version>
-    <version id="V10_1_0_0" num="10.1.0.0">{{Freedom Force vs. the 3rd Reich}}, {{Axis and Allies}}, {{Empire Earth II}}, {{Kohan 2}}, {{Sid Meier's Pirates!}}, Dark Age of Camelot, Civilization IV, Wildlife Park 2, The Guild 2, NeoSteam</version>
-    <version id="V10_1_0_101" num="10.1.0.101" user="10" bsver="4">Oblivion</version>
-    <version id="V10_1_0_106" num="10.1.0.106" user="10" bsver="5">Oblivion</version>
-    <version id="V10_2_0_0" num="10.2.0.0" user="0">{{Pro Cycling Manager}}, {{Prison Tycoon}}, {{Red Ocean}}, {{Wildlife Park 2}}, Civilization IV, Loki</version>
-    <version id="V10_2_0_0__1" num="10.2.0.0" user="1">{{Blood Bowl}}</version>
-    <version id="V10_2_0_0__10" num="10.2.0.0" user="10" bsver="6 7 8 9">Oblivion</version>
-    <version id="V10_2_0_1" num="10.2.0.1" custom="true">WorldShift</version>
-    <version id="V10_3_0_1" num="10.3.0.1" custom="true">WorldShift</version>
-    <version id="V10_4_0_1" num="10.4.0.1" custom="true">{{WorldShift}}</version>
-    <version id="V20_0_0_4" num="20.0.0.4" user="0">{{Civilization IV}}, {{Sid Meier's Railroads}}, Florensia, Ragnarok Online 2, IRIS Online</version>
-    <version id="V20_0_0_4__10" num="20.0.0.4" user="10" bsver="11">{{Oblivion KF}}</version>
-    <version id="V20_0_0_4__11" num="20.0.0.4" user="11" bsver="11">Fallout 3</version>
-    <version id="V20_0_0_5_OBL" num="20.0.0.5" user="10" bsver="11">{{Oblivion}}</version>
-    <version id="V20_1_0_3" num="20.1.0.3">{{Shin Megami Tensei: Imagine}}</version>
-    <version id="V20_2_0_7" num="20.2.0.7" user="0">{{Florensia}}, Empire Earth III, Atlantica Online, IRIS Online, Wizard101</version>
-    <version id="V20_2_0_7__11_1" num="20.2.0.7" user="11" bsver="14">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7__11_2" num="20.2.0.7" user="11" bsver="16" ext="rdt">Fallout 3</version>
-    <version id="V20_2_0_7__11_3" num="20.2.0.7" user="11" bsver="21">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7__11_4" num="20.2.0.7" user="11" bsver="24">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7__11_5" num="20.2.0.7" user="11" bsver="25">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7__11_6" num="20.2.0.7" user="11" bsver="26">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7__11_7" num="20.2.0.7" user="11" bsver="27 28">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7__11_8" num="20.2.0.7" user="11" bsver="30 31 32 33">Fallout 3, Fallout NV</version>
-    <version id="V20_2_0_7_FO3" num="20.2.0.7" user="11" bsver="34" ext="rdt">{{Fallout 3}}, {{Fallout NV}}</version>
-    <version id="V20_2_0_7_SKY" num="20.2.0.7" user="12" bsver="83" ext="bto btr">{{Skyrim}}</version>
-    <version id="V20_2_0_7_SSE" num="20.2.0.7" user="12" bsver="100" ext="bto btr">{{Skyrim SE}}</version>
-    <version id="V20_2_0_7_FO4" num="20.2.0.7" user="12" bsver="130" ext="bto btr">{{Fallout 4}}</version>
-    <version id="V20_2_0_7_FO4_2" num="20.2.0.7" user="12" bsver="132 139" ext="bto btr" supported="false">Fallout 4 (LS_Mirelurk.nif, Screen.nif)</version>
-    <version id="V20_2_0_7_F76" num="20.2.0.7" user="12" bsver="155" ext="bto">{{Fallout 76}}</version>
-    <version id="V20_2_0_8" num="20.2.0.8" ext="nifcache">{{Empire Earth III}}, {{FFT Online}}, Atlantica Online, IRIS Online, Wizard101</version>
-    <version id="V20_3_0_1" num="20.3.0.1">Emerge</version>
-    <version id="V20_3_0_2" num="20.3.0.2">Emerge</version>
-    <version id="V20_3_0_3" num="20.3.0.3">Emerge</version>
-    <version id="V20_3_0_6" num="20.3.0.6">Emerge</version>
-    <version id="V20_3_0_9" num="20.3.0.9" user="0 0x10000" ext="nft item">{{Bully SE}}, Warhammer, Lazeska, Howling Sword, Ragnarok Online 2, Divinity 2 (0x10000)</version>
-    <version id="V20_3_0_9_DIV2" num="20.3.0.9" user="0x20000 0x30000" ext="item">{{Divinity 2}}</version>
-    <version id="V20_5_0_0" num="20.5.0.0">MicroVolts, KrazyRain</version>
-    <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101</version>
-    <version id="V20_6_5_0" num="20.6.5.0" supported="false">Epic Mickey</version>
-    <version id="V20_6_5_0_DEM" num="20.6.5.0" user="15" supported="false">Epic Mickey</version>
-    <version id="V20_6_5_0_DEM2" num="20.6.5.0" user="17" supported="false">Epic Mickey 2</version>
-    <version id="V30_0_0_2" num="30.0.0.2">Emerge</version>
-    <version id="V30_1_0_1" num="30.1.0.1">Emerge</version>
-    <version id="V30_1_0_3" num="30.1.0.3">Rocksmith, Rocksmith 2014</version>
-    <version id="V30_2_0_3" num="30.2.0.3">Ghost In The Shell: First Assault, MapleStory 2</version>
-
-    <!-- BSMain = 0x1fff384d000 -->
-    <module name="NiMain" priority="0" />
-    <module name="NiAnimation" priority="25" depends="NiMain" />
-    <module name="NiParticle" priority="50" depends="NiMain NiAnimation" />
-    <module name="NiMesh" priority="70" depends="NiMain NiAnimation" />
-    <module name="NiPSParticle" priority="80" depends="NiMain NiMesh NiAnimation" />
-    <module name="NiPhysX" priority="90" depends="NiMain NiMesh NiPSParticle" />
-    <module name="NiLegacy" priority="99" depends="NiMain NiAnimation NiParticle" />
-    <module name="BSMain" priority="100" depends="NiMain" custom="true" />
-    <module name="BSAnimation" priority="125" depends="NiMain NiAnimation BSMain" custom="true" />
-    <module name="BSParticle" priority="150" depends="NiMain NiParticle BSMain" custom="true" />
-    <module name="BSHavok" priority="190" depends="NiMain BSMain" custom="true" />
-    <module name="BSLegacy" priority="199" depends="NiMain NiLegacy" custom="true" />
-    <module name="NiCustom" priority="255" depends="NiMain NiParticle" custom="true" />
-
     <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         NOTE: `string` should be wrapped in parentheses for string subsitutions in larger expressions.
@@ -137,7 +59,8 @@
     </token>
 
     <token name="condexpr" attrs="cond">
-        <condexpr token="#FLT_MAX#" string="0x7F7FFFFF" />
+        <condexpr token="#FLT_MAX#" string="3.402823466e+38" />
+        <condexpr token="#INF#" string="INFINITY" />
         <condexpr token="#BSSTREAMHEADER#" string="(Version #EQ# 10.0.1.2) #OR# ((Version #EQ# 20.2.0.7) #OR# (Version #EQ# 20.0.0.5) #OR# ((Version #GTE# 10.1.0.0) #AND# (Version #LTE# 20.0.0.4) #AND# (User Version #LTE# 11))) #AND# (User Version #GTE# 3)" />
     </token>
 
@@ -232,6 +155,84 @@
         <operator token="#BITAND#" string="&amp;" />
         <operator token="#BITOR#" string="|" />
     </token>
+
+    <verattr name="num" access="#VER#" index="0" />
+    <verattr name="user" access="#USER#" index="1" />
+    <verattr name="bsver" access="#BSVER#" index="2" />
+
+    <version id="V2_3" num="2.3" supported="false">Dark Age of Camelot</version>
+    <version id="V3_0" num="3.0" supported="false">Star Trek: Bridge Commander</version>
+    <version id="V3_03" num="3.03" supported="false">Dark Age of Camelot</version>
+    <version id="V3_1" num="3.1" supported="false">Dark Age of Camelot, Star Trek: Bridge Commander</version>
+    <version id="V3_3_0_13" num="3.3.0.13">{{Munch's Oddysee}}, Oblivion</version>
+    <version id="V4_0_0_0" num="4.0.0.0">Freedom Force</version>
+    <version id="V4_0_0_2" num="4.0.0.2">{{Morrowind}}, {{Freedom Force}}</version>
+    <version id="V4_1_0_12" num="4.1.0.12">Dark Age of Camelot</version>
+    <version id="V4_2_0_2" num="4.2.0.2">Civilization IV</version>
+    <version id="V4_2_1_0" num="4.2.1.0">Dark Age of Camelot, Civilization IV</version>
+    <version id="V4_2_2_0" num="4.2.2.0">{{Culpa Innata}}, Civilization IV, Dark Age of Camelot, Empire Earth II</version>
+    <version id="V10_0_1_0" num="10.0.1.0">{{Zoo Tycoon 2}}, Civilization IV, Oblivion</version>
+    <version id="V10_0_1_2" num="10.0.1.2" bsver="1 3">Oblivion</version>
+    <version id="V10_1_0_0" num="10.1.0.0">{{Freedom Force vs. the 3rd Reich}}, {{Axis and Allies}}, {{Empire Earth II}}, {{Kohan 2}}, {{Sid Meier's Pirates!}}, Dark Age of Camelot, Civilization IV, Wildlife Park 2, The Guild 2, NeoSteam</version>
+    <version id="V10_1_0_101" num="10.1.0.101" user="10" bsver="4">Oblivion</version>
+    <version id="V10_1_0_106" num="10.1.0.106" user="10" bsver="5">Oblivion</version>
+    <version id="V10_2_0_0" num="10.2.0.0" user="0">{{Pro Cycling Manager}}, {{Prison Tycoon}}, {{Red Ocean}}, {{Wildlife Park 2}}, Civilization IV, Loki</version>
+    <version id="V10_2_0_0__1" num="10.2.0.0" user="1">{{Blood Bowl}}</version>
+    <version id="V10_2_0_0__10" num="10.2.0.0" user="10" bsver="6 7 8 9">Oblivion</version>
+    <version id="V10_2_0_1" num="10.2.0.1" custom="true">WorldShift</version>
+    <version id="V10_3_0_1" num="10.3.0.1" custom="true">WorldShift</version>
+    <version id="V10_4_0_1" num="10.4.0.1" custom="true">{{WorldShift}}</version>
+    <version id="V20_0_0_4" num="20.0.0.4" user="0">{{Civilization IV}}, {{Sid Meier's Railroads}}, Florensia, Ragnarok Online 2, IRIS Online</version>
+    <version id="V20_0_0_4__10" num="20.0.0.4" user="10" bsver="11">{{Oblivion KF}}</version>
+    <version id="V20_0_0_4__11" num="20.0.0.4" user="11" bsver="11">Fallout 3</version>
+    <version id="V20_0_0_5_OBL" num="20.0.0.5" user="10" bsver="11">{{Oblivion}}</version>
+    <version id="V20_1_0_3" num="20.1.0.3">{{Shin Megami Tensei: Imagine}}</version>
+    <version id="V20_2_0_7" num="20.2.0.7" user="0">{{Florensia}}, Empire Earth III, Atlantica Online, IRIS Online, Wizard101</version>
+    <version id="V20_2_0_7__11_1" num="20.2.0.7" user="11" bsver="14">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7__11_2" num="20.2.0.7" user="11" bsver="16" ext="rdt">Fallout 3</version>
+    <version id="V20_2_0_7__11_3" num="20.2.0.7" user="11" bsver="21">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7__11_4" num="20.2.0.7" user="11" bsver="24">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7__11_5" num="20.2.0.7" user="11" bsver="25">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7__11_6" num="20.2.0.7" user="11" bsver="26">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7__11_7" num="20.2.0.7" user="11" bsver="27 28">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7__11_8" num="20.2.0.7" user="11" bsver="30 31 32 33">Fallout 3, Fallout NV</version>
+    <version id="V20_2_0_7_FO3" num="20.2.0.7" user="11" bsver="34" ext="rdt">{{Fallout 3}}, {{Fallout NV}}</version>
+    <version id="V20_2_0_7_SKY" num="20.2.0.7" user="12" bsver="83" ext="bto btr">{{Skyrim}}</version>
+    <version id="V20_2_0_7_SSE" num="20.2.0.7" user="12" bsver="100" ext="bto btr">{{Skyrim SE}}</version>
+    <version id="V20_2_0_7_FO4" num="20.2.0.7" user="12" bsver="130" ext="bto btr">{{Fallout 4}}</version>
+    <version id="V20_2_0_7_FO4_2" num="20.2.0.7" user="12" bsver="132 139" ext="bto btr" supported="false">Fallout 4 (LS_Mirelurk.nif, Screen.nif)</version>
+    <version id="V20_2_0_7_F76" num="20.2.0.7" user="12" bsver="155" ext="bto">{{Fallout 76}}</version>
+    <version id="V20_2_0_8" num="20.2.0.8" ext="nifcache">{{Empire Earth III}}, {{FFT Online}}, Atlantica Online, IRIS Online, Wizard101</version>
+    <version id="V20_3_0_1" num="20.3.0.1">Emerge</version>
+    <version id="V20_3_0_2" num="20.3.0.2">Emerge</version>
+    <version id="V20_3_0_3" num="20.3.0.3">Emerge</version>
+    <version id="V20_3_0_6" num="20.3.0.6">Emerge</version>
+    <version id="V20_3_0_9" num="20.3.0.9" user="0 0x10000" ext="nft item">{{Bully SE}}, Warhammer, Lazeska, Howling Sword, Ragnarok Online 2, Divinity 2 (0x10000)</version>
+    <version id="V20_3_0_9_DIV2" num="20.3.0.9" user="0x20000 0x30000" ext="item">{{Divinity 2}}</version>
+    <version id="V20_5_0_0" num="20.5.0.0">MicroVolts, KrazyRain</version>
+    <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101</version>
+    <version id="V20_6_5_0" num="20.6.5.0" supported="false">Epic Mickey</version>
+    <version id="V20_6_5_0_DEM" num="20.6.5.0" user="15" supported="false">Epic Mickey</version>
+    <version id="V20_6_5_0_DEM2" num="20.6.5.0" user="17" supported="false">Epic Mickey 2</version>
+    <version id="V30_0_0_2" num="30.0.0.2">Emerge</version>
+    <version id="V30_1_0_1" num="30.1.0.1">Emerge</version>
+    <version id="V30_1_0_3" num="30.1.0.3">Rocksmith, Rocksmith 2014</version>
+    <version id="V30_2_0_3" num="30.2.0.3">Ghost In The Shell: First Assault, MapleStory 2</version>
+
+    <!-- BSMain = 0x1fff384d000 -->
+    <module name="NiMain" priority="0" />
+    <module name="NiAnimation" priority="25" depends="NiMain" />
+    <module name="NiParticle" priority="50" depends="NiMain NiAnimation" />
+    <module name="NiMesh" priority="70" depends="NiMain NiAnimation" />
+    <module name="NiPSParticle" priority="80" depends="NiMain NiMesh NiAnimation" />
+    <module name="NiPhysX" priority="90" depends="NiMain NiMesh NiPSParticle" />
+    <module name="NiLegacy" priority="99" depends="NiMain NiAnimation NiParticle" />
+    <module name="BSMain" priority="100" depends="NiMain" custom="true" />
+    <module name="BSAnimation" priority="125" depends="NiMain NiAnimation BSMain" custom="true" />
+    <module name="BSParticle" priority="150" depends="NiMain NiParticle BSMain" custom="true" />
+    <module name="BSHavok" priority="190" depends="NiMain BSMain" custom="true" />
+    <module name="BSLegacy" priority="199" depends="NiMain NiLegacy" custom="true" />
+    <module name="NiCustom" priority="255" depends="NiMain NiParticle" custom="true" />
 
     <!--Basic Types-->
 
@@ -2028,7 +2029,7 @@
         <field name="PS2 K" type="short" default="-75" until="10.4.0.1">K is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.</field>
         <field name="Unknown Short 1" type="ushort" until="4.1.0.12" />
         <!-- NiTextureTransform -->
-        <field name="Has Texture Transform" type="bool" default="false" since="10.1.0.0">Whether or not the texture coordinates are transformed.</field>
+        <field name="Has Texture Transform" type="bool" default="0" since="10.1.0.0">Whether or not the texture coordinates are transformed.</field>
         <field name="Translation" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0">The UV translation.</field>
         <field name="Scale" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0" default="#VEC2_ONE#">The UV scale.</field>
         <field name="Rotation" type="float" default="0.0" cond="Has Texture Transform" since="10.1.0.0">The W axis rotation in texture space.</field>
@@ -2216,7 +2217,7 @@
         <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
         <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
         <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
-        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false" />
+        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="0" />
     </bitfield>
 
     <struct name="TriangleData" module="BSHavok" versions="#BETHESDA#">
@@ -4197,7 +4198,7 @@
         <field name="Play Backwards" type="bool" since="10.1.0.106" until="10.1.0.106" />
         <field name="Manager" type="Ptr" template="NiControllerManager" since="10.1.0.106">The owner of this sequence.</field>
         <field name="Accum Root Name" type="string" since="10.1.0.106">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
-        <field name="Accum Flags" type="AccumFlags" default="ACCUM_X_FRONT" since="20.3.0.8" />
+        <field name="Accum Flags" type="AccumFlags" default="0x40" since="20.3.0.8" />
         <field name="String Palette" type="Ref" template="NiStringPalette" since="10.1.0.113" until="20.1.0.0" />
         <field name="Anim Notes" type="Ref" template="BSAnimNotes" since="20.2.0.7" vercond="(#BSVER# #GTE# 24) #AND# (#BSVER# #LTE# 28)" />
         <field name="Num Anim Note Arrays" type="ushort" since="20.2.0.7" vercond="#BSVER# #GT# 28" />
@@ -6579,7 +6580,7 @@
         <field name="Lighting Effect 2" type="float" default="2.0" range="#F0_1000#" vercond="#NI_BS_LT_FO4#">Controls strength for envmap/backlight/rim/softlight lighting effect?</field>
         <field name="Subsurface Rolloff" type="float" default="0.0" range="#F0_10#" vercond="#BS_FO4_2#" />
         <field name="Rimlight Power" type="float" default="#FLT_MAX#" vercond="#BS_FO4_2#" />
-        <field name="Backlight Power" type="float" range="#F0_1000#" cond="Rimlight Power == #FLT_MAX#" vercond="#BS_FO4_2#" />
+        <field name="Backlight Power" type="float" range="#F0_1000#" cond="(Rimlight Power #GTE# #FLT_MAX#) #AND# (Rimlight Power #LT# #INF#)" vercond="#BS_FO4_2#" />
         <field name="Grayscale to Palette Scale" type="float" default="1.0" range="#F0_1#" vercond="#BS_GTE_130#" />
         <field name="Fresnel Power" type="float" default="5.0" range="#F_PNZ#" vercond="#BS_GTE_130#" />
         <field name="Wetness" type="BSSPWetnessParams" vercond="#BS_GTE_130#" />
@@ -8016,7 +8017,7 @@
         <field name="Cycle Type" type="CycleType" />
         <field name="Frequency" type="float" default="1.0" />
         <field name="Accum Root Name" type="NiFixedString">The name of the NiAVObject serving as the accumulation root. This is where all accumulated translations, scales, and rotations are applied.</field>
-        <field name="Accum Flags" type="AccumFlags" default="ACCUM_X_FRONT" />
+        <field name="Accum Flags" type="AccumFlags" default="0x40" />
     </niobject>
 
     <bitflags name="NiShadowGeneratorFlags" storage="ushort">

--- a/nif.xml
+++ b/nif.xml
@@ -271,6 +271,10 @@
         An 8-bit character.
     </basic>
 
+    <basic name="sbyte" integral="true" countable="false" size="1" convertible="short int int64">
+        A signed 8-bit integer.
+    </basic>
+
     <basic name="byte" boolean="true" integral="true" countable="true" size="1" convertible="ushort uint uint64">
         An unsigned 8-bit integer.
     </basic>
@@ -2532,7 +2536,7 @@
         <field name="Sphere" type="NiBound" cond="Collision Type == 0" />
         <field name="Box" type="BoxBV" cond="Collision Type == 1" />
         <field name="Capsule" type="CapsuleBV" cond="Collision Type == 2" />
-        <!--<field name="Union BV" type="UnionBV" cond="Collision Type == 4" />-->
+        <field name="Union BV" type="UnionBV" cond="Collision Type == 4" recursive="True" />
         <field name="Half Space" type="HalfSpaceBV" cond="Collision Type == 5" />
     </struct>
 
@@ -3299,8 +3303,8 @@
         <!-- Flags conds -->
         <field name="Interp Count" type="byte" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <field name="Single Index" type="byte" default="#BYTE_MAX#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
-        <field name="High Priority" type="char" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
-        <field name="Next High Priority" type="char" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="High Priority" type="sbyte" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
+        <field name="Next High Priority" type="sbyte" default="#CHAR_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <field name="Single Time" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <field name="High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
         <field name="Next High Weights Sum" type="float" default="#FLT_MIN#" cond="!(Flags #BITAND# 1)" since="10.1.0.112" />
@@ -3319,8 +3323,8 @@
         <field name="Single Time" type="float" default="#FLT_MIN#" since="10.1.0.108" until="10.1.0.111" />
         <field name="High Priority" type="int" default="#INT_MIN#" until="10.1.0.109" />
         <field name="Next High Priority" type="int" default="#INT_MIN#" until="10.1.0.109" />
-        <field name="High Priority" type="char" default="#CHAR_MIN#" since="10.1.0.110" until="10.1.0.111" />
-        <field name="Next High Priority" type="char" default="#CHAR_MIN#" since="10.1.0.110" until="10.1.0.111" />
+        <field name="High Priority" type="sbyte" default="#CHAR_MIN#" since="10.1.0.110" until="10.1.0.111" />
+        <field name="Next High Priority" type="sbyte" default="#CHAR_MIN#" since="10.1.0.110" until="10.1.0.111" />
     </niobject>
 
     <niobject name="NiBSplineInterpolator" abstract="true" inherit="NiInterpolator" module="NiAnimation">
@@ -7153,8 +7157,8 @@
         <option bit="6" name="CPU Write Static Inititialized"></option>
     </bitflags>
 
-    <struct name="DataStreamData" generic="true" module="NiMesh" since="V20_5_0_0">
-        <field name="Data" type="byte" binary="true" length="#ARG#">The data stream as binary (fallback if interpretation with template is not implemented).</field>
+    <struct name="DataStreamData" args="2" module="NiMesh" since="V20_5_0_0">
+        <field name="Data" type="byte" binary="true" length="#ARG1#">The data stream as binary (fallback if interpretation with template is not implemented).</field>
     </struct>
 
     <niobject name="NiDataStream" inherit="NiObject" module="NiMesh" since="V20_5_0_0">
@@ -7166,7 +7170,7 @@
         <field name="Regions" type="Region" length="Num Regions">The regions in the mesh. Regions can be used to mark off submeshes which are independent draw calls.</field>
         <field name="Num Components" type="uint">Number of components of the data (matches corresponding field in MeshData).</field>
         <field name="Component Formats" type="ComponentFormat" length="Num Components">The format of each component in this data stream.</field>
-        <field name="Data" type="DataStreamData" arg="Num Bytes" template="Component Formats" />
+        <field name="Data" type="DataStreamData" arg1="Num Bytes" arg2="Component Formats" />
         <field name="Streamable" type="bool" default="1" />
     </niobject>
 
@@ -7248,7 +7252,7 @@
     </struct>
 
     <struct name="ExtraMeshDataEpicMickey" module="NiMesh" versions="V20_6_5_0_DEM">
-        <field name="Unknown 1" type="uint" />
+        <field name="Has Weights" type="uint" >1 if it has weights, 0 otherwise.</field>
         <field name="Num Transform Floats" type="uint" >Total number of floats in the bone transform matrices - divide by 16 to get the number of matrices.</field>
         <field name="Bone Transforms" type="Matrix44" length="Num Transform Floats #DIV# 16" >Transform matrices corresponding to the bones. Note: Stored transposed to normally.</field>
         <field name="Num Weights" type="uint" />

--- a/nif.xml
+++ b/nif.xml
@@ -7063,73 +7063,79 @@
         <option value="2" name="CLONING_BLANK_COPY">Create a copy of this object for use with the newly cloned stream, leaving some of the data to be written later.</option>
     </enum>
 
-    <enum name="ComponentFormat" storage="uint" since="V20_5_0_0">
+    <enum name="ComponentType" storage="byte" since="V20_5_0_0">
         The data format of components.
-        <option value="0x00000000" name="F_UNKNOWN">Unknown, or don't care, format.</option>
-        <option value="0x00010101" name="F_INT8_1"></option>
-        <option value="0x00020102" name="F_INT8_2"></option>
-        <option value="0x00030103" name="F_INT8_3"></option>
-        <option value="0x00040104" name="F_INT8_4"></option>
-        <option value="0x00010105" name="F_UINT8_1"></option>
-        <option value="0x00020106" name="F_UINT8_2"></option>
-        <option value="0x00030107" name="F_UINT8_3"></option>
-        <option value="0x00040108" name="F_UINT8_4"></option>
-        <option value="0x00010109" name="F_NORMINT8_1"></option>
-        <option value="0x0002010A" name="F_NORMINT8_2"></option>
-        <option value="0x0003010B" name="F_NORMINT8_3"></option>
-        <option value="0x0004010C" name="F_NORMINT8_4"></option>
-        <option value="0x0001010D" name="F_NORMUINT8_1"></option>
-        <option value="0x0002010E" name="F_NORMUINT8_2"></option>
-        <option value="0x0003010F" name="F_NORMUINT8_3"></option>
-        <option value="0x00040110" name="F_NORMUINT8_4"></option>
-        <option value="0x00010211" name="F_INT16_1"></option>
-        <option value="0x00020212" name="F_INT16_2"></option>
-        <option value="0x00030213" name="F_INT16_3"></option>
-        <option value="0x00040214" name="F_INT16_4"></option>
-        <option value="0x00010215" name="F_UINT16_1"></option>
-        <option value="0x00020216" name="F_UINT16_2"></option>
-        <option value="0x00030217" name="F_UINT16_3"></option>
-        <option value="0x00040218" name="F_UINT16_4"></option>
-        <option value="0x00010219" name="F_NORMINT16_1"></option>
-        <option value="0x0002021A" name="F_NORMINT16_2"></option>
-        <option value="0x0003021B" name="F_NORMINT16_3"></option>
-        <option value="0x0004021C" name="F_NORMINT16_4"></option>
-        <option value="0x0001021D" name="F_NORMUINT16_1"></option>
-        <option value="0x0002021E" name="F_NORMUINT16_2"></option>
-        <option value="0x0003021F" name="F_NORMUINT16_3"></option>
-        <option value="0x00040220" name="F_NORMUINT16_4"></option>
-        <option value="0x00010421" name="F_INT32_1"></option>
-        <option value="0x00020422" name="F_INT32_2"></option>
-        <option value="0x00030423" name="F_INT32_3"></option>
-        <option value="0x00040424" name="F_INT32_4"></option>
-        <option value="0x00010425" name="F_UINT32_1"></option>
-        <option value="0x00020426" name="F_UINT32_2"></option>
-        <option value="0x00030427" name="F_UINT32_3"></option>
-        <option value="0x00040428" name="F_UINT32_4"></option>
-        <option value="0x00010429" name="F_NORMINT32_1"></option>
-        <option value="0x0002042A" name="F_NORMINT32_2"></option>
-        <option value="0x0003042B" name="F_NORMINT32_3"></option>
-        <option value="0x0004042C" name="F_NORMINT32_4"></option>
-        <option value="0x0001042D" name="F_NORMUINT32_1"></option>
-        <option value="0x0002042E" name="F_NORMUINT32_2"></option>
-        <option value="0x0003042F" name="F_NORMUINT32_3"></option>
-        <option value="0x00040430" name="F_NORMUINT32_4"></option>
-        <option value="0x00010231" name="F_FLOAT16_1"></option>
-        <option value="0x00020232" name="F_FLOAT16_2"></option>
-        <option value="0x00030233" name="F_FLOAT16_3"></option>
-        <option value="0x00040234" name="F_FLOAT16_4"></option>
-        <option value="0x00010435" name="F_FLOAT32_1"></option>
-        <option value="0x00020436" name="F_FLOAT32_2"></option>
-        <option value="0x00030437" name="F_FLOAT32_3"></option>
-        <option value="0x00040438" name="F_FLOAT32_4"></option>
-        <option value="0x00010439" name="F_UINT_10_10_10_L1"></option>
-        <option value="0x0001043A" name="F_NORMINT_10_10_10_L1"></option>
-        <option value="0x0001043B" name="F_NORMINT_11_11_10"></option>
-        <option value="0x0004013C" name="F_NORMUINT8_4_BGRA"></option>
-        <option value="0x0001043D" name="F_NORMINT_10_10_10_2"></option>
-        <option value="0x0001043E" name="F_UINT_10_10_10_2"></option>
-        <option value="0x00020240" name="F_UNKNOWN_20240"></option>
+        <option value="0x00" name="F_UNKNOWN">Unknown, or don't care, format.</option>
+        <option value="0x01" name="F_INT8_1"></option>
+        <option value="0x02" name="F_INT8_2"></option>
+        <option value="0x03" name="F_INT8_3"></option>
+        <option value="0x04" name="F_INT8_4"></option>
+        <option value="0x05" name="F_UINT8_1"></option>
+        <option value="0x06" name="F_UINT8_2"></option>
+        <option value="0x07" name="F_UINT8_3"></option>
+        <option value="0x08" name="F_UINT8_4"></option>
+        <option value="0x09" name="F_NORMINT8_1"></option>
+        <option value="0x0A" name="F_NORMINT8_2"></option>
+        <option value="0x0B" name="F_NORMINT8_3"></option>
+        <option value="0x0C" name="F_NORMINT8_4"></option>
+        <option value="0x0D" name="F_NORMUINT8_1"></option>
+        <option value="0x0E" name="F_NORMUINT8_2"></option>
+        <option value="0x0F" name="F_NORMUINT8_3"></option>
+        <option value="0x10" name="F_NORMUINT8_4"></option>
+        <option value="0x11" name="F_INT16_1"></option>
+        <option value="0x12" name="F_INT16_2"></option>
+        <option value="0x13" name="F_INT16_3"></option>
+        <option value="0x14" name="F_INT16_4"></option>
+        <option value="0x15" name="F_UINT16_1"></option>
+        <option value="0x16" name="F_UINT16_2"></option>
+        <option value="0x17" name="F_UINT16_3"></option>
+        <option value="0x18" name="F_UINT16_4"></option>
+        <option value="0x19" name="F_NORMINT16_1"></option>
+        <option value="0x1A" name="F_NORMINT16_2"></option>
+        <option value="0x1B" name="F_NORMINT16_3"></option>
+        <option value="0x1C" name="F_NORMINT16_4"></option>
+        <option value="0x1D" name="F_NORMUINT16_1"></option>
+        <option value="0x1E" name="F_NORMUINT16_2"></option>
+        <option value="0x1F" name="F_NORMUINT16_3"></option>
+        <option value="0x20" name="F_NORMUINT16_4"></option>
+        <option value="0x21" name="F_INT32_1"></option>
+        <option value="0x22" name="F_INT32_2"></option>
+        <option value="0x23" name="F_INT32_3"></option>
+        <option value="0x24" name="F_INT32_4"></option>
+        <option value="0x25" name="F_UINT32_1"></option>
+        <option value="0x26" name="F_UINT32_2"></option>
+        <option value="0x27" name="F_UINT32_3"></option>
+        <option value="0x28" name="F_UINT32_4"></option>
+        <option value="0x29" name="F_NORMINT32_1"></option>
+        <option value="0x2A" name="F_NORMINT32_2"></option>
+        <option value="0x2B" name="F_NORMINT32_3"></option>
+        <option value="0x2C" name="F_NORMINT32_4"></option>
+        <option value="0x2D" name="F_NORMUINT32_1"></option>
+        <option value="0x2E" name="F_NORMUINT32_2"></option>
+        <option value="0x2F" name="F_NORMUINT32_3"></option>
+        <option value="0x30" name="F_NORMUINT32_4"></option>
+        <option value="0x31" name="F_FLOAT16_1"></option>
+        <option value="0x32" name="F_FLOAT16_2"></option>
+        <option value="0x33" name="F_FLOAT16_3"></option>
+        <option value="0x34" name="F_FLOAT16_4"></option>
+        <option value="0x35" name="F_FLOAT32_1"></option>
+        <option value="0x36" name="F_FLOAT32_2"></option>
+        <option value="0x37" name="F_FLOAT32_3"></option>
+        <option value="0x38" name="F_FLOAT32_4"></option>
+        <option value="0x39" name="F_UINT_10_10_10_L1"></option>
+        <option value="0x3A" name="F_NORMINT_10_10_10_L1"></option>
+        <option value="0x3B" name="F_NORMINT_11_11_10"></option>
+        <option value="0x3C" name="F_NORMUINT8_4_BGRA"></option>
+        <option value="0x3D" name="F_NORMINT_10_10_10_2"></option>
+        <option value="0x3E" name="F_UINT_10_10_10_2"></option>
+        <option value="0x40" name="F_UNKNOWN_20240"></option>
     </enum>
+
+    <bitfield name="ComponentFormat" storage="uint" since="V20_5_0_0">
+        <member width="8" pos="0" mask="0xFF" name="Type" type="ComponentType"></member>
+        <member width="8" pos="8" mask="0xFF00" name="Element Width" type="byte"></member>
+        <member width="8" pos="16" mask="0xFF0000" name="Num Elements" type="byte"></member>
+    </bitfield>
 
     <enum name="DataStreamUsage" storage="uint" since="V20_5_0_0">
         Determines how a data stream is used?
@@ -7150,6 +7156,10 @@
         <option bit="6" name="CPU Write Static Inititialized"></option>
     </bitflags>
 
+    <struct name="DataStreamData" generic="true" module="NiMesh" since="V20_5_0_0">
+        <field name="Data" type="byte" binary="true" length="#ARG#">The data stream as binary (fallback if interpretation with template is not implemented).</field>
+    </struct>
+
 
     <niobject name="NiDataStream" inherit="NiObject" module="NiMesh" since="V20_5_0_0">
         <field name="Usage" type="DataStreamUsage" abstract="true"></field>
@@ -7160,7 +7170,7 @@
         <field name="Regions" type="Region" length="Num Regions">The regions in the mesh. Regions can be used to mark off submeshes which are independent draw calls.</field>
         <field name="Num Components" type="uint">Number of components of the data (matches corresponding field in MeshData).</field>
         <field name="Component Formats" type="ComponentFormat" length="Num Components">The format of each component in this data stream.</field>
-        <field name="Data" type="byte" binary="true" length="Num Bytes" />
+        <field name="Data" type="DataStreamData" arg="Num Bytes" template="Component Formats"/>
         <field name="Streamable" type="bool" default="1" />
     </niobject>
 

--- a/nif.xml
+++ b/nif.xml
@@ -2051,7 +2051,7 @@
         <field name="PS2 K" type="short" default="-75" until="10.4.0.1">K is used as an offset into the mipmap levels and can range from -2047 to 2047. Positive values push the mipmap towards being blurry and negative values make the mipmap sharper.</field>
         <field name="Unknown Short 1" type="ushort" until="4.1.0.12" />
         <!-- NiTextureTransform -->
-        <field name="Has Texture Transform" type="bool" default="0" since="10.1.0.0">Whether or not the texture coordinates are transformed.</field>
+        <field name="Has Texture Transform" type="bool" default="false" since="10.1.0.0">Whether or not the texture coordinates are transformed.</field>
         <field name="Translation" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0">The UV translation.</field>
         <field name="Scale" type="TexCoord" cond="Has Texture Transform" since="10.1.0.0" default="#VEC2_ONE#">The UV scale.</field>
         <field name="Rotation" type="float" default="0.0" cond="Has Texture Transform" since="10.1.0.0">The W axis rotation in texture space.</field>
@@ -2239,7 +2239,7 @@
         <member width="5" pos="0" mask="0x001F" name="Angle Edge 1" type="ushort" default="15"/>
         <member width="5" pos="5" mask="0x03E0" name="Angle Edge 2" type="ushort" default="15" />
         <member width="5" pos="10" mask="0x7C00" name="Angle Edge 3" type="ushort" default="15" />
-        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="0" />
+        <member width="1" pos="15" mask="0x8000" name="Unused bit" type="bool" default="false" />
     </bitfield>
 
     <struct name="TriangleData" module="BSHavok" versions="#BETHESDA#">

--- a/nif.xml
+++ b/nif.xml
@@ -209,6 +209,8 @@
     <version id="V20_3_0_6" num="20.3.0.6">Emerge</version>
     <version id="V20_3_0_9" num="20.3.0.9" user="0 0x10000" ext="nft item">{{Bully SE}}, Warhammer, Lazeska, Howling Sword, Ragnarok Online 2, Divinity 2 (0x10000)</version>
     <version id="V20_3_0_9_DIV2" num="20.3.0.9" user="0x20000 0x30000" ext="item">{{Divinity 2}}</version>
+    <version id ="V20_3_1_1" num="20.3.1.1">Fantasy Frontier, Aura Kingdom</version>
+    <version id ="V20_3_1_2" num="20.3.1.2">{{Fantasy Frontier}}, {{Aura Kingdom}}</version>
     <version id="V20_5_0_0" num="20.5.0.0">MicroVolts, KrazyRain</version>
     <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101</version>
     <version id="V20_6_5_0" num="20.6.5.0" supported="false">Epic Mickey</version>

--- a/nif.xml
+++ b/nif.xml
@@ -1,32 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE niftoolsxml>
 <niftoolsxml version="0.9.3.0">
-    <!-- The versions found in use by the engine which have any amount of decoding or support from nif.xml
-            NOTE: Hypothetical versions such as those used in version conditions must NOT receive version tags.
-
-        id = "VX_X_X_X": The unique identifier for this version. Can be used to generate C-style enums, etc.
-        num = "X.X.X.X": The numeric representation created by storing each part of the version in a byte.
-            Example:  4.0.0.2 == 0x04000002
-                     10.1.0.0 == 0x0A010000.
-        supported = "<boolean>": False if the XML does not fully support reading of this version.
-        user = "<List[integer]>": The custom User Version(s) for a specific Version from a game/developer.
-            Note: Grouping multiple user in a list means that these user produce identical NIF layout.
-            Example: user="12"
-                     user="0x20000 0x30000"
-        bsver = "<List[integer]>": The custom Bethesda Version(s) for a specific Version and User Version.
-            Note: Grouping multiple bsver in a list means that these bsver produce identical NIF layout.
-            Example: bsver="34"
-                     bsver="30 31 32 33"
-        custom = "<boolean>": True when version contains extensions to the format not originating from Gamebryo.
-            Note: A user or bsver of non-zero implies custom="true" and is not necessary.
-        ext = "<List[string]>": Any custom NIF extensions associated with this version.
-            Example: ext="bto btr"
-
-        Content: A comma-separated list of games which use this version.
-            `{{}}` around a game name denotes that this version is the primary version for that game.
-            A version without any `{{}}` names implies that this version is "secondary".
-            Note: A unique game name should only have `{{}}` around it once.
-    -->
 
     <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
@@ -160,6 +134,33 @@
     <verattr name="user" access="#USER#" index="1" />
     <verattr name="bsver" access="#BSVER#" index="2" />
 
+    <!-- The versions found in use by the engine which have any amount of decoding or support from nif.xml
+            NOTE: Hypothetical versions such as those used in version conditions must NOT receive version tags.
+
+        id = "VX_X_X_X": The unique identifier for this version. Can be used to generate C-style enums, etc.
+        num = "X.X.X.X": The numeric representation created by storing each part of the version in a byte.
+            Example:  4.0.0.2 == 0x04000002
+                     10.1.0.0 == 0x0A010000.
+        supported = "<boolean>": False if the XML does not fully support reading of this version.
+        user = "<List[integer]>": The custom User Version(s) for a specific Version from a game/developer.
+            Note: Grouping multiple user in a list means that these user produce identical NIF layout.
+            Example: user="12"
+                     user="0x20000 0x30000"
+        bsver = "<List[integer]>": The custom Bethesda Version(s) for a specific Version and User Version.
+            Note: Grouping multiple bsver in a list means that these bsver produce identical NIF layout.
+            Example: bsver="34"
+                     bsver="30 31 32 33"
+        custom = "<boolean>": True when version contains extensions to the format not originating from Gamebryo.
+            Note: A user or bsver of non-zero implies custom="true" and is not necessary.
+        ext = "<List[string]>": Any custom NIF extensions associated with this version.
+            Example: ext="bto btr"
+
+        Content: A comma-separated list of games which use this version.
+            `{{}}` around a game name denotes that this version is the primary version for that game.
+            A version without any `{{}}` names implies that this version is "secondary".
+            Note: A unique game name should only have `{{}}` around it once.
+    -->
+
     <version id="V2_3" num="2.3" supported="false">Dark Age of Camelot</version>
     <version id="V3_0" num="3.0" supported="false">Star Trek: Bridge Commander</version>
     <version id="V3_03" num="3.03" supported="false">Dark Age of Camelot</version>
@@ -212,7 +213,7 @@
     <version id ="V20_3_1_1" num="20.3.1.1">Fantasy Frontier, Aura Kingdom</version>
     <version id ="V20_3_1_2" num="20.3.1.2">{{Fantasy Frontier}}, {{Aura Kingdom}}</version>
     <version id="V20_5_0_0" num="20.5.0.0">MicroVolts, KrazyRain</version>
-    <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101</version>
+    <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101, Archlord 2</version>
     <version id="V20_6_0_2" num="20.6.0.2">{{MXM}}</version>
     <version id="V20_6_5_0" num="20.6.5.0" user="0" supported="false">Epic Mickey</version>
     <version id="V20_6_5_0_DEM" num="20.6.5.0" user="14 15" ext="nif_wii" >Epic Mickey</version>
@@ -7160,7 +7161,7 @@
     </bitflags>
 
     <struct name="DataStreamData" args="2" module="NiMesh" since="V20_5_0_0">
-        <field name="Data" type="byte" binary="true" length="#ARG1#">The data stream as binary (fallback if interpretation with template is not implemented).</field>
+        <field name="Data" type="byte" binary="true" length="#ARG1#">The data stream as binary (fallback if interpretation with arg2 is not implemented).</field>
     </struct>
 
     <niobject name="NiDataStream" inherit="NiObject" module="NiMesh" since="V20_5_0_0">

--- a/nif.xml
+++ b/nif.xml
@@ -3589,6 +3589,7 @@
         <field name="Radius Variation" type="float" since="10.4.0.1">Particle Radius randomness.</field>
         <field name="Life Span" type="float">Duration until a particle dies.</field>
         <field name="Life Span Variation" type="float">Adds randomness to Life Span.</field>
+        <field name="Unknown QQSpeed Floats" type="float" length="2">Both 1.0 in example nif.</field>
     </niobject>
 
     <niobject name="NiPSysVolumeEmitter" abstract="true" inherit="NiPSysEmitter" module="NiParticle">
@@ -4028,10 +4029,12 @@
         Particle system data.
         <field name="Particle Info" type="NiParticleInfo" length="Num Vertices" vercond="!#BS202#" />
         <field name="Unknown Vector" type="Vector3" vercond="#BS_F76#" />
+        <field name="Unknown QQSpeed Byte 1" type="byte" since="20.2.4.7" until="20.2.4.7" />
         <field name="Has Rotation Speeds" type="bool" since="20.0.0.2" />
         <field name="Rotation Speeds" type="float" length="Num Vertices" cond="Has Rotation Speeds" since="20.0.0.2" vercond="!#BS202#" />
         <field name="Num Added Particles" type="ushort" vercond="!#BS202#" />
         <field name="Added Particles Base" type="ushort" vercond="!#BS202#" />
+        <field name="Unknown QQSpeed Byte 2" type="byte" since="20.2.4.7" until="20.2.4.7">Exact position unknown, could be before Num Added Particles instead.</field>
     </niobject>
     
     <niobject name="NiMeshPSysData" inherit="NiPSysData" module="NiParticle">
@@ -8505,6 +8508,11 @@
         <field name="Unknown Bytes 1" type="byte" length="14" />
         <field name="Unknown Float" type="float" />
         <field name="Unknown Bytes 2" type="byte" length="13" />
+    </niobject>
+
+    <niobject name="NiRimLightProperty" inherit="NiProperty" module="NiMain" versions="V20_2_4_7">
+        <field name="Unknown Byte" type="byte">01 in the example nifs</field>
+        <field name="Unknown Floats" type="float" length="6"></field>
     </niobject>
 
     <struct name="QQSpeedLODEntry">

--- a/nif.xml
+++ b/nif.xml
@@ -184,7 +184,7 @@
     <version id="V10_4_0_1" num="10.4.0.1" custom="true">{{WorldShift}}</version>
     <version id="V20_0_0_4" num="20.0.0.4" user="0">{{Civilization IV}}, {{Sid Meier's Railroads}}, Florensia, Ragnarok Online 2, IRIS Online</version>
     <version id="V20_0_0_4__10" num="20.0.0.4" user="10" bsver="11">{{Oblivion KF}}</version>
-    <version id="V20_0_0_4__11" num="20.0.0.4" user="11" bsver="11">Fallout 3</version>
+    <version id="V20_0_0_4__11" num="20.0.0.4" user="11" bsver="11">Oblivion, Fallout 3</version>
     <version id="V20_0_0_5_OBL" num="20.0.0.5" user="10" bsver="11">{{Oblivion}}</version>
     <version id="V20_1_0_3" num="20.1.0.3">{{Shin Megami Tensei: Imagine}}</version>
     <version id="V20_2_0_7" num="20.2.0.7" user="0">{{Florensia}}, Empire Earth III, Atlantica Online, IRIS Online, Wizard101</version>
@@ -213,9 +213,10 @@
     <version id ="V20_3_1_2" num="20.3.1.2">{{Fantasy Frontier}}, {{Aura Kingdom}}</version>
     <version id="V20_5_0_0" num="20.5.0.0">MicroVolts, KrazyRain</version>
     <version id="V20_6_0_0" num="20.6.0.0">{{MicroVolts}}, {{IRIS Online}}, {{Ragnarok Online 2}}, KrazyRain, Atlantica Online, Wizard101</version>
-    <version id="V20_6_5_0" num="20.6.5.0" supported="false">Epic Mickey</version>
-    <version id="V20_6_5_0_DEM" num="20.6.5.0" user="15" supported="false">Epic Mickey</version>
-    <version id="V20_6_5_0_DEM2" num="20.6.5.0" user="17" supported="false">Epic Mickey 2</version>
+    <version id="V20_6_0_2" num="20.6.0.2">{{MXM}}</version>
+    <version id="V20_6_5_0" num="20.6.5.0" user="0" supported="false">Epic Mickey</version>
+    <version id="V20_6_5_0_DEM" num="20.6.5.0" user="14 15" ext="nif_wii" >Epic Mickey</version>
+    <version id="V20_6_5_0_DEM2" num="20.6.5.0" user="17">Epic Mickey 2</version>
     <version id="V30_0_0_2" num="30.0.0.2">Emerge</version>
     <version id="V30_1_0_1" num="30.1.0.1">Emerge</version>
     <version id="V30_1_0_3" num="30.1.0.3">Rocksmith, Rocksmith 2014</version>
@@ -559,7 +560,7 @@
     </enum>
 
     <enum name="SkyrimHavokMaterial" storage="uint" versions="#SKY_AND_LATER#">
-        Bethesda Havok. Material descriptor for a Havok shape in Skyrim.
+        Bethesda Havok. Material descriptor for a Havok shape in Skyrim. CRC32 of the lowercase of the Creation Kit Material Name.
         <option value="0" name="SKY_HAV_MAT_NONE">Invalid Material</option>
         <option value="131151687" name="SKY_HAV_MAT_BROKEN_STONE">Broken Stone</option>
         <option value="322207473" name="SKY_HAV_MAT_MATERIAL_CARRIAGE_WHEEL">Material Carriage Wheel</option>
@@ -2214,7 +2215,7 @@
         <field name="Orientation" type="ushort" vercond="#NI_BS_LTE_FO3#">Furniture marker orientation.</field>
         <field name="Position Ref 1" type="byte" vercond="#NI_BS_LTE_FO3#">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 2.</field>
         <field name="Position Ref 2" type="byte" vercond="#NI_BS_LTE_FO3#">Refers to a furnituremarkerxx.nif file. Always seems to be the same as Position Ref 1.</field>
-        <field name="Heading" type="float" vercond="#BS_GT_FO3#">Similar to Orientation, in float form.</field>
+        <field name="Heading" type="float" vercond="#BS_GT_FO3#">Rotation around z-axis in radians.</field>
         <field name="Animation Type" type="AnimationType" vercond="#BS_GT_FO3#" />
         <field name="Entry Properties" type="FurnitureEntryPoints" vercond="#BS_GT_FO3#" />
     </struct>
@@ -7063,79 +7064,74 @@
         <option value="2" name="CLONING_BLANK_COPY">Create a copy of this object for use with the newly cloned stream, leaving some of the data to be written later.</option>
     </enum>
 
-    <enum name="ComponentType" storage="byte" since="V20_5_0_0">
-        The data format of components.
-        <option value="0x00" name="F_UNKNOWN">Unknown, or don't care, format.</option>
-        <option value="0x01" name="F_INT8_1"></option>
-        <option value="0x02" name="F_INT8_2"></option>
-        <option value="0x03" name="F_INT8_3"></option>
-        <option value="0x04" name="F_INT8_4"></option>
-        <option value="0x05" name="F_UINT8_1"></option>
-        <option value="0x06" name="F_UINT8_2"></option>
-        <option value="0x07" name="F_UINT8_3"></option>
-        <option value="0x08" name="F_UINT8_4"></option>
-        <option value="0x09" name="F_NORMINT8_1"></option>
-        <option value="0x0A" name="F_NORMINT8_2"></option>
-        <option value="0x0B" name="F_NORMINT8_3"></option>
-        <option value="0x0C" name="F_NORMINT8_4"></option>
-        <option value="0x0D" name="F_NORMUINT8_1"></option>
-        <option value="0x0E" name="F_NORMUINT8_2"></option>
-        <option value="0x0F" name="F_NORMUINT8_3"></option>
-        <option value="0x10" name="F_NORMUINT8_4"></option>
-        <option value="0x11" name="F_INT16_1"></option>
-        <option value="0x12" name="F_INT16_2"></option>
-        <option value="0x13" name="F_INT16_3"></option>
-        <option value="0x14" name="F_INT16_4"></option>
-        <option value="0x15" name="F_UINT16_1"></option>
-        <option value="0x16" name="F_UINT16_2"></option>
-        <option value="0x17" name="F_UINT16_3"></option>
-        <option value="0x18" name="F_UINT16_4"></option>
-        <option value="0x19" name="F_NORMINT16_1"></option>
-        <option value="0x1A" name="F_NORMINT16_2"></option>
-        <option value="0x1B" name="F_NORMINT16_3"></option>
-        <option value="0x1C" name="F_NORMINT16_4"></option>
-        <option value="0x1D" name="F_NORMUINT16_1"></option>
-        <option value="0x1E" name="F_NORMUINT16_2"></option>
-        <option value="0x1F" name="F_NORMUINT16_3"></option>
-        <option value="0x20" name="F_NORMUINT16_4"></option>
-        <option value="0x21" name="F_INT32_1"></option>
-        <option value="0x22" name="F_INT32_2"></option>
-        <option value="0x23" name="F_INT32_3"></option>
-        <option value="0x24" name="F_INT32_4"></option>
-        <option value="0x25" name="F_UINT32_1"></option>
-        <option value="0x26" name="F_UINT32_2"></option>
-        <option value="0x27" name="F_UINT32_3"></option>
-        <option value="0x28" name="F_UINT32_4"></option>
-        <option value="0x29" name="F_NORMINT32_1"></option>
-        <option value="0x2A" name="F_NORMINT32_2"></option>
-        <option value="0x2B" name="F_NORMINT32_3"></option>
-        <option value="0x2C" name="F_NORMINT32_4"></option>
-        <option value="0x2D" name="F_NORMUINT32_1"></option>
-        <option value="0x2E" name="F_NORMUINT32_2"></option>
-        <option value="0x2F" name="F_NORMUINT32_3"></option>
-        <option value="0x30" name="F_NORMUINT32_4"></option>
-        <option value="0x31" name="F_FLOAT16_1"></option>
-        <option value="0x32" name="F_FLOAT16_2"></option>
-        <option value="0x33" name="F_FLOAT16_3"></option>
-        <option value="0x34" name="F_FLOAT16_4"></option>
-        <option value="0x35" name="F_FLOAT32_1"></option>
-        <option value="0x36" name="F_FLOAT32_2"></option>
-        <option value="0x37" name="F_FLOAT32_3"></option>
-        <option value="0x38" name="F_FLOAT32_4"></option>
-        <option value="0x39" name="F_UINT_10_10_10_L1"></option>
-        <option value="0x3A" name="F_NORMINT_10_10_10_L1"></option>
-        <option value="0x3B" name="F_NORMINT_11_11_10"></option>
-        <option value="0x3C" name="F_NORMUINT8_4_BGRA"></option>
-        <option value="0x3D" name="F_NORMINT_10_10_10_2"></option>
-        <option value="0x3E" name="F_UINT_10_10_10_2"></option>
-        <option value="0x40" name="F_UNKNOWN_20240"></option>
+    <enum name="ComponentFormat" storage="uint" since="V20_5_0_0">
+        The data format of components. Mask 0x00FF0000 to get the number of subfields. Mask 0x0000FF00 to get the size of each subfield.
+        It's not a bitfield, because the values are not independent.
+        <option value="0x00000000" name="F_UNKNOWN">Unknown, or don't care, format.</option>
+        <option value="0x00010101" name="F_INT8_1"></option>
+        <option value="0x00020102" name="F_INT8_2"></option>
+        <option value="0x00030103" name="F_INT8_3"></option>
+        <option value="0x00040104" name="F_INT8_4"></option>
+        <option value="0x00010105" name="F_UINT8_1"></option>
+        <option value="0x00020106" name="F_UINT8_2"></option>
+        <option value="0x00030107" name="F_UINT8_3"></option>
+        <option value="0x00040108" name="F_UINT8_4"></option>
+        <option value="0x00010109" name="F_NORMINT8_1"></option>
+        <option value="0x0002010A" name="F_NORMINT8_2"></option>
+        <option value="0x0003010B" name="F_NORMINT8_3"></option>
+        <option value="0x0004010C" name="F_NORMINT8_4"></option>
+        <option value="0x0001010D" name="F_NORMUINT8_1"></option>
+        <option value="0x0002010E" name="F_NORMUINT8_2"></option>
+        <option value="0x0003010F" name="F_NORMUINT8_3"></option>
+        <option value="0x00040110" name="F_NORMUINT8_4"></option>
+        <option value="0x00010211" name="F_INT16_1"></option>
+        <option value="0x00020212" name="F_INT16_2"></option>
+        <option value="0x00030213" name="F_INT16_3"></option>
+        <option value="0x00040214" name="F_INT16_4"></option>
+        <option value="0x00010215" name="F_UINT16_1"></option>
+        <option value="0x00020216" name="F_UINT16_2"></option>
+        <option value="0x00030217" name="F_UINT16_3"></option>
+        <option value="0x00040218" name="F_UINT16_4"></option>
+        <option value="0x00010219" name="F_NORMINT16_1"></option>
+        <option value="0x0002021A" name="F_NORMINT16_2"></option>
+        <option value="0x0003021B" name="F_NORMINT16_3"></option>
+        <option value="0x0004021C" name="F_NORMINT16_4"></option>
+        <option value="0x0001021D" name="F_NORMUINT16_1"></option>
+        <option value="0x0002021E" name="F_NORMUINT16_2"></option>
+        <option value="0x0003021F" name="F_NORMUINT16_3"></option>
+        <option value="0x00040220" name="F_NORMUINT16_4"></option>
+        <option value="0x00010421" name="F_INT32_1"></option>
+        <option value="0x00020422" name="F_INT32_2"></option>
+        <option value="0x00030423" name="F_INT32_3"></option>
+        <option value="0x00040424" name="F_INT32_4"></option>
+        <option value="0x00010425" name="F_UINT32_1"></option>
+        <option value="0x00020426" name="F_UINT32_2"></option>
+        <option value="0x00030427" name="F_UINT32_3"></option>
+        <option value="0x00040428" name="F_UINT32_4"></option>
+        <option value="0x00010429" name="F_NORMINT32_1"></option>
+        <option value="0x0002042A" name="F_NORMINT32_2"></option>
+        <option value="0x0003042B" name="F_NORMINT32_3"></option>
+        <option value="0x0004042C" name="F_NORMINT32_4"></option>
+        <option value="0x0001042D" name="F_NORMUINT32_1"></option>
+        <option value="0x0002042E" name="F_NORMUINT32_2"></option>
+        <option value="0x0003042F" name="F_NORMUINT32_3"></option>
+        <option value="0x00040430" name="F_NORMUINT32_4"></option>
+        <option value="0x00010231" name="F_FLOAT16_1"></option>
+        <option value="0x00020232" name="F_FLOAT16_2"></option>
+        <option value="0x00030233" name="F_FLOAT16_3"></option>
+        <option value="0x00040234" name="F_FLOAT16_4"></option>
+        <option value="0x00010435" name="F_FLOAT32_1"></option>
+        <option value="0x00020436" name="F_FLOAT32_2"></option>
+        <option value="0x00030437" name="F_FLOAT32_3"></option>
+        <option value="0x00040438" name="F_FLOAT32_4"></option>
+        <option value="0x00010439" name="F_UINT_10_10_10_L1"></option>
+        <option value="0x0001043A" name="F_NORMINT_10_10_10_L1"></option>
+        <option value="0x0001043B" name="F_NORMINT_11_11_10"></option>
+        <option value="0x0004013C" name="F_NORMUINT8_4_BGRA"></option>
+        <option value="0x0001043D" name="F_NORMINT_10_10_10_2"></option>
+        <option value="0x0001043E" name="F_UINT_10_10_10_2"></option>
+        <option value="0x00020240" name="F_UNKNOWN_20240"></option>
     </enum>
-
-    <bitfield name="ComponentFormat" storage="uint" since="V20_5_0_0">
-        <member width="8" pos="0" mask="0xFF" name="Type" type="ComponentType"></member>
-        <member width="8" pos="8" mask="0xFF00" name="Element Width" type="byte"></member>
-        <member width="8" pos="16" mask="0xFF0000" name="Num Elements" type="byte"></member>
-    </bitfield>
 
     <enum name="DataStreamUsage" storage="uint" since="V20_5_0_0">
         Determines how a data stream is used?
@@ -7143,6 +7139,7 @@
         <option value="1" name="USAGE_VERTEX"></option>
         <option value="2" name="USAGE_SHADER_CONSTANT"></option>
         <option value="3" name="USAGE_USER"></option>
+        <option value="4" name="USAGE_UNKNOWN">Seems to be associated with DISPLAYLIST component semantics.</option>
     </enum>
     
     <bitflags name="DataStreamAccess" storage="uint" since="V20_5_0_0">
@@ -7160,7 +7157,6 @@
         <field name="Data" type="byte" binary="true" length="#ARG#">The data stream as binary (fallback if interpretation with template is not implemented).</field>
     </struct>
 
-
     <niobject name="NiDataStream" inherit="NiObject" module="NiMesh" since="V20_5_0_0">
         <field name="Usage" type="DataStreamUsage" abstract="true"></field>
         <field name="Access" type="DataStreamAccess" abstract="true"></field>
@@ -7170,7 +7166,7 @@
         <field name="Regions" type="Region" length="Num Regions">The regions in the mesh. Regions can be used to mark off submeshes which are independent draw calls.</field>
         <field name="Num Components" type="uint">Number of components of the data (matches corresponding field in MeshData).</field>
         <field name="Component Formats" type="ComponentFormat" length="Num Components">The format of each component in this data stream.</field>
-        <field name="Data" type="DataStreamData" arg="Num Bytes" template="Component Formats"/>
+        <field name="Data" type="DataStreamData" arg="Num Bytes" template="Component Formats" />
         <field name="Streamable" type="bool" default="1" />
     </niobject>
 
@@ -7178,7 +7174,7 @@
         <field name="Name" type="NiFixedString">
             Type of data (POSITION, POSITION_BP, INDEX, NORMAL, NORMAL_BP,
             TEXCOORD, BLENDINDICES, BLENDWEIGHT, BONE_PALETTE, COLOR, DISPLAYLIST,
-            MORPH_POSITION, BINORMAL_BP, TANGENT_BP).
+            MORPH_POSITION, BINORMAL_BP, TANGENT, TANGENT_BP).
         </field>
         <field name="Index" type="uint" default="0">
             An extra index of the data. For example, if there are 3 uv maps,
@@ -7253,8 +7249,8 @@
 
     <struct name="ExtraMeshDataEpicMickey" module="NiMesh" versions="V20_6_5_0_DEM">
         <field name="Unknown 1" type="uint" />
-        <field name="Num Unknown Floats" type="uint" />
-        <field name="Unknown Floats 1" type="float" length="Num Unknown Floats" />
+        <field name="Num Transform Floats" type="uint" >Total number of floats in the bone transform matrices - divide by 16 to get the number of matrices.</field>
+        <field name="Bone Transforms" type="Matrix44" length="Num Transform Floats #DIV# 16" >Transform matrices corresponding to the bones. Note: Stored transposed to normally.</field>
         <field name="Num Weights" type="uint" />
         <field name="Weights" type="WeightDataEpicMickey" length="Num Weights" />
         <field name="Vertex to Weight Map Size" type="uint" />
@@ -8087,6 +8083,10 @@
         <field name="Data" type="ByteArray" cond="Has Data" />
         <field name="Num Refs" type="uint" />
         <field name="Refs" type="Ref" template="NiObject" length="Num Refs" />
+    </niobject>
+
+    <niobject name="JPSJigsawNode" inherit="NiNode" module="NiMesh" >
+        Epic Mickey specific block.
     </niobject>
 
     <niobject name="bhkCompressedMeshShape" inherit="bhkShape" module="BSHavok" versions="#SKY_AND_LATER#">

--- a/nif.xml
+++ b/nif.xml
@@ -274,6 +274,10 @@
         An unsigned 8-bit integer.
     </basic>
 
+    <basic name="normbyte" boolean="false" size="1">
+        A float in the range -1.0:1.0, stored as a byte.
+    </basic>
+
     <basic name="bool" boolean="true" integral="true" countable="false">
         A boolean; 32-bit from 4.0.0.2, and 8-bit from 4.1.0.1 on.
     </basic>
@@ -1750,9 +1754,9 @@
 
     <struct name="ByteVector3" size="3" convertible="Vector3 UshortVector3" module="NiMain">
         A vector in 3D space (x,y,z).
-        <field name="x" type="byte">First coordinate.</field>
-        <field name="y" type="byte">Second coordinate.</field>
-        <field name="z" type="byte">Third coordinate.</field>
+        <field name="x" type="normbyte">First coordinate.</field>
+        <field name="y" type="normbyte">Second coordinate.</field>
+        <field name="z" type="normbyte">Third coordinate.</field>
     </struct>
 
     <struct name="Vector4" size="16" module="NiMain">
@@ -2095,9 +2099,9 @@
 
 		<field name="UV" type="HalfTexCoord" cond="#ARG# #BITAND# 0x2" />
 		<field name="Normal" type="ByteVector3" cond="#ARG# #BITAND# 0x8" />
-		<field name="Bitangent Y" type="byte" cond="#ARG# #BITAND# 0x8" />
+		<field name="Bitangent Y" type="normbyte" cond="#ARG# #BITAND# 0x8" />
 		<field name="Tangent" type="ByteVector3" cond="(#ARG# #BITAND# 0x18) == 0x18" />
-		<field name="Bitangent Z" type="byte" cond="(#ARG# #BITAND# 0x18) == 0x18" />
+		<field name="Bitangent Z" type="normbyte" cond="(#ARG# #BITAND# 0x18) == 0x18" />
 		<field name="Vertex Colors" type="ByteColor4" cond="#ARG# #BITAND# 0x20" />
 		<field name="Bone Weights" type="hfloat" length="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Bone Indices" type="byte" length="4" cond="#ARG# #BITAND# 0x40" />
@@ -2110,9 +2114,9 @@
 		<field name="Unused W" type="uint" cond="(#ARG# #BITAND# 0x11) == 0x1" />
 		<field name="UV" type="HalfTexCoord" cond="#ARG# #BITAND# 0x2" />
 		<field name="Normal" type="ByteVector3" cond="#ARG# #BITAND# 0x8" />
-		<field name="Bitangent Y" type="byte" cond="#ARG# #BITAND# 0x8" />
+		<field name="Bitangent Y" type="normbyte" cond="#ARG# #BITAND# 0x8" />
 		<field name="Tangent" type="ByteVector3" cond="(#ARG# #BITAND# 0x18) == 0x18" />
-		<field name="Bitangent Z" type="byte" cond="(#ARG# #BITAND# 0x18) == 0x18" />
+		<field name="Bitangent Z" type="normbyte" cond="(#ARG# #BITAND# 0x18) == 0x18" />
 		<field name="Vertex Colors" type="ByteColor4" cond="#ARG# #BITAND# 0x20" />
 		<field name="Bone Weights" type="hfloat" length="4" cond="#ARG# #BITAND# 0x40" />
 		<field name="Bone Indices" type="byte" length="4" cond="#ARG# #BITAND# 0x40" />

--- a/nif.xml
+++ b/nif.xml
@@ -212,6 +212,7 @@
     <version id="V20_2_0_7_FO4_2" num="20.2.0.7" user="12" bsver="132 139" ext="bto btr" supported="false">Fallout 4 (LS_Mirelurk.nif, Screen.nif)</version>
     <version id="V20_2_0_7_F76" num="20.2.0.7" user="12" bsver="155" ext="bto">{{Fallout 76}}</version>
     <version id="V20_2_0_8" num="20.2.0.8" ext="nifcache">{{Empire Earth III}}, {{FFT Online}}, Atlantica Online, IRIS Online, Wizard101</version>
+    <version id="V20_2_4_7" num="20.2.4.7">QQSpeed</version>
     <version id="V20_3_0_1" num="20.3.0.1">Emerge</version>
     <version id="V20_3_0_2" num="20.3.0.2">Emerge</version>
     <version id="V20_3_0_3" num="20.3.0.3">Emerge</version>
@@ -8497,5 +8498,26 @@
     </niobject>
 
     <niobject name="CsNiNode" inherit="NiNode" />
+
+    <!-- QQSpeed -->
+
+    <niobject name="NiYAMaterialProperty" inherit="NiProperty" module="NiMain" versions="V20_2_4_7">
+        <field name="Unknown Bytes 1" type="byte" length="14" />
+        <field name="Unknown Float" type="float" />
+        <field name="Unknown Bytes 2" type="byte" length="13" />
+    </niobject>
+
+    <struct name="QQSpeedLODEntry">
+        <field name="Unknown Bytes" type="byte" length="12" >Seemingly always zeros.</field>
+        <field name="Num Levels" type="uint">Always 3 in tested mesh.</field>
+        <field name="Unknown Values" type="float" length="Num Levels">Middle entry seemingly always 10^8, other two the same as LOD Distances</field>
+        <field name="LOD Distances" type="float" length="Num Levels">Entries corresponding to LODDistance specification in the block's NiStringExtraData, in the order of 1, 3, 2</field>
+    </struct>
+
+    <niobject name="NiProgramLODData" inherit="NiLODData" module="NiMain" versions="V20_2_4_7">
+        <field name="Unknown Uint" type="uint" />
+        <field name="Num LOD Entries" type="uint">Guess is that this is the number of LOD entries, but unsure given that there was only one example.</field>
+        <field name="LOD Entries" type="QQSpeedLODEntry" length="Num LOD Entries" />
+    </niobject>
 
 </niftoolsxml>

--- a/nif.xml
+++ b/nif.xml
@@ -2853,7 +2853,7 @@
             A good choice is 5% - 20% of the smallest diameter of the object.
         </field>
         <field name="Motion System" type="hkMotionType" default="MO_SYS_DYNAMIC">Motion system? Overrides Quality when on Keyframed?</field>
-        <field name="Enable Deactivation" type="bool" default="1" />
+        <field name="Deactivator Type" type="hkDeactivatorType" default="DEACTIVATOR_NEVER">The initial deactivator type of the body.</field>
         <field name="Solver Deactivation" type="hkSolverDeactivation" default="SOLVER_DEACTIVATION_OFF">How aggressively the engine will try to zero the velocity for slow objects. This does not save CPU.</field>
         <field name="Quality Type" type="hkQualityType" default="MO_QUAL_FIXED">The type of interaction with other objects.</field>
         <field name="Auto Remove Level" type="byte" />
@@ -2886,7 +2886,7 @@
         <field name="Max Linear Velocity" type="float" default="104.4">Maximal linear velocity.</field>
         <field name="Max Angular Velocity" type="float" default="31.57">Maximal angular velocity.</field>
         <field name="Motion System" type="hkMotionType" default="MO_SYS_DYNAMIC">Motion system? Overrides Quality when on Keyframed?</field>
-        <field name="Enable Deactivation" type="bool" default="1" />
+        <field name="Deactivator Type" type="hkDeactivatorType" default="DEACTIVATOR_NEVER">The initial deactivator type of the body.</field>
         <field name="Solver Deactivation" type="hkSolverDeactivation" default="SOLVER_DEACTIVATION_OFF">How aggressively the engine will try to zero the velocity for slow objects. This does not save CPU.</field>
         <field name="Unused 03" type="byte" />
         <field name="Penetration Depth" type="float" default="0.15">


### PR DESCRIPTION
1. Created a separate type (DataStreamData) for the data of the NiDataStream, rather than bare bytes. This allows encapsulation of the interpretation of the data by that type. It is used extensively by the NiMesh processing of the blender addon.
2. Addition of Master X Master (MXM) to the games.
3. Updates to some unknown fields of Epic Mickey structs.
4. Addition of Oblivion to some versions.
5. Addition of sbyte to represent signed, single-byte fields.
6. Addition of recursive='true' to Union BV field in BoundingVolume.
7. Addition of args="2" to DataStreamData.
8. Two small updates (extra options for BSShaderType155 and adjusted conditions in BSStreamHeader) based on eckserah nifskope dev10 xml.
9. Addition of Archlord to the games.
10. Added QQSpeed information.

It seems there's some duplicate commits that are already in develop. Not sure how it happened, but I think nothing got broken.